### PR TITLE
refactor!: Deprecate EnclosureAPI and refactor GUIInterface with PageTemplates enum

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,0 +1,33 @@
+# GUI interface
+
+`GUIInterface` (`ovos_bus_client/apis/gui.py`) is the skill- and plugin-facing
+API for driving the OVOS GUI over the messagebus. Set `gui["key"] = value` to
+sync session data to every connected client, register handlers for QML-side
+events, and request a screen via the template API.
+
+## Spec conformance (OVOS-GUI-1)
+
+This is the bus-client precursor to the template-based GUI described by the
+`OVOS-GUI-1` architecture spec. The surface is being narrowed so that OVOS
+components can only request **pre-defined system templates**, never arbitrary
+QML resource names:
+
+- **`PageTemplates` enum** — the only pages a skill or plugin may show:
+  `IDLE` (reserved for the `ovos-gui` service), `LOADING`, `STATUS`, `TEXT`,
+  `ERROR`, `IMAGE`, `ANIMATED_IMAGE`, `HTML`, `URL`, `WEATHER`, `CLOCK`, and
+  `FACE` (avatar). `page`/`pages` are now typed as `PageTemplates`.
+- **Page management is internal.** `show_page(s)`, `remove_page(s)`,
+  `remove_all_pages`, `build_message_type`, and `setup_default_handlers` are now
+  private (`_`-prefixed). High-level helpers such as `show_face`,
+  `show_loading_animation`, and `show_status_animation` route through these
+  templates instead of named `.qml` files.
+- **Removed legacy surface** — `GUIWidgets`, `extend_about_data`,
+  `ui_directories`/local GUI-file caching, the custom notification helpers, and
+  per-skill `.qml` page normalization. GUIs no longer load skill-supplied QML.
+
+## `EnclosureAPI` is deprecated
+
+`EnclosureAPI` (`ovos_bus_client/apis/enclosure.py`) is no longer a core
+abstraction. Mark 1 / hardware-specific visual output should move into a
+dedicated `ovos-ui-enclosure-protocol-plugin`; all in-core visual output is
+done through `GUIInterface`.

--- a/ovos_bus_client/apis/gui.py
+++ b/ovos_bus_client/apis/gui.py
@@ -1,51 +1,30 @@
+import enum
 import os
-import shutil
-from os.path import splitext, isfile
 from typing import List, Union, Optional, Callable
 
 from ovos_config import Configuration
-from ovos_config.locations import get_xdg_cache_save_path
-from ovos_utils.gui import can_use_gui
+from ovos_utils.gui import can_use_gui # TODO deprecate
 from ovos_utils.log import LOG
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.util import get_mycroft_bus
 
 
-def extend_about_data(about_data: Union[list, dict],
-                      bus=None):
-    """
-    Add more information to the "About" section in the GUI.
-    @param about_data: list of dict key, val information to add to the GUI
-    @param bus: MessageBusClient object to emit update on
-    """
-    bus = bus or get_mycroft_bus()
-    if isinstance(about_data, list):
-        bus.emit(Message("smartspeaker.extension.extend.about",
-                         {"display_list": about_data}))
-    elif isinstance(about_data, dict):
-        display_list = [about_data]
-        bus.emit(Message("smartspeaker.extension.extend.about",
-                         {"display_list": display_list}))
-    else:
-        LOG.error("about_data is not a list or dictionary")
+class PageTemplates(str, enum.Enum):
+    """OVOS components (skills and plugins) can ONLY display pre-defined templates"""
+    IDLE = 'SYSTEM_idle' # default state, reserved for use by ovos-gui service only
+    LOADING = "SYSTEM_loading"
+    STATUS = "SYSTEM_status"
+    TEXT = "SYSTEM_text"
+    ERROR = "SYSTEM_error"
+    IMAGE = "SYSTEM_image"
+    ANIMATED_IMAGE = "SYSTEM_animated_image"
+    HTML = "SYSTEM_html"
+    URL = "SYSTEM_url"
 
-
-class GUIWidgets:
-    def __init__(self, bus=None):
-        self.bus = bus or get_mycroft_bus()
-
-    def show_widget(self, widget_type, widget_data):
-        LOG.debug("Showing widget: " + widget_type)
-        self.bus.emit(Message("ovos.widgets.display", {"type": widget_type, "data": widget_data}))
-
-    def remove_widget(self, widget_type, widget_data):
-        LOG.debug("Removing widget: " + widget_type)
-        self.bus.emit(Message("ovos.widgets.remove", {"type": widget_type, "data": widget_data}))
-
-    def update_widget(self, widget_type, widget_data):
-        LOG.debug("Updating widget: " + widget_type)
-        self.bus.emit(Message("ovos.widgets.update", {"type": widget_type, "data": widget_data}))
+    WEATHER = "SYSTEM_weather"
+    CLOCK = "SYSTEM_clock"
+    FACE = "SYSTEM_face" # avatar
 
 
 class _GUIDict(dict):
@@ -68,7 +47,7 @@ class _GUIDict(dict):
 class GUIInterface:
     """
     Interface to the Graphical User Interface, allows interaction with
-    the mycroft-gui from anywhere
+    the ovos-gui from anywhere
 
     Values set in this class are synced to the GUI, accessible within QML
     via the built-in sessionData mechanism.  For example, in Python you can
@@ -80,8 +59,7 @@ class GUIInterface:
     """
 
     def __init__(self, skill_id: str, bus=None,
-                 config: dict = None,
-                 ui_directories: dict = None):
+                 config: dict = None):
         """
         Create an interface to the GUI module. Values set here are exposed to
         the GUI client as sessionData
@@ -94,46 +72,17 @@ class GUIInterface:
         self.config = config
         self._bus = bus
         self.__session_data = {}  # synced to GUI for use by this skill's pages
-        self._pages = []
-        self.current_page_idx = -1
-        self._skill_id = skill_id
+        self._pages: List[PageTemplates] = [] # empty when GUI not in use by this skill_id
+        self.current_page_idx = -1 # -1 when GUI not in use by this skill_id
+        self._skill_id = skill_id # same as a "namespace" in GUI documentation
         self.on_gui_changed_callback = None
         self._events = []
-        self.ui_directories = ui_directories or dict()
         if bus:
             self.set_bus(bus)
-        self._cache_gui_files()
-
-    def _cache_gui_files(self):
-        if not self.ui_directories:
-            LOG.debug(f"{self.skill_id} has no GUI resources")
-            return
-
-        # this path is hardcoded in ovos_gui.constants and follows XDG spec
-        GUI_CACHE_PATH = get_xdg_cache_save_path('ovos_gui')
-
-        output_path = f"{GUI_CACHE_PATH}/{self.skill_id}"
-        if os.path.exists(output_path):
-            LOG.info(f"Removing existing {self.skill_id} cached GUI resources before updating")
-            try:
-                shutil.rmtree(output_path)
-            except Exception as e:
-                LOG.error(f"Failed to remove existing cache: ({e})")
-        for framework, bpath in self.ui_directories.items():
-            if framework == "all":
-                # mostly applies to image files
-                shutil.copytree(bpath, output_path, dirs_exist_ok=True)
-                LOG.debug(f"Copied {self.skill_id} shared GUI resources from {bpath} to {output_path}")
-                continue
-            if not os.path.isdir(bpath):
-                LOG.error(f"invalid '{framework}' resources directory: {bpath}")
-                continue
-            shutil.copytree(bpath, f"{output_path}/{framework}", dirs_exist_ok=True)
-            LOG.debug(f"Copied {self.skill_id} GUI resources from {bpath} to {output_path}/{framework}")
 
     def set_bus(self, bus=None):
         self._bus = bus or get_mycroft_bus()
-        self.setup_default_handlers()
+        self._setup_default_handlers()
 
     @property
     def gui_disabled(self) -> bool:
@@ -162,7 +111,7 @@ class GUIInterface:
         self._skill_id = val
 
     @property
-    def page(self) -> Optional[str]:
+    def page(self) -> Optional[PageTemplates]:
         """
         Return the active GUI page name to show
         """
@@ -181,13 +130,14 @@ class GUIInterface:
         return can_use_gui(self.bus)
 
     @property
-    def pages(self) -> List[str]:
+    def pages(self) -> List[PageTemplates]:
         """
         Get a list of the active page ID's managed by this interface
         """
+        # TODO - return PageTemplates.XXX
         return self._pages
 
-    def build_message_type(self, event: str) -> str:
+    def _build_message_type(self, event: str) -> str:
         """
         Ensure the specified event prepends this interface's `skill_id`
         """
@@ -196,11 +146,11 @@ class GUIInterface:
         return event
 
     # events
-    def setup_default_handlers(self):
+    def _setup_default_handlers(self):
         """
         Sets the handlers for the default messages.
         """
-        msg_type = self.build_message_type('set')
+        msg_type = self._build_message_type('set')
         self.bus.on(msg_type, self.gui_set)
         self._events.append((msg_type, self.gui_set))
 
@@ -219,7 +169,7 @@ class GUIInterface:
         """
         if not self.bus:
             raise RuntimeError("bus not set, did you call self.bind() ?")
-        event = self.build_message_type(event)
+        event = self._build_message_type(event)
         self._events.append((event, handler))
         self.bus.on(event, handler)
 
@@ -322,27 +272,11 @@ class GUIInterface:
                                "event_name": event_name,
                                "params": params}))
 
-    @staticmethod
-    def _normalize_page_name(page_name: str) -> str:
-        """
-        Normalize a requested GUI resource
-        @param page_name: string name of a GUI resource
-        @return: normalized string name (`.qml` removed for other GUI support)
-        """
-        if isfile(page_name):
-            raise ValueError("GUI resources should specify a resource name and not a file path.")
-        file, ext = splitext(page_name)
-        if ext == ".qml":
-            LOG.error("GUI resources should exclude gui-specific file "
-                      f"extensions. This call should probably pass "
-                      f"`{file}`, instead of `{page_name}`")
-            return file
-        return page_name
-
     # base gui interactions
-    def show_page(self, name: str, override_idle: Union[bool, int] = None,
-                  override_animations: bool = False, index: int = 0,
-                  remove_others=False):
+    def _show_page(self, name: PageTemplates,
+                   override_idle: Union[bool, int] = None,
+                   override_animations: bool = False, index: int = 0,
+                   remove_others=False):
         """
         Request to show a page in the GUI.
         @param name: page resource requested
@@ -350,12 +284,12 @@ class GUIInterface:
             if True, override display indefinitely
         @param override_animations: if True, disables all GUI animations
         """
-        self.show_pages([name], index, override_idle, override_animations, remove_others)
+        self._show_pages([name], index, override_idle, override_animations, remove_others)
 
-    def show_pages(self, page_names: List[str], index: int = 0,
-                   override_idle: Union[bool, int] = None,
-                   override_animations: bool = False,
-                   remove_others=False):
+    def _show_pages(self, page_names: List[PageTemplates], index: int = 0,
+                    override_idle: Union[bool, int] = None,
+                    override_animations: bool = False,
+                    remove_others=False):
         """
         Request to show a list of pages in the GUI.
         @param page_names: list of page resources requested
@@ -375,13 +309,8 @@ class GUIInterface:
             LOG.error('Default index is larger than page list length')
             index = len(page_names) - 1
 
-        if any(p.endswith(".qml") for p in page_names):
-            LOG.warning("received invalid page, please remove '.qml' extension from your code, "
-                        "this has been deprecated in ovos-gui and may stop working anytime")
-            page_names = [self._normalize_page_name(n) for n in page_names]
-
         if remove_others:
-            self.remove_all_pages(except_pages=page_names)
+            self._remove_all_pages(except_pages=page_names)
 
         self._pages = page_names
         self.current_page_idx = index
@@ -402,14 +331,14 @@ class GUIInterface:
                                "__idle": override_idle,
                                "__animations": override_animations}))
 
-    def remove_page(self, page: str):
+    def _remove_page(self, page: PageTemplates):
         """
         Remove a single page from the GUI.
         @param page: Name of page to remove
         """
-        self.remove_pages([page])
+        self._remove_pages([page])
 
-    def remove_pages(self, page_names: List[str]):
+    def _remove_pages(self, page_names: List[PageTemplates]):
         """
         Request to remove a list of pages from the GUI.
         @param page_names: list of page resources requested
@@ -422,16 +351,12 @@ class GUIInterface:
             page_names = [page_names]
         if not isinstance(page_names, list):
             raise ValueError('page_names must be a list')
-        if any(p.endswith(".qml") for p in page_names):
-            LOG.warning("received invalid page, please remove '.qml' extension from your code, "
-                        "this has been deprecated in ovos-gui and may stop working anytime")
-            page_names = [self._normalize_page_name(n) for n in page_names]
 
         self.bus.emit(Message("gui.page.delete",
                               {"page_names": page_names,
                                "__from": self.skill_id}))
 
-    def remove_all_pages(self, except_pages=None):
+    def _remove_all_pages(self, except_pages=None):
         """
         Request to remove all pages from the GUI.
         @param except_pages: list of optional page resources to keep
@@ -445,81 +370,11 @@ class GUIInterface:
                                "except": except_pages or []}))
 
     # Utils / Templates
-
-    # backport - PR https://github.com/MycroftAI/mycroft-core/pull/2862
-    def show_notification(self, content: str, duration: int = 10,
-                          action: str = None, noticetype: str = "transient",
-                          style: str = "info",
-                          callback_data: Optional[dict] = None):
-        """Display a Notification on homepage in the GUI.
-        Arguments:
-            content (str): Main text content of a notification, Limited
-            to two visual lines.
-            duration (int): seconds to display notification for
-            action (str): Callback to any event registered by the skill
-            to perform a certain action when notification is clicked.
-            noticetype (str):
-                transient: 'Default' displays a notification with a timeout.
-                sticky: displays a notification that sticks to the screen.
-            style (str):
-                info: 'Default' displays a notification with information styling
-                warning: displays a notification with warning styling
-                success: displays a notification with success styling
-                error: displays a notification with error styling
-            callback_data (dict): data dictionary available to use with action
-        """
-        # TODO: Define enums for style and noticetype
-        if not self.bus:
-            raise RuntimeError("bus not set, did you call self.bind() ?")
-        # GUI does not accept NONE type, send an empty dict
-        # Sending NONE will corrupt entries in the model
-        callback_data = callback_data or dict()
-        self.bus.emit(Message("ovos.notification.api.set",
-                              data={
-                                  "duration": duration,
-                                  "sender": self.skill_id,
-                                  "text": content,
-                                  "action": action,
-                                  "type": noticetype,
-                                  "style": style,
-                                  "callback_data": callback_data
-                              }))
-
-    def show_controlled_notification(self, content: str, style: str = "info"):
-        """
-        Display a controlled Notification in the GUI.
-        Arguments:
-            content (str): Main text content of a notification, Limited
-            to two visual lines.
-            style (str):
-                info: 'Default' displays a notification with information styling
-                warning: displays a notification with warning styling
-                success: displays a notification with success styling
-                error: displays a notification with error styling
-        """
-        # TODO: Define enum for style
-        if not self.bus:
-            raise RuntimeError("bus not set, did you call self.bind() ?")
-        self.bus.emit(Message("ovos.notification.api.set.controlled",
-                              data={
-                                  "sender": self.skill_id,
-                                  "text": content,
-                                  "style": style
-                              }))
-
-    def remove_controlled_notification(self):
-        """
-        Remove a controlled Notification in the GUI.
-        """
-        if not self.bus:
-            raise RuntimeError("bus not set, did you call self.bind() ?")
-        self.bus.emit(Message("ovos.notification.api.remove.controlled"))
-
     def show_face(self, awake: bool = True,
                   override_idle: Union[int, bool] = True,
                   override_animations: bool = True):
         """
-        Display a sleeping/awake face
+        Display a sleeping/awake face - for GUIs that are some sort of avatar.
 
         Arguments:
             awake (bool): open or closed eyes
@@ -532,13 +387,13 @@ class GUIInterface:
                 False: 'Default' always show animations.
         """
         self["sleeping"] = not awake
-        self.show_page("SYSTEM_Face", override_idle, override_animations)
+        self._show_page(PageTemplates.FACE, override_idle, override_animations)
 
     def show_loading_animation(self, text: str,
                                override_idle: Union[int, bool] = None,
                                override_animations: bool = False):
         """
-        Display a GUI loading animation
+        Display a generic loading animation
 
         Arguments:
             text (str): Main text content.
@@ -551,7 +406,7 @@ class GUIInterface:
                 False: 'Default' always show animations.
         """
         self["label"] = text
-        self.show_page("SYSTEM_Loading", override_idle, override_animations)
+        self._show_page(PageTemplates.LOADING, override_idle, override_animations)
 
     def show_status_animation(self, text: str, success: bool,
                               override_idle: Union[int, bool] = None,
@@ -572,7 +427,7 @@ class GUIInterface:
         """
         self["status"] = "Enabled" if success else "Disabled"  # string check in QML
         self["label"] = text
-        self.show_page("SYSTEM_Status", override_idle, override_animations)
+        self._show_page(PageTemplates.STATUS, override_idle, override_animations)
 
     def show_text(self, text: str, title: Optional[str] = None,
                   override_idle: Union[int, bool] = None,
@@ -593,40 +448,8 @@ class GUIInterface:
         """
         self["text"] = text
         self["title"] = title
-        self.show_page("SYSTEM_TextFrame", override_idle,
-                       override_animations)
-
-    def _resolve_url(self, url: str) -> str:
-        """Resolve a URL to a valid file path.
-        
-        Args:
-            url (str): URL or file path to resolve
-            
-        Returns:
-            str: Resolved absolute file path or original URL
-            
-        Raises:
-            ValueError: If url is None or empty
-        """
-        if not url or not isinstance(url, str):
-            raise ValueError("URL must be a non-empty string")
-        if url.startswith("http"):
-            return url
-
-        if not os.path.isfile(url):
-            GUI_CACHE_PATH = get_xdg_cache_save_path('ovos_gui')
-            # Use os.path.join for path construction
-            gui_cache = os.path.join(GUI_CACHE_PATH, self.skill_id, url)
-            if os.path.isfile(gui_cache):
-                LOG.debug(f"Resolved image: {gui_cache}")
-                return gui_cache
-            else:
-                for framework in self.ui_directories:
-                    gui_cache = os.path.join(GUI_CACHE_PATH, self.skill_id, framework, url)
-                    if os.path.isfile(gui_cache):
-                        LOG.debug(f"Resolved image: {gui_cache}")
-                        return gui_cache
-        return url
+        self._show_page(PageTemplates.TEXT, override_idle,
+                        override_animations)
 
     def show_image(self, url: str, caption: Optional[str] = None,
                    title: Optional[str] = None,
@@ -652,7 +475,7 @@ class GUIInterface:
                 True: Disables showing all platform skill animations.
                 False: 'Default' always show animations.
         """
-        url = self._resolve_url(url)
+        # TODO - b64 encode files, no paths
         if not url.startswith("http") and not os.path.isfile(url):
             LOG.error(f"Provided image file does not exist! '{url}'")
             return
@@ -661,8 +484,8 @@ class GUIInterface:
         self["caption"] = caption
         self["fill"] = fill
         self["background_color"] = background_color
-        self.show_page("SYSTEM_ImageFrame", override_idle,
-                       override_animations)
+        self._show_page(PageTemplates.IMAGE, override_idle,
+                        override_animations)
 
     def show_animated_image(self, url: str, caption: Optional[str] = None,
                             title: Optional[str] = None,
@@ -688,7 +511,7 @@ class GUIInterface:
                 True: Disables showing all platform skill animations.
                 False: 'Default' always show animations.
         """
-        url = self._resolve_url(url)
+        # TODO - b64 encode files, no paths
         if not url.startswith("http") and not os.path.isfile(url):
             LOG.error(f"Provided image file does not exist! '{url}'")
             return
@@ -697,8 +520,8 @@ class GUIInterface:
         self["caption"] = caption
         self["fill"] = fill
         self["background_color"] = background_color
-        self.show_page("SYSTEM_AnimatedImageFrame", override_idle,
-                       override_animations)
+        self._show_page(PageTemplates.ANIMATED_IMAGE, override_idle,
+                        override_animations)
 
     def show_html(self, html: str, resource_url: Optional[str] = None,
                   override_idle: Union[int, bool] = None,
@@ -719,8 +542,8 @@ class GUIInterface:
         """
         self["html"] = html
         self["resourceLocation"] = resource_url
-        self.show_page("SYSTEM_HtmlFrame", override_idle,
-                       override_animations)
+        self._show_page(PageTemplates.HTML, override_idle,
+                        override_animations)
 
     def show_url(self, url: str, override_idle: Union[int, bool] = None,
                  override_animations: bool = False):
@@ -738,50 +561,8 @@ class GUIInterface:
                 False: 'Default' always show animations.
         """
         self["url"] = url
-        self.show_page("SYSTEM_UrlFrame", override_idle,
-                       override_animations)
-
-    def show_input_box(self, title: Optional[str] = None,
-                       placeholder: Optional[str] = None,
-                       confirm_text: Optional[str] = None,
-                       exit_text: Optional[str] = None,
-                       override_idle: Union[int, bool] = None,
-                       override_animations: bool = False):
-        """
-        Display a fullscreen UI for a user to enter text and confirm or cancel
-        @param title: title of input UI should describe what the input is
-        @param placeholder: default text hint to show in an empty entry box
-        @param confirm_text: text to display on the submit/confirm button
-        @param exit_text: text to display on the cancel/exit button
-        @param override_idle: if True, takes over the resting page indefinitely
-            else Delays resting page for the specified number of seconds.
-        @param override_animations: disable showing all platform animations
-        """
-        self["title"] = title
-        self["placeholder"] = placeholder
-        self["skill_id_handler"] = self.skill_id
-        if not confirm_text:
-            self["confirm_text"] = "Confirm"
-        else:
-            self["confirm_text"] = confirm_text
-
-        if not exit_text:
-            self["exit_text"] = "Exit"
-        else:
-            self["exit_text"] = exit_text
-
-        self.show_page("SYSTEM_InputBox", override_idle,
-                       override_animations)
-
-    def remove_input_box(self):
-        """
-        Remove an input box shown by `show_input_box`
-        """
-        LOG.info(f"GUI pages length {len(self._pages)}")
-        if len(self._pages) > 1:
-            self.remove_page("SYSTEM_InputBox")
-        else:
-            self.release()
+        self._show_page(PageTemplates.URL, override_idle,
+                        override_animations)
 
     def release(self):
         """

--- a/test/unittests/test_gui_api.py
+++ b/test/unittests/test_gui_api.py
@@ -1,41 +1,40 @@
-"""Coverage tests for ovos_bus_client.apis.gui — GUIInterface, GUIWidgets."""
-import unittest
+"""Coverage tests for ovos_bus_client.apis.gui — the template-based GUIInterface.
+
+The classic free-form page / widget API was removed (OVOS-GUI-1): applications
+now declare *what* to display by naming a SYSTEM_* template (PageTemplates) and
+supplying its data; the wire protocol is ``gui.value.set`` + ``gui.page.show``.
+These tests assert that observable contract.
+"""
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from ovos_bus_client.apis.gui import GUIInterface, GUIWidgets, _GUIDict
-from ovos_bus_client.message import Message
+from ovos_bus_client.apis.gui import GUIInterface, PageTemplates, _GUIDict
 
 
-def _last(bus) -> Message:
-    return bus.emit.call_args[0][0]
+def _emitted(bus):
+    return [c.args[0] for c in bus.emit.call_args_list]
 
 
-def _emitted_types(bus):
-    return [c.args[0].msg_type for c in bus.emit.call_args_list]
+def _types(bus):
+    return [m.msg_type for m in _emitted(bus)]
 
 
-class TestGUIWidgets(TestCase):
-    def setUp(self):
-        self.bus = MagicMock()
-        self.widgets = GUIWidgets(bus=self.bus)
-
-    def test_show_widget(self):
-        self.widgets.show_widget("clock", {"face": "round"})
-        emitted = _last(self.bus)
-        self.assertEqual(emitted.msg_type, "ovos.widgets.display")
-        self.assertEqual(emitted.data["type"], "clock")
-
-    def test_remove_widget(self):
-        self.widgets.remove_widget("clock", {})
-        self.assertEqual(_last(self.bus).msg_type, "ovos.widgets.remove")
-
-    def test_update_widget(self):
-        self.widgets.update_widget("clock", {"hand": "minute"})
-        self.assertEqual(_last(self.bus).msg_type, "ovos.widgets.update")
+def _first(bus, msg_type):
+    return next(m for m in _emitted(bus) if m.msg_type == msg_type)
 
 
-class TestGUIInterfaceConstructionAndProps(TestCase):
+class TestPageTemplates(TestCase):
+    def test_values_are_system_prefixed(self):
+        for t in PageTemplates:
+            self.assertTrue(t.value.startswith("SYSTEM_"), t.value)
+
+    def test_known_templates_present(self):
+        names = {t.name for t in PageTemplates}
+        for expected in ("TEXT", "IMAGE", "FACE", "LOADING", "STATUS", "HTML", "URL"):
+            self.assertIn(expected, names)
+
+
+class TestConstructionAndProps(TestCase):
     def setUp(self):
         self.bus = MagicMock()
         self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
@@ -45,49 +44,37 @@ class TestGUIInterfaceConstructionAndProps(TestCase):
         self.gui.skill_id = "new.skill"
         self.assertEqual(self.gui.skill_id, "new.skill")
 
-    def test_bus_property_and_setter(self):
+    def test_bus_property_and_set_bus(self):
         new_bus = MagicMock()
-        self.gui.bus = new_bus
+        self.gui.set_bus(new_bus)
         self.assertIs(self.gui.bus, new_bus)
 
     def test_build_message_type_prepends_skill_id(self):
-        self.assertEqual(self.gui.build_message_type("clicked"), "t.skill.clicked")
+        self.assertEqual(self.gui._build_message_type("clicked"), "t.skill.clicked")
 
-    def test_build_message_type_already_prefixed(self):
-        self.assertEqual(
-            self.gui.build_message_type("t.skill.clicked"),
-            "t.skill.clicked",
-        )
+    def test_build_message_type_idempotent_when_prefixed(self):
+        self.assertEqual(self.gui._build_message_type("t.skill.clicked"),
+                         "t.skill.clicked")
 
-    def test_setup_default_handlers_registers_set(self):
-        self.bus.reset_mock()
-        self.gui.setup_default_handlers()
-        registered = {c.args[0] for c in self.bus.on.call_args_list}
-        self.assertIn("t.skill.set", registered)
-
-    def test_page_property_empty(self):
+    def test_pages_initial_empty(self):
+        self.assertEqual(self.gui.pages, [])
         self.assertIsNone(self.gui.page)
 
-    def test_pages_property_initial_empty(self):
-        self.assertEqual(self.gui.pages, [])
+    def test_gui_disabled_default_false(self):
+        self.assertFalse(self.gui.gui_disabled)
 
     def test_connected_false_without_bus(self):
         gui = GUIInterface(skill_id="t.skill")
         self.assertFalse(gui.connected)
 
-    def test_gui_disabled_default(self):
-        # default config should not disable
-        self.assertFalse(self.gui.gui_disabled)
 
-
-class TestGUIRegisterHandler(TestCase):
+class TestHandlers(TestCase):
     def setUp(self):
         self.bus = MagicMock()
         self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
 
-    def test_register_handler_registers_with_prefix(self):
-        cb = MagicMock()
-        self.gui.register_handler("clicked", cb)
+    def test_register_handler_prefixes_event(self):
+        self.gui.register_handler("clicked", lambda m: None)
         registered = {c.args[0] for c in self.bus.on.call_args_list}
         self.assertIn("t.skill.clicked", registered)
 
@@ -102,329 +89,258 @@ class TestGUIRegisterHandler(TestCase):
         self.assertIs(self.gui.on_gui_changed_callback, cb)
 
 
-class TestGUIDictAccess(TestCase):
+class TestDictAccess(TestCase):
     def setUp(self):
         self.bus = MagicMock()
         self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
 
-    def test_setitem_stores_value(self):
+    def test_setitem_and_getitem(self):
         self.gui["temperature"] = 22
         self.assertEqual(self.gui["temperature"], 22)
 
-    def test_setitem_same_value_skips_sync(self):
-        self.gui._pages = ["page"]  # so page property is non-None and sync happens
-        self.gui.current_page_idx = 0
-        self.gui["k"] = "v"
-        self.bus.reset_mock()
-        self.gui["k"] = "v"  # same → no sync
-        self.assertFalse(self.bus.emit.called)
-
-    def test_setitem_dict_gets_wrapped(self):
-        self.gui["meta"] = {"a": 1}
-        self.assertIsInstance(self.gui["meta"], _GUIDict)
-
-    def test_get_method(self):
+    def test_get_with_default(self):
         self.gui["k"] = "v"
         self.assertEqual(self.gui.get("k"), "v")
         self.assertIsNone(self.gui.get("missing"))
         self.assertEqual(self.gui.get("missing", "default"), "default")
 
-    def test_contains_operator(self):
+    def test_contains(self):
         self.gui["k"] = "v"
         self.assertIn("k", self.gui)
         self.assertNotIn("missing", self.gui)
 
-    def test_guidict_sync_on_change(self):
-        d = _GUIDict(gui=self.gui, x=1)
-        d["x"] = 99
-        # _sync_data raises if there's no bus; we have one, so it just emits
-        # whether emit fired depends on gui_disabled, but no exception is fine
-        d["x"] = 99   # same value, no sync needed
+    def test_dict_value_wrapped(self):
+        self.gui["meta"] = {"a": 1}
+        self.assertIsInstance(self.gui["meta"], _GUIDict)
 
 
-class TestGUIClear(TestCase):
+class TestClearAndEvents(TestCase):
     def setUp(self):
         self.bus = MagicMock()
         self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
 
-    def test_clear_resets_state_and_emits(self):
-        self.gui["a"] = 1
-        self.gui._pages = ["p1", "p2"]
+    def test_clear_resets_pages_and_emits_namespace(self):
+        self.gui.show_text("hi")
         self.gui.clear()
         self.assertEqual(self.gui.pages, [])
-        self.assertEqual(self.gui.current_page_idx, -1)
-        self.assertIn("gui.clear.namespace", _emitted_types(self.bus))
-
-
-class TestGUISendEvent(TestCase):
-    def setUp(self):
-        self.bus = MagicMock()
-        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
+        self.assertIn("gui.clear.namespace", _types(self.bus))
 
     def test_send_event_payload(self):
         self.gui.send_event("clicked", {"target": "btn"})
-        emitted = _last(self.bus)
-        self.assertEqual(emitted.msg_type, "gui.event.send")
-        self.assertEqual(emitted.data["event_name"], "clicked")
-        self.assertEqual(emitted.data["params"], {"target": "btn"})
+        msg = _first(self.bus, "gui.event.send")
+        self.assertEqual(msg.data["event_name"], "clicked")
+        self.assertEqual(msg.data["params"], {"target": "btn"})
 
     def test_send_event_default_params(self):
         self.gui.send_event("idle")
-        self.assertEqual(_last(self.bus).data["params"], {})
+        self.assertEqual(_first(self.bus, "gui.event.send").data["params"], {})
+
+    def test_release_clears_pages(self):
+        self.gui.show_text("hi")
+        self.gui.release()
+        self.assertEqual(self.gui.pages, [])
 
 
-class TestNormalizePageName(TestCase):
-    def test_strips_qml_extension(self):
-        self.assertEqual(GUIInterface._normalize_page_name("Foo.qml"), "Foo")
+class TestShowTemplates(TestCase):
+    """Each show_* helper names exactly one SYSTEM_* template and emits the
+    gui.value.set + gui.page.show pair (OVOS-GUI-1 §3, §4)."""
 
-    def test_passes_through_non_qml(self):
-        self.assertEqual(GUIInterface._normalize_page_name("Foo"), "Foo")
-
-    def test_raises_on_existing_filepath(self):
-        with patch("ovos_bus_client.apis.gui.isfile", return_value=True):
-            with self.assertRaises(ValueError):
-                GUIInterface._normalize_page_name("/tmp/foo.qml")
-
-
-class TestShowPages(TestCase):
     def setUp(self):
         self.bus = MagicMock()
         self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
 
-    def test_show_page_basic(self):
-        self.gui.show_page("Weather")
-        types = _emitted_types(self.bus)
-        self.assertIn("gui.value.set", types)
-        self.assertIn("gui.page.show", types)
-        self.assertEqual(self.gui._pages, ["Weather"])
+    def _assert_template(self, template):
+        self.assertEqual(_types(self.bus), ["gui.value.set", "gui.page.show"])
+        self.assertEqual(self.gui._pages, [template])
+        self.assertEqual(self.gui.page, template)
+        show = _first(self.bus, "gui.page.show")
+        self.assertEqual(show.data["page_names"], [template])
+        self.assertEqual(show.data["__from"], "t.skill")
 
-    def test_show_page_with_overrides(self):
-        self.gui.show_page("Weather", override_idle=30, override_animations=True)
-        emitted = [c.args[0] for c in self.bus.emit.call_args_list
-                   if c.args[0].msg_type == "gui.page.show"][0]
-        self.assertEqual(emitted.data["__idle"], 30)
-        self.assertTrue(emitted.data["__animations"])
+    def test_show_text(self):
+        self.gui.show_text("hello", title="T")
+        self._assert_template(PageTemplates.TEXT)
+        vs = _first(self.bus, "gui.value.set")
+        self.assertEqual(vs.data["text"], "hello")
+        self.assertEqual(vs.data["title"], "T")
 
-    def test_show_pages_list(self):
-        self.gui.show_pages(["A", "B"])
-        self.assertEqual(self.gui._pages, ["A", "B"])
+    def test_show_image(self):
+        self.gui.show_image("http://x/i.png", caption="c")
+        self._assert_template(PageTemplates.IMAGE)
 
-    def test_show_pages_string_treated_as_list(self):
-        self.gui.show_pages("OnlyOne")
-        self.assertEqual(self.gui._pages, ["OnlyOne"])
+    def test_show_animated_image(self):
+        self.gui.show_animated_image("http://x/a.gif")
+        self._assert_template(PageTemplates.ANIMATED_IMAGE)
 
-    def test_show_pages_invalid_type_raises(self):
-        with self.assertRaises(ValueError):
-            self.gui.show_pages(42)
+    def test_show_html(self):
+        self.gui.show_html("<p>x</p>")
+        self._assert_template(PageTemplates.HTML)
 
-    def test_show_pages_strips_qml(self):
-        self.gui.show_pages(["Foo.qml", "Bar.qml"])
-        self.assertEqual(self.gui._pages, ["Foo", "Bar"])
+    def test_show_url(self):
+        self.gui.show_url("http://x")
+        self._assert_template(PageTemplates.URL)
 
-    def test_show_pages_index_clamped(self):
-        self.gui.show_pages(["A"], index=10)
-        # current_page_idx clamped to len-1
-        self.assertEqual(self.gui.current_page_idx, 0)
+    def test_show_face(self):
+        self.gui.show_face()
+        self._assert_template(PageTemplates.FACE)
+
+    def test_show_loading_animation(self):
+        self.gui.show_loading_animation("loading")
+        self._assert_template(PageTemplates.LOADING)
+
+    def test_show_status_animation(self):
+        self.gui.show_status_animation("done", success=True)
+        self._assert_template(PageTemplates.STATUS)
+
+    def test_overrides_passed_through(self):
+        self.gui.show_text("hi", override_idle=30, override_animations=True)
+        show = _first(self.bus, "gui.page.show")
+        self.assertEqual(show.data["__idle"], 30)
+        self.assertTrue(show.data["__animations"])
+
+
+class TestTemplateData(TestCase):
+    """Each show_* helper supplies its template's normative session-data keys
+    on gui.value.set (OVOS-GUI-1 §3.3)."""
+
+    def setUp(self):
+        self.bus = MagicMock()
+        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
+
+    def _value_data(self):
+        return _first(self.bus, "gui.value.set").data
+
+    def test_image_data(self):
+        self.gui.show_image("http://x/i.png", caption="c", title="T")
+        d = self._value_data()
+        self.assertEqual(d["image"], "http://x/i.png")
+        self.assertEqual(d["caption"], "c")
+        self.assertEqual(d["title"], "T")
+
+    def test_html_data(self):
+        self.gui.show_html("<p>h</p>", resource_url="http://r")
+        d = self._value_data()
+        self.assertEqual(d["html"], "<p>h</p>")
+        self.assertEqual(d["resourceLocation"], "http://r")
+
+    def test_url_data(self):
+        self.gui.show_url("http://u")
+        self.assertEqual(self._value_data()["url"], "http://u")
+
+    def test_status_data(self):
+        self.gui.show_status_animation("s", success=False)
+        d = self._value_data()
+        self.assertEqual(d["label"], "s")
+        self.assertIn("status", d)
+
+    def test_loading_data(self):
+        self.gui.show_loading_animation("L")
+        self.assertEqual(self._value_data()["label"], "L")
+
+
+class TestGuiDisabled(TestCase):
+    def test_disabled_suppresses_emissions(self):
+        with patch("ovos_bus_client.apis.gui.Configuration",
+                   return_value={"gui": {"disable_gui": True}}):
+            bus = MagicMock()
+            gui = GUIInterface(skill_id="t.skill", bus=bus)
+            self.assertTrue(gui.gui_disabled)
+            gui.show_text("x")
+            self.assertEqual(_types(bus), [])
+
+
+class TestPrivatePageHelpers(TestCase):
+    """The private template-page primitives the public show_* methods build on."""
+
+    def setUp(self):
+        self.bus = MagicMock()
+        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
+
+    def test_show_pages_multiple_sets_index(self):
+        self.gui._show_pages([PageTemplates.TEXT, PageTemplates.IMAGE], index=1)
+        self.assertEqual(self.gui._pages,
+                         [PageTemplates.TEXT, PageTemplates.IMAGE])
+        self.assertEqual(self.gui.current_page_idx, 1)
+        self.assertIn("gui.page.show", _types(self.bus))
+
+    def test_show_page_single(self):
+        self.gui._show_page(PageTemplates.STATUS)
+        self.assertEqual(self.gui._pages, [PageTemplates.STATUS])
+
+    def test_remove_pages_emits_delete(self):
+        self.gui.show_text("x")
+        self.bus.reset_mock()
+        self.gui._remove_pages([PageTemplates.TEXT])
+        self.assertIn("gui.page.delete", _types(self.bus))
+
+    def test_remove_page_emits_delete(self):
+        self.gui.show_text("x")
+        self.bus.reset_mock()
+        self.gui._remove_page(PageTemplates.TEXT)
+        self.assertIn("gui.page.delete", _types(self.bus))
+
+    def test_remove_all_pages_emits_delete_all(self):
+        self.gui.show_text("x")
+        self.bus.reset_mock()
+        self.gui._remove_all_pages()
+        self.assertIn("gui.page.delete.all", _types(self.bus))
+
+    def test_sync_data_emits_value_set(self):
+        self.gui.show_text("x")
+        self.bus.reset_mock()
+        self.gui._sync_data()
+        self.assertIn("gui.value.set", _types(self.bus))
 
     def test_show_pages_without_bus_raises(self):
         gui = GUIInterface(skill_id="t.skill")
         with self.assertRaises(RuntimeError):
-            gui.show_pages(["X"])
+            gui._show_pages([PageTemplates.TEXT])
 
 
-class TestRemovePages(TestCase):
+class TestGuiSetAndDict(TestCase):
     def setUp(self):
         self.bus = MagicMock()
         self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
 
-    def test_remove_page(self):
-        self.gui.remove_page("Weather")
-        emitted = _last(self.bus)
-        self.assertEqual(emitted.msg_type, "gui.page.delete")
-        self.assertEqual(emitted.data["page_names"], ["Weather"])
-
-    def test_remove_pages_list(self):
-        self.gui.remove_pages(["A", "B"])
-        self.assertEqual(_last(self.bus).data["page_names"], ["A", "B"])
-
-    def test_remove_pages_invalid_raises(self):
-        with self.assertRaises(ValueError):
-            self.gui.remove_pages(42)
-
-    def test_remove_pages_strips_qml(self):
-        self.gui.remove_pages(["Foo.qml"])
-        self.assertEqual(_last(self.bus).data["page_names"], ["Foo"])
-
-    def test_remove_all_pages(self):
-        self.gui.remove_all_pages()
-        emitted = _last(self.bus)
-        self.assertEqual(emitted.msg_type, "gui.page.delete.all")
-
-    def test_remove_all_pages_with_keep_list(self):
-        self.gui.remove_all_pages(except_pages=["A"])
-        self.assertEqual(_last(self.bus).data["except"], ["A"])
-
-
-class TestShowNotificationVariants(TestCase):
-    def setUp(self):
-        self.bus = MagicMock()
-        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
-
-    def test_show_notification(self):
-        self.gui.show_notification("hello")
-        emitted = _last(self.bus)
-        self.assertEqual(emitted.msg_type, "ovos.notification.api.set")
-        self.assertEqual(emitted.data["text"], "hello")
-        self.assertEqual(emitted.data["sender"], "t.skill")
-        self.assertEqual(emitted.data["duration"], 10)
-
-    def test_show_notification_with_action(self):
-        self.gui.show_notification("hi", action="my.event",
-                                   callback_data={"x": 1})
-        emitted = _last(self.bus)
-        self.assertEqual(emitted.data["action"], "my.event")
-        self.assertEqual(emitted.data["callback_data"], {"x": 1})
-
-    def test_show_controlled_notification(self):
-        self.gui.show_controlled_notification("hi", style="warning")
-        emitted = _last(self.bus)
-        self.assertEqual(emitted.msg_type, "ovos.notification.api.set.controlled")
-        self.assertEqual(emitted.data["style"], "warning")
-
-    def test_remove_controlled_notification(self):
-        self.gui.remove_controlled_notification()
-        self.assertEqual(_last(self.bus).msg_type, "ovos.notification.api.remove.controlled")
-
-
-class TestShowTemplates(TestCase):
-    def setUp(self):
-        self.bus = MagicMock()
-        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
-
-    def test_show_text(self):
-        self.gui.show_text("hello", title="greeting")
-        self.assertEqual(self.gui["text"], "hello")
-        self.assertEqual(self.gui["title"], "greeting")
-        self.assertEqual(self.gui._pages, ["SYSTEM_TextFrame"])
-
-    def test_show_face_awake(self):
-        self.gui.show_face(awake=True)
-        self.assertFalse(self.gui["sleeping"])
-        self.assertEqual(self.gui._pages, ["SYSTEM_Face"])
-
-    def test_show_face_asleep(self):
-        self.gui.show_face(awake=False)
-        self.assertTrue(self.gui["sleeping"])
-
-    def test_show_loading_animation(self):
-        self.gui.show_loading_animation("loading...")
-        self.assertEqual(self.gui["label"], "loading...")
-        self.assertEqual(self.gui._pages, ["SYSTEM_Loading"])
-
-    def test_show_status_animation_success(self):
-        self.gui.show_status_animation("done", success=True)
-        self.assertEqual(self.gui["status"], "Enabled")
-        self.assertEqual(self.gui._pages, ["SYSTEM_Status"])
-
-    def test_show_status_animation_failure(self):
-        self.gui.show_status_animation("failed", success=False)
-        self.assertEqual(self.gui["status"], "Disabled")
-
-    def test_show_html(self):
-        self.gui.show_html("<h1>hi</h1>")
-        self.assertEqual(self.gui["html"], "<h1>hi</h1>")
-        self.assertEqual(self.gui._pages, ["SYSTEM_HtmlFrame"])
-
-    def test_show_url(self):
-        self.gui.show_url("https://example.com")
-        self.assertEqual(self.gui["url"], "https://example.com")
-        self.assertEqual(self.gui._pages, ["SYSTEM_UrlFrame"])
-
-    def test_show_input_box_defaults(self):
-        self.gui.show_input_box()
-        self.assertEqual(self.gui["confirm_text"], "Confirm")
-        self.assertEqual(self.gui["exit_text"], "Exit")
-
-    def test_show_input_box_custom(self):
-        self.gui.show_input_box(title="Q", placeholder="...",
-                                confirm_text="OK", exit_text="Cancel")
-        self.assertEqual(self.gui["confirm_text"], "OK")
-        self.assertEqual(self.gui["exit_text"], "Cancel")
-
-    def test_remove_input_box_single_page_releases(self):
-        # one page → release path
-        self.gui._pages = ["SYSTEM_InputBox"]
-        self.gui.remove_input_box()
-        # release emits gui.clear.namespace and mycroft.gui.screen.close
-        types = _emitted_types(self.bus)
-        self.assertIn("mycroft.gui.screen.close", types)
-
-    def test_remove_input_box_multi_page_removes_only_input(self):
-        self.gui._pages = ["A", "SYSTEM_InputBox"]
-        self.gui.remove_input_box()
-        types = _emitted_types(self.bus)
-        self.assertIn("gui.page.delete", types)
-
-
-class TestShowImage(TestCase):
-    def setUp(self):
-        self.bus = MagicMock()
-        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
-
-    def test_show_image_http(self):
-        self.gui.show_image("https://x/y.png", caption="cap", title="ttl")
-        self.assertEqual(self.gui["image"], "https://x/y.png")
-        self.assertEqual(self.gui["caption"], "cap")
-        self.assertEqual(self.gui._pages, ["SYSTEM_ImageFrame"])
-
-    def test_show_image_missing_file_logs_and_returns(self):
-        # non-http, non-existent file → logs error and returns early
-        self.gui.show_image("/no/such/file.png")
-        self.assertNotEqual(self.gui._pages, ["SYSTEM_ImageFrame"])
-
-    def test_show_animated_image_http(self):
-        self.gui.show_animated_image("https://x/y.gif")
-        self.assertEqual(self.gui["image"], "https://x/y.gif")
-        self.assertEqual(self.gui._pages, ["SYSTEM_AnimatedImageFrame"])
-
-
-class TestReleaseAndShutdown(TestCase):
-    def setUp(self):
-        self.bus = MagicMock()
-        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
-
-    def test_release_clears_and_emits_close(self):
-        self.gui["k"] = "v"
-        self.gui.release()
-        types = _emitted_types(self.bus)
-        self.assertIn("gui.clear.namespace", types)
-        self.assertIn("mycroft.gui.screen.close", types)
-
-    def test_shutdown_removes_handlers(self):
-        cb = MagicMock()
-        self.gui.register_handler("clicked", cb)
-        self.gui.shutdown()
-        # bus.remove should have been called at least for the registered handler
-        self.assertTrue(self.bus.remove.called)
-
-
-class TestGUISet(TestCase):
-    def setUp(self):
-        self.bus = MagicMock()
-        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
-
-    def test_gui_set_writes_each_key_into_session_data(self):
-        msg = Message("t.skill.set", {"temp": 22, "city": "Lisbon"})
-        self.gui.gui_set(msg)
+    def test_gui_set_stores_data_and_fires_callback(self):
+        from ovos_bus_client.message import Message
+        fired = []
+        self.gui.set_on_gui_changed(lambda: fired.append(True))
+        self.gui.gui_set(Message("t.skill.set", {"temp": 22, "unit": "C"}))
         self.assertEqual(self.gui["temp"], 22)
-        self.assertEqual(self.gui["city"], "Lisbon")
+        self.assertEqual(self.gui["unit"], "C")
+        self.assertTrue(fired)
 
-    def test_gui_set_invokes_callback(self):
-        called = []
-        self.gui.set_on_gui_changed(lambda: called.append(True))
-        self.gui.gui_set(Message("set", {"k": 1}))
-        self.assertEqual(called, [True])
+    def test_dict_value_is_wrapped(self):
+        self.gui["outer"] = {"inner": 1}
+        self.assertIsInstance(self.gui["outer"], _GUIDict)
+
+    def test_page_property_reflects_current_index(self):
+        self.gui._pages = [PageTemplates.TEXT, PageTemplates.IMAGE]
+        self.gui.current_page_idx = 1
+        self.assertEqual(self.gui.page, PageTemplates.IMAGE)
+
+    def test_page_property_none_when_index_out_of_range(self):
+        self.gui._pages = [PageTemplates.TEXT]
+        self.gui.current_page_idx = 9
+        self.assertIsNone(self.gui.page)
+
+
+class TestShutdown(TestCase):
+    def test_shutdown_no_error(self):
+        bus = MagicMock()
+        gui = GUIInterface(skill_id="t.skill", bus=bus)
+        gui.show_text("hi")
+        gui.shutdown()  # must not raise
+
+    def test_release_emits_and_clears(self):
+        bus = MagicMock()
+        gui = GUIInterface(skill_id="t.skill", bus=bus)
+        gui.show_text("hi")
+        gui.release()
+        self.assertEqual(gui.pages, [])
 
 
 if __name__ == "__main__":
+    import unittest
     unittest.main()

--- a/test/unittests/test_misc_coverage.py
+++ b/test/unittests/test_misc_coverage.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.apis.enclosure import EnclosureAPI
 from ovos_bus_client.apis.events import EventSchedulerInterface
-from ovos_bus_client.apis.gui import GUIInterface
+from ovos_bus_client.apis.gui import GUIInterface, PageTemplates
 from ovos_bus_client.message import Message
 
 
@@ -49,38 +49,6 @@ class TestGUICacheAndUrl(TestCase):
     def setUp(self):
         self.bus = MagicMock()
 
-    def test_gui_with_no_ui_directories(self):
-        # exercises _cache_gui_files early-return branch
-        gui = GUIInterface(skill_id="t.skill", bus=self.bus,
-                           ui_directories=None)
-        self.assertEqual(gui.ui_directories, {})
-
-    def test_gui_with_ui_directories(self):
-        tmp = tempfile.mkdtemp()
-        try:
-            qml_dir = os.path.join(tmp, "qt5")
-            os.makedirs(qml_dir)
-            with open(os.path.join(qml_dir, "Foo.qml"), "w") as f:
-                f.write("// Foo")
-            gui = GUIInterface(skill_id="cache.test", bus=self.bus,
-                               ui_directories={"qt5": qml_dir})
-            # cache succeeded; ui_directories preserved
-            self.assertIn("qt5", gui.ui_directories)
-        finally:
-            shutil.rmtree(tmp, ignore_errors=True)
-
-    def test_resolve_url_http(self):
-        gui = GUIInterface(skill_id="t.skill", bus=self.bus)
-        self.assertEqual(gui._resolve_url("https://example.com/img.png"),
-                         "https://example.com/img.png")
-
-    def test_resolve_url_invalid_raises(self):
-        gui = GUIInterface(skill_id="t.skill", bus=self.bus)
-        with self.assertRaises(ValueError):
-            gui._resolve_url(None)
-        with self.assertRaises(ValueError):
-            gui._resolve_url("")
-
     def test_pages_property_with_value(self):
         gui = GUIInterface(skill_id="t.skill", bus=self.bus)
         gui._pages = ["A", "B"]
@@ -100,12 +68,6 @@ class TestGUINotificationsAndExtras(TestCase):
         self.bus = MagicMock()
         self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
 
-    def test_show_notification_no_bus_raises(self):
-        # detach bus by recreating
-        gui = GUIInterface(skill_id="t.skill")
-        with self.assertRaises(RuntimeError):
-            gui.show_notification("hi")
-
     def test_clear_without_bus_raises(self):
         gui = GUIInterface(skill_id="t.skill")
         # avoid the gui_disabled early-return by inspecting current state
@@ -123,12 +85,12 @@ class TestClientMissingBusBranches(TestCase):
     def test_remove_all_pages_no_bus_raises(self):
         gui = GUIInterface(skill_id="t.skill")
         with self.assertRaises(RuntimeError):
-            gui.remove_all_pages()
+            gui._remove_all_pages()
 
     def test_remove_pages_no_bus_raises(self):
         gui = GUIInterface(skill_id="t.skill")
         with self.assertRaises(RuntimeError):
-            gui.remove_pages(["A"])
+            gui._remove_pages([PageTemplates.TEXT])
 
 
 class TestRemainingOCPMethods(TestCase):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * EnclosureAPI marked for deprecation; functionality transitioning to platform-specific plugins with visual output managed through the updated UI framework.

* **Breaking Changes**
  * GUI interface initialization refactored with parameter removal and method visibility adjustments.

* **New Features**
  * Standardized template identifiers introduced for GUI pages, replacing string-based references with enumerated constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->