### PR TITLE
refactor/remove_stt+tts_prefs

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -269,8 +269,6 @@ class Session:
                  context: IntentContextManager = None,
                  site_id: str = "unknown",
                  pipeline: List[str] = None,
-                 stt_prefs: Dict = None,
-                 tts_prefs: Dict = None,
                  location_prefs: Dict = None,
                  system_unit: str = None,
                  time_format: str = None,
@@ -315,19 +313,6 @@ class Session:
         ]
         self.context = context or IntentContextManager()
 
-        if not stt_prefs:
-            stt = Configuration().get("stt", {})
-            sttm = stt.get("module", "ovos-stt-plugin-server")
-            stt_prefs = {"plugin_id": sttm,
-                         "config": stt.get(sttm) or {}}
-        self.stt_preferences = stt_prefs
-
-        if not tts_prefs:
-            tts = Configuration().get("tts", {})
-            ttsm = tts.get("module", "ovos-tts-plugin-server")
-            tts_prefs = {"plugin_id": ttsm,
-                         "config": tts.get(ttsm) or {}}
-        self.tts_preferences = tts_prefs
         self.location_preferences = location_prefs or Configuration().get("location", {})
 
     @property
@@ -424,8 +409,6 @@ class Session:
             "context": self.context.serialize(),
             "site_id": self.site_id,
             "pipeline": self.pipeline,
-            "stt": self.stt_preferences,
-            "tts": self.tts_preferences,
             "location": self.location_preferences,
             "system_unit": self.system_unit,
             "time_format": self.time_format,
@@ -454,8 +437,6 @@ class Session:
         context = IntentContextManager.deserialize(data.get("context", {}))
         site_id = data.get("site_id", "unknown")
         pipeline = data.get("pipeline", [])
-        tts = data.get("tts", {})
-        stt = data.get("stt", {})
         location = data.get("location", {})
         system_unit = data.get("system_unit")
         date_format = data.get("date_format")
@@ -467,8 +448,6 @@ class Session:
                        context=context,
                        pipeline=pipeline,
                        site_id=site_id,
-                       tts_prefs=tts,
-                       stt_prefs=stt,
                        location_prefs=location,
                        system_unit=system_unit,
                        date_format=date_format,

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -269,6 +269,8 @@ class Session:
                  context: IntentContextManager = None,
                  site_id: str = "unknown",
                  pipeline: List[str] = None,
+                 stt_prefs: Dict = None,
+                 tts_prefs: Dict = None,
                  location_prefs: Dict = None,
                  system_unit: str = None,
                  time_format: str = None,
@@ -282,6 +284,10 @@ class Session:
         @param lang: language associated with this Session
         @param context: IntentContextManager for this Session
         """
+        if tts_prefs:
+            LOG.warning("tts_prefs have been deprecated! value will be ignored and fully removed in 0.1.0")
+        if stt_prefs:
+            LOG.warning("stt_prefs have been deprecated! value will be ignored and fully removed in 0.1.0")
         self.session_id = session_id or str(uuid4())
 
         self.lang = lang or get_default_lang()


### PR DESCRIPTION
deeper changes are needed in listener/audio to support this properly, removing from session until this is more fleshed out

there will be some overlap with [user_id](https://github.com/JarbasHiveMind/ovos-user-id) later and maybe makes more sense to retrieve this out of bounds instead of passing full plugin configs in message.context. 

perhaps in the future ovos-audio/listener can load multiple plugins at once and this functionality restored

these were present for a short amount of time and didnt make it into a stable ovos release, however they made it into bus-client 0.0.7. This would accommodate Neon user prefs but since Neon did not adopt this the partial implementation can be removed (nothing else in OVOS integrated this yet)