### PR TITLE
refactor/handle_new_SEIs

### DIFF
--- a/ovos_bus_client/apis/ocp.py
+++ b/ovos_bus_client/apis/ocp.py
@@ -263,7 +263,7 @@ class OCPInterface:
         for idx, track in enumerate(tracks):
             if isinstance(track, dict):
                 tracks[idx] = dict2entry(track)
-            elif isinstance(track, PluginStream):
+            if isinstance(track, PluginStream):
                 # TODO - this method will be deprecated
                 #  once all SEI parsers can handle the new objects
                 #  this module can serialize them just fine,
@@ -271,7 +271,7 @@ class OCPInterface:
                 tracks[idx] = track.as_media_entry()
             elif isinstance(track, list) and not isinstance(track, Playlist):
                 tracks[idx] = OCPInterface.norm_tracks(track)
-            elif not isinstance(track, (MediaEntry, PluginStream)):
+            elif not isinstance(track, MediaEntry):
                 # TODO - support string uris
                 # let it fail in next assert
                 # log all bad entries before failing

--- a/ovos_bus_client/apis/ocp.py
+++ b/ovos_bus_client/apis/ocp.py
@@ -253,7 +253,7 @@ class OCPInterface:
     @staticmethod
     def norm_tracks(tracks: list):
         try:
-            from ovos_utils.ocp import Playlist, MediaEntry, PluginStream
+            from ovos_utils.ocp import Playlist, MediaEntry, PluginStream, dict2entry
         except ImportError as e:
             raise RuntimeError("This method requires ovos-utils ~=0.1") from e
 
@@ -262,7 +262,7 @@ class OCPInterface:
         # support Playlist and MediaEntry objects in tracks
         for idx, track in enumerate(tracks):
             if isinstance(track, dict):
-                tracks[idx] = MediaEntry.from_dict(track)
+                tracks[idx] = dict2entry(track)
             elif isinstance(track, PluginStream):
                 # TODO - this method will be deprecated
                 #  once all SEI parsers can handle the new objects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-config >= 0.0.12, < 0.2.0
-ovos-utils >= 0.0.38, < 0.2.0
+ovos-utils >= 0.1.0a23, < 0.2.0
 websocket-client>=0.54.0
 pyee>=8.1.0, < 9.0.0
 orjson

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-config >= 0.0.12, < 0.2.0
-ovos-utils >= 0.1.0a23, < 0.2.0
+ovos-utils >= 0.0.38, < 0.2.0
 websocket-client>=0.54.0
 pyee>=8.1.0, < 9.0.0
 orjson


### PR DESCRIPTION
requires https://github.com/OpenVoiceOS/ovos-utils/pull/246

relates to https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/issues/114

currently the new PluginStream objects are converted to the expected MediaEntry, this is to ensure whatever is listening to the OCP bus api can handle it.

once this is removed old OCP wont be able to parse PluginStreams, this can only be done once we fully migrate to ovos-media and deprecate old OCP