### PR TITLE
Update EventScheduler init for backwards-compat.

### DIFF
--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -347,6 +347,8 @@ class EventScheduler(Thread):
             self._running.clear()
         except Exception as e:
             self._running.clear()
+            if not isinstance(e, OSError):
+                self.store()
             raise e
 
 

--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -338,14 +338,21 @@ class EventScheduler(Thread):
             self.bus.remove_all_listeners('mycroft.scheduler.remove_event')
             self.bus.remove_all_listeners('mycroft.scheduler.update_event')
             # Wait for thread to finish
-            self.join()
+            self.join(30)
             # Prune event list in preparation for saving
             self.clear_repeating()
             self.clear_empty()
             # Store all pending scheduled events
             self.store()
-        except Exception as e:
-            LOG.exception(e)
+        except TimeoutError:
+            # self.join timeout
+            LOG.error("Timed out joining thread")
+        except RuntimeError as e:
+            # self.join failed
+            LOG.error(e)
+        except OSError as e:
+            # self.store failed
+            LOG.error(e)
         finally:
             self._running.clear()
 

--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -344,17 +344,10 @@ class EventScheduler(Thread):
             self.clear_empty()
             # Store all pending scheduled events
             self.store()
-        except TimeoutError:
-            # self.join timeout
-            LOG.error("Timed out joining thread")
-        except RuntimeError as e:
-            # self.join failed
-            LOG.error(e)
-        except OSError as e:
-            # self.store failed
-            LOG.error(e)
-        finally:
             self._running.clear()
+        except Exception as e:
+            self._running.clear()
+            raise e
 
 
 class EventContainer(_EventContainer):

--- a/test/unittests/test_util.py
+++ b/test/unittests/test_util.py
@@ -49,6 +49,14 @@ class TestEventScheduler(unittest.TestCase):
         self.scheduler._stopping.set()
         self.assertFalse(self.scheduler.is_running)
 
+    def test_scheduler_init(self):
+        from ovos_bus_client.util.scheduler import EventScheduler
+        scheduler = EventScheduler(self.bus, self.test_schedule_name)
+        self.assertTrue(scheduler.is_running)
+        self.assertEqual(scheduler.bus, self.bus)
+        self.assertNotEqual(scheduler, self.scheduler)
+        scheduler.shutdown()
+
 
 class TestUtils(unittest.TestCase):
     def test_create_echo_function(self):


### PR DESCRIPTION
Update scheduler init to wait for thread start for test compat.
Add unit test coverage for started state after init

Followup to #45 
Resolves https://github.com/OpenVoiceOS/ovos-core/issues/342
Validated https://github.com/OpenVoiceOS/ovos-core/actions/runs/6016994283/job/16322198179?pr=339