### PR TITLE
chore: add warnings

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/ovos_bus_client/apis/ocp.py
+++ b/ovos_bus_client/apis/ocp.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import warnings
 import time
 from datetime import timedelta
 from functools import wraps
@@ -93,6 +94,12 @@ class ClassicAudioServiceInterface:
     @deprecated("removed from ovos-audio with the adoption of ovos-media service, "
                 "use OCPInterface instead", "0.1.0")
     def __init__(self, bus=None):
+
+        warnings.warn(
+            "use OCPInterface instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.bus = bus or get_mycroft_bus()
 
     @_ensure_message_kwarg()

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -6,7 +6,7 @@ from threading import Event, Thread
 from typing import Union, Callable, Any, List, Optional
 from uuid import uuid4
 
-from ovos_utils.log import LOG, deprecated
+from ovos_utils.log import LOG
 try:
     from pyee import ExecutorEventEmitter
 except (ImportError, ModuleNotFoundError):

--- a/ovos_bus_client/message.py
+++ b/ovos_bus_client/message.py
@@ -22,11 +22,9 @@ serializing / deserializing the message for transmission.
 
 import inspect
 import orjson
-import re
 from copy import deepcopy
 from typing import Optional
 from binascii import hexlify, unhexlify
-from ovos_utils.log import LOG, deprecated
 from ovos_utils.security import encrypt, decrypt
 from ovos_config.config import Configuration
 


### PR DESCRIPTION
make IDEs signal deprecated code instead of relying on runtime logs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Deprecation**
  - Added deprecation warning for `ClassicAudioServiceInterface`
  - Recommended users transition to `OCPInterface`

- **Code Cleanup**
  - Removed unused imports
  - Streamlined message serialization and deserialization methods
  - Simplified message handling logic

- **Maintenance**
  - No functional changes to existing methods or classes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->