### PR TITLE
chore: fix pyee import, maintain backwards compat

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install -r test/requirements.txt
-          pip install -U pyee<12.0.0
+          pip install -U "pyee<12.0.0"
       - name: Run unittests
         run: |
           pytest --cov=ovos_bus_client --cov-report=xml test/unittests
@@ -62,7 +62,7 @@ jobs:
           #       (for an example, see OVOS Skill Manager's workflow)
       - name: Maintain Pyee backwards compat
         run: |
-          pip install -U pyee>12.0.0
+          pip install -U "pyee>12.0.0"
           pytest --cov=ovos_bus_client --cov-report=xml --cov-append test/unittests
       - name: Upload coverage
         if: "${{ matrix.python-version == '3.9' }}"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,42 +4,42 @@ on:
     branches:
       - dev
     paths-ignore:
-      - 'ovos_bus_client/version.py'
-      - 'examples/**'
-      - '.github/**'
-      - '.gitignore'
-      - 'LICENSE'
-      - 'CHANGELOG.md'
-      - 'MANIFEST.in'
-      - 'README.md'
-      - 'scripts/**'
+      - "ovos_bus_client/version.py"
+      - "examples/**"
+      - ".github/**"
+      - ".gitignore"
+      - "LICENSE"
+      - "CHANGELOG.md"
+      - "MANIFEST.in"
+      - "README.md"
+      - "scripts/**"
   push:
     branches:
       - master
     paths-ignore:
-      - 'ovos_bus_client/version.py'
-      - 'requirements/**'
-      - 'examples/**'
-      - '.github/**'
-      - '.gitignore'
-      - 'LICENSE'
-      - 'CHANGELOG.md'
-      - 'MANIFEST.in'
-      - 'README.md'
-      - 'scripts/**'
+      - "ovos_bus_client/version.py"
+      - "requirements/**"
+      - "examples/**"
+      - ".github/**"
+      - ".gitignore"
+      - "LICENSE"
+      - "CHANGELOG.md"
+      - "MANIFEST.in"
+      - "README.md"
+      - "scripts/**"
   workflow_dispatch:
 
 jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install System Dependencies
@@ -53,15 +53,20 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install -r test/requirements.txt
+          pip install -U pyee<12.0.0
       - name: Run unittests
         run: |
           pytest --cov=ovos_bus_client --cov-report=xml test/unittests
           # NOTE: additional pytest invocations should also add the --cov-append flag
           #       or they will overwrite previous invocations' coverage reports
           #       (for an example, see OVOS Skill Manager's workflow)
+      - name: Maintain Pyee backwards compat
+        run: |
+          pip install -U pyee>12.0.0
+          pytest --cov=ovos_bus_client --cov-report=xml --cov-append test/unittests
       - name: Upload coverage
         if: "${{ matrix.python-version == '3.9' }}"
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: coverage.xml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install -r test/requirements.txt
-          pip install -U "pyee<12.0.0"
       - name: Run unittests
         run: |
           pytest --cov=ovos_bus_client --cov-report=xml test/unittests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -60,7 +60,7 @@ jobs:
           #       (for an example, see OVOS Skill Manager's workflow)
       - name: Maintain Pyee backwards compat
         run: |
-          pip install -U "pyee>12.0.0"
+          pip install -U "pyee==8.1.0"
           pytest --cov=ovos_bus_client --cov-report=xml --cov-append test/unittests
       - name: Upload coverage
         if: "${{ matrix.python-version == '3.9' }}"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,7 +18,6 @@ on:
       - master
     paths-ignore:
       - "ovos_bus_client/version.py"
-      - "requirements/**"
       - "examples/**"
       - ".github/**"
       - ".gitignore"

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -7,7 +7,11 @@ from typing import Union, Callable, Any, List, Optional
 from uuid import uuid4
 
 from ovos_utils.log import LOG, deprecated
-from pyee import ExecutorEventEmitter
+try:
+    from pyee import ExecutorEventEmitter
+except ImportError:
+    from pyee.executor import ExecutorEventEmitter
+
 from websocket import (WebSocketApp,
                        WebSocketConnectionClosedException,
                        WebSocketException)

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from ovos_utils.log import LOG, deprecated
 try:
     from pyee import ExecutorEventEmitter
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from pyee.executor import ExecutorEventEmitter
 
 from websocket import (WebSocketApp,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-config>=0.0.12,<1.0.0
 ovos-utils>=0.3.5,<1.0.0
 websocket-client>=0.54.0
-pyee>=8.1.0, < 12.0.0
+pyee>= 8.1.0, < 13.0.0
 orjson

--- a/test/unittests/test_client.py
+++ b/test/unittests/test_client.py
@@ -13,7 +13,10 @@
 import unittest
 from unittest.mock import call, Mock, patch
 
-from pyee import ExecutorEventEmitter
+try:
+    from pyee import ExecutorEventEmitter
+except ImportError:
+    from pyee.executor import ExecutorEventEmitter
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.client.client import MessageBusClient, GUIWebsocketClient

--- a/test/unittests/test_client.py
+++ b/test/unittests/test_client.py
@@ -15,7 +15,7 @@ from unittest.mock import call, Mock, patch
 
 try:
     from pyee import ExecutorEventEmitter
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from pyee.executor import ExecutorEventEmitter
 
 from ovos_bus_client.message import Message

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -4,7 +4,11 @@
 
 import unittest
 import time
-from pyee import ExecutorEventEmitter
+try:
+    from pyee import ExecutorEventEmitter
+except ImportError:
+    from pyee.executor import ExecutorEventEmitter
+
 
 from unittest.mock import MagicMock, patch
 from ovos_utils.messagebus import FakeBus

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -6,7 +6,7 @@ import unittest
 import time
 try:
     from pyee import ExecutorEventEmitter
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from pyee.executor import ExecutorEventEmitter
 
 


### PR DESCRIPTION
https://github.com/OpenVoiceOS/ovos-bus-client/pull/130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new method `run_in_thread` in the MessageBusClient for concurrent websocket handling.

- **Improvements**
  - Enhanced import handling for better compatibility with different versions of the `pyee` library.
  - Updated the `emit` method to ensure messages are sent only after confirming connection establishment.
  - Improved the GitHub Actions workflow for running unit tests, including updates to Python versions and package compatibility checks.
  - Added error handling for import failures in test files.

- **Bug Fixes**
  - Improved error handling in the message emission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->