### PR TITLE
fix/init_of_context_manager

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -303,7 +303,7 @@ class Session:
             "padatious_low",
             "fallback_low"
         ]
-        self.context = context or IntentContextManager(timeout=self.touch_time + self.expiration_seconds)
+        self.context = context or IntentContextManager()
 
         # deprecated - TODO remove 0.0.8
         if history is not None or max_time is not None or max_messages is not None:


### PR DESCRIPTION
expects a duration not a timestamp

just let is use the default value if not passed explicitly