### PR TITLE
fix:events_in_the_past

### DIFF
--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -70,22 +70,13 @@ class EventScheduler(Thread):
 
         self.events = {}
         self.event_lock = Lock()
-        clock_cache = get_xdg_cache_save_path("ovos_clock")
-        os.makedirs(clock_cache, exist_ok=True)
-        self.clock_cache = os.path.join(clock_cache, "ovos_clock_sync.ts")
-        self.last_sync = time.time()
-        if os.path.isfile(self.clock_cache):
-            with open(self.clock_cache) as f:
-                self.last_sync = float(f.read())
-        else:
-            with open(self.clock_cache, "w") as f:
-                f.write(str(self.last_sync))
-        self._dropped_events = 0
+        
         # to check if its our first connection to the internet via clock_skew
+        self._last_sync = time.time()
+        self._dropped_events = 0
         self._past_date = datetime.datetime(day=1, month=12, year=2024)
-
         # Convert Unix timestamp to human-readable datetime
-        pretty_last_sync = datetime.datetime.fromtimestamp(self.last_sync).strftime("%Y-%m-%d %H:%M:%S")
+        pretty_last_sync = datetime.datetime.fromtimestamp(self._last_sync).strftime("%Y-%m-%d %H:%M:%S")
         LOG.debug(f"Last clock sync: {pretty_last_sync}")
 
         self.bus = bus
@@ -214,7 +205,7 @@ class EventScheduler(Thread):
                                       context to send when the
                                       handler is called
         """
-        if datetime.datetime.fromtimestamp(self.last_sync) < self._past_date:
+        if datetime.datetime.fromtimestamp(self._last_sync) < self._past_date:
             # this works around problems in raspOVOS images and other
             # systems without RTC that didnt sync clock with the internet yet
             # eg. issue demonstration without this:
@@ -277,15 +268,13 @@ class EventScheduler(Thread):
 
     def handle_system_clock_sync(self, message: Message):
         # clock sync, are we in the past?
-        if datetime.datetime.fromtimestamp(self.last_sync) < self._past_date:
+        if datetime.datetime.fromtimestamp(self._last_sync) < self._past_date:
             LOG.warning(f"Clock was in the past!!! {self._dropped_events} scheduled events have been dropped")
 
-        self.last_sync = time.time()
+        self._last_sync = time.time()
         # Convert Unix timestamp to human-readable datetime
-        pretty_last_sync = datetime.datetime.fromtimestamp(self.last_sync).strftime("%Y-%m-%d %H:%M:%S")
+        pretty_last_sync = datetime.datetime.fromtimestamp(self._last_sync).strftime("%Y-%m-%d %H:%M:%S")
         LOG.info(f"clock sync: {pretty_last_sync}")
-        with open(self.clock_cache, "w") as f:
-            f.write(str(self.last_sync))
 
     def remove_event_handler(self, message: Message):
         """

--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -77,7 +77,7 @@ class EventScheduler(Thread):
         self._past_date = datetime.datetime(day=1, month=12, year=2024)
         # Convert Unix timestamp to human-readable datetime
         pretty_last_sync = datetime.datetime.fromtimestamp(self._last_sync).strftime("%Y-%m-%d %H:%M:%S")
-        LOG.debug(f"Last clock sync: {pretty_last_sync}")
+        LOG.debug(f"Boot time clock: {pretty_last_sync}")
 
         self.bus = bus
 

--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -29,7 +29,7 @@ from threading import Thread, Lock
 from typing import Optional
 
 from ovos_config.config import Configuration
-from ovos_config.locations import get_xdg_data_save_path, get_xdg_config_save_path, get_xdg_cache_save_path
+from ovos_config.locations import get_xdg_data_save_path, get_xdg_config_save_path
 from ovos_utils.log import LOG
 
 from ovos_bus_client.message import Message

--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -222,9 +222,7 @@ class EventScheduler(Thread):
             LOG.error("Refusing to schedule event, system clock is in the past!")
             self._dropped_events += 1
             return
-        elif datetime.datetime.fromtimestamp(sched_time) < datetime.datetime.now():
-            LOG.error("Refusing to schedule event, it is in the past!")
-            return
+        
         data = data or {}
         with self.event_lock:
             # get current list of scheduled times for event, [] if missing

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+langcodes


### PR DESCRIPTION
don't allow event scheduler to schedule events until clock has been synced since first boot

some systems will think we are still in the last century at boot time!

the system.clock.synced event needs to be emitted externally by the OS itself, eg https://github.com/TigreGotico/raspOVOS/commit/3ab5f44a189832bf4b61acfcfadabea352092f9e#diff-390ab68cb47cd597ab61ab48741f9d35ce7a7d514a4a40014df1222d402bead8R8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method for managing system clock synchronization, enhancing event scheduling reliability.
	- Added a new dependency for testing to improve coverage.

- **Bug Fixes**
	- Improved error handling to prevent scheduling events with an out-of-sync system clock.

- **Documentation**
	- Enhanced logging messages for better clarity regarding scheduled events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->