### PR TITLE
fix/huge_integer_error

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -96,7 +96,7 @@ class IntentContextManager:
 
         config = Configuration().get('context', {})
         if timeout is None:
-            timeout = config.get('timeout', 2)
+            timeout = config.get('timeout', 2) * 60  # minutes to seconds
         if greedy is None:
             greedy = config.get('greedy', False)
         if keywords is None:
@@ -105,7 +105,7 @@ class IntentContextManager:
             max_frames = config.get('max_frames', 3)
 
         self.frame_stack = frame_stack or []
-        self.timeout = timeout * 60  # minutes to seconds
+        self.timeout = timeout
         self.context_keywords = keywords
         self.context_max_frames = max_frames
         self.context_greedy = greedy
@@ -125,7 +125,7 @@ class IntentContextManager:
         @param data: serialized (dict) data
         @return: IntentContextManager for the specified data
         """
-        timeout = data.get("timeout", 2)
+        timeout = data.get("timeout", 2 * 60)
         framestack = [(IntentContextManagerFrame.deserialize(f), t)
                       for (f, t) in data.get("frame_stack", [])]
         return IntentContextManager(timeout, framestack)

--- a/test/unittests/test_session.py
+++ b/test/unittests/test_session.py
@@ -177,7 +177,7 @@ class TestSession(unittest.TestCase):
         new_ctx = new_serial.pop('context')
         self.assertEqual(new_serial, serialized)
         self.assertEqual(ctx['frame_stack'], new_ctx['frame_stack'])
-        self.assertGreater(new_ctx['timeout'], ctx['timeout'])
+        self.assertEqual(new_ctx['timeout'], ctx['timeout'])
 
         # Test default value deserialize
         test_session = Session.deserialize(dict())


### PR DESCRIPTION
timeout is getting multiplied by 60 every time it is serialized/deserialized, conversion from seconds to minutes should only be done when assigning the default value from config

```
exception calling callback for <Future at 0x7f3c5ff8d0 state=finished raised ValueError>
Traceback (most recent call last):
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 340, in _invoke_callbacks
    callback(self)
  File "/home/ovos/.venv/lib/python3.11/site-packages/pyee/_executor.py", line 57, in _callback
    self.emit("error", exc)
  File "/home/ovos/.venv/lib/python3.11/site-packages/pyee/_base.py", line 118, in emit
    self._emit_handle_potential_error(event, args[0] if args else None)
  File "/home/ovos/.venv/lib/python3.11/site-packages/pyee/_base.py", line 88, in _emit_handle_potential_error
    raise error
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_bus_client/client/client.py", line 162, in on_default_session_update
    SessionManager.update(sess, make_default=True)
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_bus_client/session.py", line 538, in update
    LOG.debug(f"replacing default session with: {sess.serialize()}")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Exceeds the limit (4300 digits) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit

```