### PR TITLE
fix/KeyError

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -340,7 +340,7 @@ class MessageBusClient(_MessageBusClientBase):
             if event_name not in self.emitter._events:
                 LOG.debug("Not able to find '%s'", event_name)
             self.emitter.remove_listener(event_name, func)
-        except ValueError:
+        except (ValueError, KeyError):
             LOG.warning('Failed to remove event %s: %s',
                         event_name, str(func))
             for line in traceback.format_stack():


### PR DESCRIPTION
handle KeyError when trying to remove an event that isnt registered

the debug logs and handling are there, but only checked for ValueError

noticed in hivemind, relates to https://github.com/JarbasHiveMind/hivemind-websocket-client/pull/29