### PR TITLE
fix bus loading

### DIFF
--- a/ovos_bus_client/apis/gui.py
+++ b/ovos_bus_client/apis/gui.py
@@ -103,8 +103,7 @@ class GUIInterface:
         self.on_gui_changed_callback = None
         self._events = []
         self.ui_directories = ui_directories or dict()
-        if bus:
-            self.set_bus(bus)
+        self.set_bus(bus)
 
     @property
     def remote_url(self) -> Optional[str]:


### PR DESCRIPTION
This was noticed in `ovos-gui-plugin-shell-companion` as no default `bus` is sent.  When no bus is sent, it was never configured to a default state.  This still allows a custom bus to be specified.