### PR TITLE
rm/valid_langs_session

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1,11 +1,12 @@
 import enum
 import time
-from ovos_config.config import Configuration
-from ovos_config.locale import get_default_lang
-from ovos_utils.log import LOG
 from threading import Lock
 from typing import Optional, List, Tuple, Union, Iterable
 from uuid import uuid4
+
+from ovos_config.config import Configuration
+from ovos_config.locale import get_default_lang
+from ovos_utils.log import LOG
 
 from ovos_bus_client.message import dig_for_message, Message
 
@@ -265,6 +266,7 @@ class Session:
                  history=None, max_time=None, max_messages=None,
                  utterance_states: dict = None, lang: str = None,
                  context: IntentContextManager = None,
+                 valid_langs: List[str] = None,
                  site_id: str = "unknown",
                  pipeline: List[str] = None):
         """
@@ -278,6 +280,7 @@ class Session:
         @param utterance_states: dict of skill_id to UtteranceState
         @param lang: language associated with this Session
         @param context: IntentContextManager for this Session
+        @param valid_langs: DEPRECATED
         """
         self.session_id = session_id or str(uuid4())
         self.lang = lang or get_default_lang()
@@ -304,10 +307,12 @@ class Session:
 
         # deprecated - TODO remove 0.0.8
         if history is not None or max_time is not None or max_messages is not None:
-            LOG.warning("history, max_time and max_messages have been deprecated")
+            LOG.warning("valid_langs , history, max_time and max_messages have been deprecated")
         self.history = []  # (Message , timestamp)
         self.max_time = 5  # minutes
         self.max_messages = 5
+        self.valid_languages = list(set([get_default_lang()] +
+                                        Configuration().get("secondary_langs", [])))
 
     @property
     def active(self) -> bool:

--- a/test/unittests/test_session.py
+++ b/test/unittests/test_session.py
@@ -10,37 +10,6 @@ class TestSessionModule(unittest.TestCase):
             self.assertIsInstance(state, UtteranceState)
             self.assertIsInstance(state, str)
 
-    @patch("ovos_bus_client.session.get_default_lang")
-    @patch("ovos_bus_client.session.Configuration")
-    def test_get_valid_langs(self, config, default_lang):
-        config.return_value = {
-            "secondary_langs": ["en-us", "es-mx", "fr-ca"]
-        }
-        default_lang.return_value = "en-us"
-        from ovos_bus_client.session import _get_valid_langs
-        # Test default in secondary
-        langs = _get_valid_langs()
-        self.assertIsInstance(langs, list)
-        self.assertEqual(len(langs), len(set(langs)))
-        self.assertEqual(set(langs), {"en-us", "es-mx", "fr-ca"})
-
-        # Test default not in secondary
-        default_lang.return_value = "pt-pt"
-        langs = _get_valid_langs()
-        self.assertIsInstance(langs, list)
-        self.assertEqual(len(langs), len(set(langs)))
-        self.assertEqual(set(langs), {"en-us", "es-mx", "fr-ca", "pt-pt"})
-
-        # Test no secondary
-        config.return_value = {}
-        langs = _get_valid_langs()
-        self.assertEqual(langs, [default_lang.return_value])
-
-        # Test invalid secondary lang config
-        config.return_value = {"secondary_langs": None}
-        with self.assertRaises(TypeError):
-            _get_valid_langs()
-
 
 class TestIntentContextManagerFrame(unittest.TestCase):
     def test_serialize_deserialize(self):
@@ -138,7 +107,6 @@ class TestSession(unittest.TestCase):
         session = Session()
         self.assertIsInstance(session.session_id, str)
         self.assertIsInstance(session.lang, str)
-        self.assertIsInstance(session.valid_languages, list)
         self.assertEqual(session.active_skills, list())
         self.assertEqual(session.utterance_states, dict())
         self.assertIsInstance(session.touch_time, int)
@@ -216,7 +184,6 @@ class TestSession(unittest.TestCase):
         self.assertIsInstance(test_session, Session)
         self.assertIsInstance(test_session.session_id, str)
         self.assertIsInstance(test_session.lang, str)
-        self.assertIsInstance(test_session.valid_languages, list)
         self.assertIsInstance(test_session.active_skills, list)
         self.assertIsInstance(test_session.utterance_states, dict)
         self.assertIsInstance(test_session.touch_time, int)


### PR DESCRIPTION
valid languages are defined by core in mycroft.conf , these can not come from Session

core is the authority about what languages it natively supports, session can only assign the current language

if session claims to support a language that core did not load / register intent for that will cause issues, adding this was an oversight