### PR TITLE
fix:allow newer pyee

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-config>=0.0.12,<1.0.0
 ovos-utils>=0.0.38,<1.0.0
 websocket-client>=0.54.0
-pyee>=8.1.0, < 9.0.0
+pyee>=8.1.0, < 11.0.0
 orjson

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-config>=0.0.12,<1.0.0
 ovos-utils>=0.0.38,<1.0.0
 websocket-client>=0.54.0
-pyee>=8.1.0, < 11.0.0
+pyee>=8.1.0, < 12.0.0
 orjson


### PR DESCRIPTION
last backwards compatible version

relates to https://github.com/OpenVoiceOS/ovos-bus-client/pull/123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `pyee` package, allowing for a broader range of compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->