### PR TITLE
feat: AsyncMessageBusClient (async/await native client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,38 @@ client.on('speak', on_speak)
 client.run_forever()
 ```
 
+### Async alternative
+
+For asyncio-native code, install the optional `[async]` extra and use
+`AsyncMessageBusClient`:
+
+```bash
+pip install ovos-bus-client[async]
+```
+
+```python
+import asyncio
+from ovos_bus_client import Message
+from ovos_bus_client.client import AsyncMessageBusClient
+
+async def main():
+    bus = AsyncMessageBusClient()
+    await bus.connect()
+    bus.on("speak", lambda m: print("OVOS said:", m.data.get("utterance")))
+
+    await bus.emit(Message("speak", {"utterance": "hello from asyncio"}))
+    reply = await bus.wait_for_response(
+        Message("ovos.languages.stt"), timeout=3.0,
+    )
+    await bus.close()
+
+asyncio.run(main())
+```
+
+Both clients share the same `Message`, `Session`, and event-emitter shape;
+pick whichever matches the rest of your application. See
+[`docs/async_client.md`](docs/async_client.md) for the full async reference.
+
 ## CLI tools
 
 | Command | Description |
@@ -76,6 +108,7 @@ Full developer docs live in [`docs/`](docs/):
 - [Core concepts](docs/concepts.md) — bus model and the security boundary
 - [Messages](docs/messages.md) — `Message`, `GUIMessage`, reply helpers
 - [The client](docs/client.md) — `MessageBusClient` API in depth
+- [The async client](docs/async_client.md) — `AsyncMessageBusClient` (`pip install ovos-bus-client[async]`)
 - [Configuration](docs/configuration.md) — host, port, route, ssl
 - [Sessions](docs/session.md) — `Session`, `SessionManager`, `IntentContextManager`
 - [Waiters and collectors](docs/waiter_and_collector.md) — request/response and multi-reply patterns

--- a/benchmarks/bench_async_vs_sync.py
+++ b/benchmarks/bench_async_vs_sync.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+Benchmark: sync MessageBusClient vs async AsyncMessageBusClient.
+
+This benchmark uses in-process fake buses (no real WebSocket server)
+so it measures pure Python overhead: serialization, event-emitter dispatch,
+session injection, and waiter/collector coordination.
+
+Usage:
+    uv run python benchmarks/bench_async_vs_sync.py
+    uv run python benchmarks/bench_async_vs_sync.py --n 5000
+"""
+
+import argparse
+import asyncio
+import json
+import statistics
+import time
+from contextlib import contextmanager
+from typing import List
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers for constructing pre-connected buses
+# ---------------------------------------------------------------------------
+
+def _cfg_patch():
+    """Context manager that stubs out config loading."""
+    mock_cfg = MagicMock()
+    mock_cfg.host = "localhost"
+    mock_cfg.port = 8181
+    mock_cfg.route = "/core"
+    mock_cfg.ssl = False
+    return patch("ovos_bus_client.client.async_client.load_message_bus_config",
+                 return_value=mock_cfg)
+
+
+def _sync_cfg_patch():
+    mock_cfg = MagicMock()
+    mock_cfg.host = "localhost"
+    mock_cfg.port = 8181
+    mock_cfg.route = "/core"
+    mock_cfg.ssl = False
+    return patch("ovos_bus_client.client.client.load_message_bus_config",
+                 return_value=mock_cfg)
+
+
+def make_sync_bus():
+    """Return a MessageBusClient with a mocked websocket, pre-connected."""
+    from ovos_bus_client.client.client import MessageBusClient
+    from unittest.mock import MagicMock
+
+    with _sync_cfg_patch():
+        bus = MessageBusClient()
+
+    ws_mock = MagicMock()
+    ws_mock.send = MagicMock()
+    bus.client = ws_mock
+    bus.connected_event.set()
+    bus.started_running = True
+    return bus
+
+
+def make_async_bus():
+    """Return an AsyncMessageBusClient with a mocked websocket, pre-connected."""
+    from ovos_bus_client.client.async_client import AsyncMessageBusClient
+    from unittest.mock import AsyncMock
+
+    with _cfg_patch():
+        bus = AsyncMessageBusClient()
+
+    ws_mock = AsyncMock()
+    ws_mock.send = AsyncMock()
+    bus._ws = ws_mock
+    bus._connected.set()
+    return bus
+
+
+# ---------------------------------------------------------------------------
+# Timing helpers
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def timer(label: str):
+    t0 = time.perf_counter()
+    yield
+    elapsed = time.perf_counter() - t0
+    print(f"  {label}: {elapsed * 1000:.2f} ms")
+    return elapsed
+
+
+def _timeit(fn, n: int) -> List[float]:
+    """Run fn() n times, return list of per-call times (seconds)."""
+    times = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+async def _atimeit(afn, n: int) -> List[float]:
+    times = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        await afn()
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+def _stats(times: List[float], label: str):
+    ms = [t * 1000 for t in times]
+    print(f"  {label}: "
+          f"min={min(ms):.3f}ms  "
+          f"mean={statistics.mean(ms):.3f}ms  "
+          f"median={statistics.median(ms):.3f}ms  "
+          f"max={max(ms):.3f}ms  "
+          f"stdev={statistics.stdev(ms):.3f}ms")
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 1 — emit() throughput
+# ---------------------------------------------------------------------------
+
+def bench_sync_emit(n: int):
+    from ovos_bus_client.message import Message
+    bus = make_sync_bus()
+    msg = Message("benchmark.emit", {"payload": "x" * 128})
+
+    def do():
+        bus.emit(msg)
+
+    times = _timeit(do, n)
+    _stats(times, f"sync  emit ×{n}")
+    return statistics.mean(times)
+
+
+async def bench_async_emit(n: int):
+    from ovos_bus_client.message import Message
+    bus = make_async_bus()
+    msg = Message("benchmark.emit", {"payload": "x" * 128})
+
+    async def do():
+        await bus.emit(msg)
+
+    times = await _atimeit(do, n)
+    _stats(times, f"async emit ×{n}")
+    return statistics.mean(times)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 2 — wait_for_message  (loopback via emitter)
+# ---------------------------------------------------------------------------
+
+def bench_sync_wait_for_message(n: int):
+    """Sync wait_for_message with immediate reply injected in a thread."""
+    import threading
+    from ovos_bus_client.message import Message
+    from ovos_bus_client.client.waiter import MessageWaiter
+
+    bus = make_sync_bus()
+
+    def do():
+        waiter = MessageWaiter(bus, "bench.reply")
+        msg = Message("bench.reply")
+        bus.emitter.emit("bench.reply", msg)
+        return waiter.wait(timeout=1.0)
+
+    times = _timeit(do, n)
+    _stats(times, f"sync  wait_for_message ×{n}")
+    return statistics.mean(times)
+
+
+async def bench_async_wait_for_message(n: int):
+    from ovos_bus_client.message import Message
+    from ovos_bus_client.client.async_client import AsyncMessageWaiter
+    bus = make_async_bus()
+
+    async def do():
+        waiter = AsyncMessageWaiter(bus, "bench.reply")
+        msg = Message("bench.reply")
+        bus.emitter.emit("bench.reply", msg)
+        return await waiter.wait(timeout=1.0)
+
+    times = await _atimeit(do, n)
+    _stats(times, f"async wait_for_message ×{n}")
+    return statistics.mean(times)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 3 — Message serialization (shared; baseline for both clients)
+# ---------------------------------------------------------------------------
+
+def bench_message_serialization(n: int):
+    from ovos_bus_client.message import Message
+    msg = Message("bench.serialize", {"data": "x" * 256,
+                                       "nested": {"a": 1, "b": [1, 2, 3]}})
+
+    def do():
+        raw = msg.serialize()
+        Message.deserialize(raw)
+
+    times = _timeit(do, n)
+    _stats(times, f"msg serialize+deserialize ×{n}")
+    return statistics.mean(times)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 4 — concurrent async emit (fan-out)
+# ---------------------------------------------------------------------------
+
+async def bench_async_concurrent_emit(n: int, concurrency: int = 100):
+    """Emit `concurrency` messages concurrently, measure wall-clock time."""
+    from ovos_bus_client.message import Message
+    bus = make_async_bus()
+    messages = [Message(f"bench.concurrent.{i}", {"i": i}) for i in range(concurrency)]
+
+    async def run_all():
+        await asyncio.gather(*[bus.emit(m) for m in messages])
+
+    times = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        await run_all()
+        times.append(time.perf_counter() - t0)
+
+    _stats(times, f"async concurrent emit ×{concurrency} (×{n} rounds)")
+    total_msgs = n * concurrency
+    total_s = sum(times)
+    print(f"  => throughput: {total_msgs / total_s:.0f} msg/s")
+    return statistics.mean(times)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Sync vs Async bus client benchmark")
+    parser.add_argument("--n", type=int, default=2000,
+                        help="Number of iterations for each benchmark (default: 2000)")
+    parser.add_argument("--concurrency", type=int, default=200,
+                        help="Fan-out size for concurrent-emit benchmark (default: 200)")
+    args = parser.parse_args()
+
+    n = args.n
+    print(f"\n{'=' * 60}")
+    print(f"  ovos-bus-client  sync vs async  (n={n})")
+    print(f"{'=' * 60}\n")
+
+    print("── 1. emit() ──────────────────────────────────────────────")
+    sync_emit_mean = bench_sync_emit(n)
+    async_emit_mean = asyncio.run(bench_async_emit(n))
+    ratio = async_emit_mean / sync_emit_mean if sync_emit_mean else float("inf")
+    print(f"  ratio async/sync: {ratio:.2f}x\n")
+
+    print("── 2. wait_for_message() ───────────────────────────────────")
+    sync_wfm = bench_sync_wait_for_message(n)
+    async_wfm = asyncio.run(bench_async_wait_for_message(n))
+    ratio = async_wfm / sync_wfm if sync_wfm else float("inf")
+    print(f"  ratio async/sync: {ratio:.2f}x\n")
+
+    print("── 3. Message serialization (baseline) ─────────────────────")
+    bench_message_serialization(n)
+    print()
+
+    print("── 4. Concurrent async emit (fan-out) ──────────────────────")
+    asyncio.run(bench_async_concurrent_emit(n=max(n // 10, 10),
+                                             concurrency=args.concurrency))
+    print()
+
+    print(f"{'=' * 60}")
+    print("  Done.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_async_vs_sync_ws.py
+++ b/benchmarks/bench_async_vs_sync_ws.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Benchmark sync vs async clients against a **real** WebSocket server.
+
+The in-process benchmark (`bench_async_vs_sync.py`) measures library overhead
+only — it stubs out the transport. This file spins up a localhost WebSocket
+echo server (on a free port) and exercises both clients end-to-end so the
+numbers include socket setup, JSON over the wire, and event-loop / thread
+scheduling.
+
+Both runs hit the same loopback socket, so this is not "real network" — it
+is "real transport, no network." Add latency separately if you care about
+remote scenarios.
+
+Usage:
+    python benchmarks/bench_async_vs_sync_ws.py
+    python benchmarks/bench_async_vs_sync_ws.py --n 500
+"""
+import argparse
+import asyncio
+import json
+import socket
+import statistics
+import threading
+import time
+
+import websockets
+
+from ovos_bus_client import Message, MessageBusClient
+from ovos_bus_client.client.async_client import AsyncMessageBusClient
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Echo server: receive a Message, send <type>.response back with the data.
+# Runs on its own thread + asyncio loop so both sync and async clients can
+# talk to it without interfering with each other's event loops.
+# ---------------------------------------------------------------------------
+
+class _EchoServer:
+    """Localhost WebSocket server that responds to every Message with
+    <msg_type>.response (the convention used by wait_for_response)."""
+
+    def __init__(self, port: int):
+        self.port = port
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._stop_event: asyncio.Event | None = None
+        self._ready = threading.Event()
+
+    async def _handle(self, ws):
+        try:
+            async for raw in ws:
+                try:
+                    obj = json.loads(raw)
+                    msg_type = obj.get("type", "unknown")
+                    data = obj.get("data", {})
+                    reply = json.dumps({
+                        "type": f"{msg_type}.response",
+                        "data": data,
+                        "context": obj.get("context", {}),
+                    })
+                    await ws.send(reply)
+                except Exception:
+                    pass
+        except websockets.ConnectionClosed:
+            pass
+
+    async def _serve(self):
+        async with websockets.serve(self._handle, "127.0.0.1", self.port):
+            self._stop_event = asyncio.Event()
+            self._ready.set()
+            await self._stop_event.wait()
+
+    def start(self):
+        def _run():
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+            self._loop.run_until_complete(self._serve())
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+        self._ready.wait(timeout=5)
+
+    def stop(self):
+        if self._stop_event and self._loop:
+            self._loop.call_soon_threadsafe(self._stop_event.set)
+        if self._thread:
+            self._thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _stats(times: list[float], label: str):
+    times_ms = [t * 1000 for t in times]
+    print(f"  {label:48s} "
+          f"min={min(times_ms):.2f}ms  "
+          f"mean={statistics.mean(times_ms):.2f}ms  "
+          f"median={statistics.median(times_ms):.2f}ms  "
+          f"p95={sorted(times_ms)[int(len(times_ms) * 0.95)]:.2f}ms  "
+          f"max={max(times_ms):.2f}ms")
+    return statistics.mean(times)
+
+
+# ---------------------------------------------------------------------------
+# Sync client benchmark
+# ---------------------------------------------------------------------------
+
+def bench_sync(port: int, n: int):
+    bus = MessageBusClient(host="127.0.0.1", port=port, route="/")
+    bus.run_in_thread()
+    bus.connected_event.wait(timeout=5)
+
+    # 1. fire-and-forget emit
+    times_emit = []
+    for i in range(n):
+        t0 = time.perf_counter()
+        bus.emit(Message(f"bench.emit.{i}", {"i": i}))
+        times_emit.append(time.perf_counter() - t0)
+    _stats(times_emit, f"sync emit ×{n}")
+
+    # 2. round-trip via wait_for_response
+    times_rt = []
+    for i in range(n):
+        t0 = time.perf_counter()
+        bus.wait_for_response(Message(f"bench.rt.{i}", {"i": i}), timeout=2.0)
+        times_rt.append(time.perf_counter() - t0)
+    _stats(times_rt, f"sync round-trip (wait_for_response) ×{n}")
+
+    bus.close()
+
+
+# ---------------------------------------------------------------------------
+# Async client benchmark
+# ---------------------------------------------------------------------------
+
+async def bench_async(port: int, n: int):
+    bus = AsyncMessageBusClient(host="127.0.0.1", port=port, route="/")
+    await bus.connect()
+
+    # 1. fire-and-forget emit
+    times_emit = []
+    for i in range(n):
+        t0 = time.perf_counter()
+        await bus.emit(Message(f"bench.emit.{i}", {"i": i}))
+        times_emit.append(time.perf_counter() - t0)
+    _stats(times_emit, f"async emit ×{n}")
+
+    # 2. round-trip via wait_for_response
+    times_rt = []
+    for i in range(n):
+        t0 = time.perf_counter()
+        await bus.wait_for_response(Message(f"bench.rt.{i}", {"i": i}), timeout=2.0)
+        times_rt.append(time.perf_counter() - t0)
+    _stats(times_rt, f"async round-trip (wait_for_response) ×{n}")
+
+    # 3. concurrent fan-out — the place async should pull ahead
+    queries = [Message(f"bench.fan.{i}", {"i": i}) for i in range(n)]
+    t0 = time.perf_counter()
+    await asyncio.gather(*[bus.wait_for_response(q, timeout=5.0) for q in queries])
+    fan_total = time.perf_counter() - t0
+    print(f"  async fan-out × {n:<5}                              "
+          f"total={fan_total * 1000:.0f}ms  throughput={n / fan_total:.0f} req/s")
+
+    await bus.close()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n", type=int, default=1000,
+                        help="Number of iterations per case (default 1000)")
+    args = parser.parse_args()
+
+    port = _free_port()
+    server = _EchoServer(port)
+    server.start()
+    print(f"\nWebSocket echo server: ws://127.0.0.1:{port}/\n")
+
+    try:
+        print("=" * 70)
+        print(f"  Real-transport benchmark  (n={args.n}, port={port})")
+        print("=" * 70 + "\n")
+
+        print("── sync MessageBusClient ─────────────────────────────────────────────")
+        bench_sync(port, args.n)
+        print()
+
+        print("── async AsyncMessageBusClient ───────────────────────────────────────")
+        asyncio.run(bench_async(port, args.n))
+        print()
+    finally:
+        server.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ agent backends, or anything else that talks to an OVOS messagebus.
 2. [Core concepts](concepts.md) — the OVOS bus model, message anatomy, who emits what.
 3. [Messages](messages.md) — `Message`, `GUIMessage`, `reply`/`forward`/`response`, helpers.
 4. [The client](client.md) — `MessageBusClient`: connect, threading, handlers, lifecycle.
+4b. [Async client](async_client.md) — `AsyncMessageBusClient`: same shape, but `async/await`-native (optional `[async]` extra).
 5. [Configuration](configuration.md) — `load_message_bus_config`, env knobs, SSL, custom routes.
 6. [Sessions](session.md) — `Session`, `SessionManager`, `IntentContextManager`.
 

--- a/docs/async_client.md
+++ b/docs/async_client.md
@@ -1,0 +1,360 @@
+# AsyncMessageBusClient
+
+**Module:** `ovos_bus_client.client.async_client`
+
+`AsyncMessageBusClient` is an asyncio-native WebSocket client that provides the same interface as `MessageBusClient` but with `async/await` instead of blocking threads. It uses the [`websockets`](https://websockets.readthedocs.io/) library under the hood.
+
+> **Optional dependency** — `websockets` is not installed by default.
+> Install it with: `pip install "ovos-bus-client[async]"`
+>
+> If `websockets` is not installed the rest of the package works normally;
+> `AsyncMessageBusClient` is `None` in that case and calling `connect()`
+> raises `ImportError` with a clear message.
+
+---
+
+## When to use the async client
+
+| Situation | Recommended client |
+|---|---|
+| Stand-alone script, daemon, OVOS plugin | `MessageBusClient` (sync, thread-based) |
+| Inside an existing asyncio application | `AsyncMessageBusClient` |
+| Emitting many messages concurrently (fan-out) | `AsyncMessageBusClient` |
+| `await`-ing multiple bus replies in parallel | `AsyncMessageBusClient` |
+
+The async client is a **complement**, not a replacement. Both classes share the same `Message`, `Session`, and event-registration API.
+
+---
+
+## Installation
+
+```bash
+# async support
+pip install "ovos-bus-client[async]"
+
+# or add to pyproject.toml
+dependencies = ["ovos-bus-client[async]"]
+```
+
+---
+
+## Quick Start
+
+```python
+import asyncio
+from ovos_bus_client import AsyncMessageBusClient
+from ovos_bus_client.message import Message
+
+async def main():
+    bus = AsyncMessageBusClient()
+    await bus.connect()
+
+    # Listen for events
+    bus.on("speak", lambda msg: print("OVOS said:", msg.data.get("utterance")))
+
+    # Emit a message
+    await bus.emit(Message("speak", {"utterance": "Hello world"}))
+
+    # Request / response
+    response = await bus.wait_for_response(
+        Message("intent.service.intent.get", {"utterance": "what time is it"}),
+        reply_type="intent.service.intent.reply",
+        timeout=5.0,
+    )
+    if response:
+        print(response.data)
+
+    await bus.close()
+
+asyncio.run(main())
+```
+
+---
+
+## Connection Lifecycle
+
+```python
+bus = AsyncMessageBusClient(
+    host="127.0.0.1",   # default from mycroft.conf
+    port=8181,
+    route="/core",
+    ssl=False,
+    cache=False,        # cache config object across instances
+)
+
+# Connect (starts internal receive task)
+await bus.connect()
+
+# Connect with retry disabled
+await bus.connect(retry=False)
+
+# Close
+await bus.close()
+```
+
+`connect()` starts an internal `asyncio.Task` that reads from the WebSocket indefinitely. There is no `run_forever()` or `run_in_thread()` — the receive loop runs as a cooperative coroutine inside your existing event loop.
+
+On connection, `ovos.session.sync` is automatically emitted to synchronise the default session state with `ovos-core`.
+
+### Reconnection
+
+The current implementation does **not** auto-reconnect on drop (unlike the sync client). Reconnect by catching `ConnectionClosedError` in your application and calling `await bus.connect()` again, or wrap the lifecycle in a retry loop.
+
+---
+
+## Emitting Messages
+
+```python
+await bus.emit(Message("speak", {"utterance": "Hello"}))
+```
+
+The session is automatically injected into `message.context["session"]` if not already present — identical behaviour to `MessageBusClient.emit`.
+
+`emit` raises `ValueError` (or `asyncio.TimeoutError`) if called before `connect()` is awaited.
+
+---
+
+## Listening
+
+Handler registration is **synchronous** — same API as `MessageBusClient`:
+
+```python
+# Persistent listener
+bus.on("my.event", handler)
+
+# One-shot listener
+bus.once("my.event", handler)
+
+# Remove a specific listener
+bus.remove("my.event", handler)
+
+# Remove all listeners for an event
+bus.remove_all_listeners("my.event")
+```
+
+Handlers may be plain functions or `async` coroutines — `AsyncIOEventEmitter` from `pyee` handles both.
+
+---
+
+## Waiting for a Response
+
+### `wait_for_response`
+
+Send a message and await a matching reply.
+
+```python
+response = await bus.wait_for_response(
+    Message("my.query"),
+    reply_type="my.query.response",   # default: msg_type + ".response"
+    timeout=3.0,
+)
+if response:
+    print(response.data)
+```
+
+`reply_type` accepts `str` or `List[str]`.
+
+### `wait_for_message`
+
+Await a message of a given type without sending anything first.
+
+```python
+msg = await bus.wait_for_message("mycroft.skills.initialized", timeout=30)
+```
+
+---
+
+## Collecting Responses from Multiple Handlers
+
+Used when multiple services may respond to a single request (CommonQuery, OCP search, etc.).
+
+### Sender side
+
+```python
+responses = await bus.collect_responses(
+    Message("question:query", {"phrase": "capital of France"}),
+    min_timeout=0.2,    # wait at least this long after emitting
+    max_timeout=3.0,    # give up after this long
+    direct_return_func=lambda msg: msg.data.get("conf", 0) > 0.9,
+)
+for r in responses:
+    print(r.data)
+```
+
+### Handler side
+
+Handler registration uses the same `on_collect` pattern as the sync client (register via `MessageBusClient.on_collect` — the async client does not add a separate `on_collect`; use `bus.on(event + ".handling", ...)` and `bus.on(event + ".response", ...)` directly if needed inside async code).
+
+---
+
+## Fan-out: Concurrent Emits
+
+A key advantage of the async client is the ability to fire many messages concurrently without spawning threads:
+
+```python
+import asyncio
+from ovos_bus_client import AsyncMessageBusClient
+from ovos_bus_client.message import Message
+
+async def main():
+    bus = AsyncMessageBusClient()
+    await bus.connect()
+
+    messages = [Message(f"plugin.query.{i}", {"i": i}) for i in range(100)]
+    await asyncio.gather(*[bus.emit(m) for m in messages])
+
+    await bus.close()
+```
+
+---
+
+## Connection Lifecycle Events
+
+These events are emitted on the local `AsyncIOEventEmitter` (not sent over the bus):
+
+| Event | When |
+|---|---|
+| `open` | WebSocket connection established |
+| `close` | WebSocket connection closed (normally or on error) |
+| `message` | Raw message string received |
+
+```python
+bus.on("open", lambda: print("connected"))
+bus.on("close", lambda: print("disconnected"))
+```
+
+---
+
+## API Reference
+
+### `AsyncMessageBusClient`
+
+**`ovos_bus_client.client.async_client.AsyncMessageBusClient`** — `client.py:AsyncMessageBusClient`
+
+| Method / attribute | Signature | Description |
+|---|---|---|
+| `__init__` | `(host, port, route, ssl, cache, session)` | Constructor; reads config from `mycroft.conf` |
+| `url` | property → `str` | WebSocket URL |
+| `connect` | `async (retry=True, retry_delay=5.0)` | Open connection, start receive loop |
+| `close` | `async ()` | Close connection and cancel receive task |
+| `emit` | `async (message: Message)` | Send message; injects session if absent |
+| `wait_for_message` | `async (message_type, timeout=3.0) → Message \| None` | Await a message type |
+| `wait_for_response` | `async (message, reply_type=None, timeout=3.0) → Message \| None` | Emit then await reply |
+| `collect_responses` | `async (message, min_timeout=0.2, max_timeout=3.0, direct_return_func=None) → List[Message]` | Collect multi-handler responses |
+| `on` | `(event_name, func)` | Register persistent handler |
+| `once` | `(event_name, func)` | Register one-shot handler |
+| `remove` | `(event_name, func)` | Remove handler |
+| `remove_all_listeners` | `(event_name)` | Remove all handlers for event |
+| `build_url` | `static (host, port, route, ssl) → str` | Build ws:// or wss:// URL |
+
+### `AsyncMessageWaiter`
+
+**`ovos_bus_client.client.async_client.AsyncMessageWaiter`**
+
+Encapsulates the wait-for-message logic. Usually accessed via `bus.wait_for_message` / `bus.wait_for_response`.
+
+```python
+from ovos_bus_client.client.async_client import AsyncMessageWaiter
+
+waiter = AsyncMessageWaiter(bus, ["type.a", "type.b"])
+# ... emit something ...
+msg = await waiter.wait(timeout=5.0)
+```
+
+### `AsyncMessageCollector`
+
+**`ovos_bus_client.client.async_client.AsyncMessageCollector`**
+
+Encapsulates the collect-responses logic. Usually accessed via `bus.collect_responses`.
+
+```python
+from ovos_bus_client.client.async_client import AsyncMessageCollector
+
+collector = AsyncMessageCollector(bus, message, min_timeout=0.2, max_timeout=3.0)
+responses = await collector.collect()
+```
+
+---
+
+## Benchmarks
+
+Two benchmark scripts ship under `benchmarks/`. They measure different things,
+and both numbers matter.
+
+### In-process — library overhead only
+
+`benchmarks/bench_async_vs_sync.py` stubs out the websocket transport with
+mocks. What it measures: coroutine dispatch, emitter routing, message
+serialization, waiter/collector coordination. What it does **not** measure:
+sockets, JSON over the wire, scheduler context switches between the bus
+loop and your code.
+
+Use it to spot library-level overhead regressions, not to predict real
+runtime.
+
+Python 3.11, n=2 000:
+
+| Benchmark | Sync | Async | Notes |
+|---|---|---|---|
+| `emit()` — mean | 0.017 ms | 0.042 ms | async carries coroutine-dispatch overhead |
+| `wait_for_message()` — mean | 0.023 ms | 0.018 ms | async is faster (no `threading.Event` wakeup) |
+| `Message` serialize+deserialize | 0.005 ms | 0.005 ms | shared baseline |
+| Concurrent emit ×200 fan-out | n/a | 7 ms / round (≈28 000 msg/s) | only async can do this in one process |
+
+### Real transport — loopback WebSocket echo server
+
+`benchmarks/bench_async_vs_sync_ws.py` spins up a real
+`websockets`-based echo server on a free localhost port and exercises both
+clients end-to-end. This is "real transport, no network" — add latency
+yourself if you care about remote scenarios.
+
+Python 3.11, n=500:
+
+| Benchmark | Sync | Async | Notes |
+|---|---|---|---|
+| `emit()` — mean | 0.35 ms | 0.26 ms | async is **25% faster** end-to-end |
+| `emit()` — p95 | 0.98 ms | 0.38 ms | async tail latency is much tighter |
+| Round-trip via `wait_for_response()` — mean | 0.45 ms | 0.34 ms | async is **24% faster** |
+| Round-trip — p95 | 0.61 ms | 0.42 ms | tighter tail again |
+| Concurrent `wait_for_response()` ×500 fan-out | n/a | 113 ms total (≈4 400 req/s) | async wins biggest here |
+
+### Key takeaways
+
+- **Per-call latency** is comparable between the two clients, with async
+  slightly faster on real transport because it avoids the `threading.Event`
+  wakeup path on every reply.
+- **Tail latency** is significantly tighter for async — the GIL contention
+  that occasionally spikes sync max latency is gone.
+- **Concurrent workloads are where async pulls ahead.** 500 concurrent
+  round-trips in 113 ms is something the sync client structurally cannot
+  match without spawning a thread per query.
+- **For one-shot scripts**, the sync client is fine and slightly simpler.
+  The async client is the right pick for FastAPI / aiohttp / Discord-bot
+  style applications and for anything doing many parallel queries.
+
+### Run the benchmarks yourself
+
+```bash
+# Library overhead only — fast, no transport
+python benchmarks/bench_async_vs_sync.py --n 2000 --concurrency 200
+
+# End-to-end via a real WebSocket echo server on localhost
+python benchmarks/bench_async_vs_sync_ws.py --n 500
+```
+
+---
+
+## Differences from `MessageBusClient`
+
+| Feature | `MessageBusClient` | `AsyncMessageBusClient` |
+|---|---|---|
+| WebSocket library | `websocket-client` | `websockets` |
+| I/O model | blocking threads | asyncio coroutines |
+| `emit()` | sync | `async` |
+| `wait_for_response()` | sync (blocks) | `async` |
+| `run_forever()` | required | not needed |
+| `run_in_thread()` | available | not needed |
+| Auto-reconnect | yes (exponential back-off) | not built-in |
+| GUI bus subclass | `GUIWebsocketClient` | not yet provided |
+| Event emitter | `ExecutorEventEmitter` | `AsyncIOEventEmitter` |
+| Extra dependency | none | `websockets>=10` |

--- a/docs/client.md
+++ b/docs/client.md
@@ -219,3 +219,16 @@ worked example of a subclass that overrides `emit`, `on_open`, and
 If you find yourself reaching for deeper hooks, ask whether a transport plugin
 is what you actually want — that is what `hivemind-ovos-agent-plugin` and the
 GUI client are doing structurally.
+
+## Async alternative
+
+`MessageBusClient` is synchronous. For an asyncio-native client with the same
+shape, see [`AsyncMessageBusClient`](async_client.md). It's an optional extra:
+
+```bash
+pip install ovos-bus-client[async]
+```
+
+Use it when your application is already async (FastAPI, aiohttp, Discord bots,
+etc.) and you want `await bus.emit(...)`, `await bus.wait_for_response(...)`,
+`async for msg in collector` instead of threads and blocking calls.

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -35,6 +35,16 @@ actually reaching `run_forever()` would otherwise be undone the instant
 the thread got there, and the client would reconnect right after being
 told to close.
 
+`AsyncMessageBusClient.emit()` now puts the same wire frames as
+`MessageBusClient.emit()` for the same `Message`, including the legacy
+intent-topic and namespace twins (`OVOS_BUS_EMIT_LEGACY` /
+`OVOS_BUS_WIRE_LEGACY_TWINS` still gate them the same way on both clients).
+Earlier alphas of the async client only sent the canonical frame, so a
+producer that switched onto it silently stopped emitting the V0-compat
+twins. `AsyncMessageBusClient` also gained a `connected` property matching
+`MessageBusClient`'s connection-liveness semantics, for consumers that check
+`getattr(bus, "connected", None)` against either client.
+
 ## 2.8.4a3
 
 Importing `ovos_bus_client.session` no longer emits an ovos-config

--- a/ovos_bus_client/__init__.py
+++ b/ovos_bus_client/__init__.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ovos_bus_client.client.client import MessageBusClient, GUIWebsocketClient
+try:
+    from ovos_bus_client.client.async_client import AsyncMessageBusClient
+except ImportError:
+    AsyncMessageBusClient = None  # websockets not installed
 from ovos_bus_client.message import Message, GUIMessage
 from ovos_bus_client.send_func import send
 from ovos_bus_client.session import Session, SessionManager, UtteranceState
@@ -29,6 +33,7 @@ clients connected to the bus.
 
 __all__ = [
     MessageBusClient,
+    AsyncMessageBusClient,
     GUIWebsocketClient,
     GUIMessage,
     Message,

--- a/ovos_bus_client/client/__init__.py
+++ b/ovos_bus_client/client/__init__.py
@@ -11,4 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .client import MessageBusClient, MessageWaiter, MessageCollector
+from ovos_bus_client.client.client import MessageBusClient, MessageWaiter, MessageCollector
+try:
+    from ovos_bus_client.client.async_client import AsyncMessageBusClient, AsyncMessageWaiter, AsyncMessageCollector
+except ImportError:
+    AsyncMessageBusClient = None  # websockets not installed
+    AsyncMessageWaiter = None
+    AsyncMessageCollector = None

--- a/ovos_bus_client/client/async_client.py
+++ b/ovos_bus_client/client/async_client.py
@@ -1,0 +1,446 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Async (asyncio) MessageBus client using the websockets library."""
+
+import asyncio
+from typing import Any, Callable, List, Optional, Union
+from uuid import uuid4
+
+from ovos_utils import json_dumps
+from ovos_utils.log import LOG
+
+try:
+    from pyee.asyncio import AsyncIOEventEmitter
+except ImportError:
+    from pyee import AsyncIOEventEmitter
+
+try:
+    import websockets
+    from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+except ImportError:
+    websockets = None  # type: ignore
+    ConnectionClosedError = OSError  # type: ignore
+    ConnectionClosedOK = OSError  # type: ignore
+
+from ovos_spec_tools.messages import NamespaceTranslator
+
+from ovos_bus_client.client.client import (_bus_flag,
+                                           _compute_legacy_intent_twin,
+                                           _compute_legacy_namespace_twin)
+from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf
+from ovos_bus_client.message import Message, CollectionMessage
+from ovos_bus_client.session import SessionManager, Session
+
+
+class AsyncMessageWaiter:
+    """Wait for a single message asynchronously.
+
+    Registers a one-shot handler before emitting a query, then awaits the
+    reply without blocking the event loop.
+
+    Arguments:
+        bus: AsyncMessageBusClient instance
+        message_type: message type(s) to wait for
+    """
+
+    def __init__(self, bus: "AsyncMessageBusClient",
+                 message_type: Union[str, List[str]]):
+        self.bus = bus
+        if not isinstance(message_type, list):
+            message_type = [message_type]
+        self.msg_type = message_type
+        self.received_msg: Optional[Message] = None
+        self._event = asyncio.Event()
+        for mt in self.msg_type:
+            self.bus.once(mt, self._handler)
+
+    def _handler(self, message: Message):
+        self.received_msg = message
+        self._event.set()
+
+    async def wait(self, timeout: float = 3.0) -> Optional[Message]:
+        """Await the expected message.
+
+        Arguments:
+            timeout: seconds before giving up
+
+        Returns:
+            The received Message or None on timeout.
+        """
+        try:
+            await asyncio.wait_for(self._event.wait(), timeout)
+        except asyncio.TimeoutError:
+            for mt in self.msg_type:
+                try:
+                    self.bus.remove(mt, self._handler)
+                except (ValueError, KeyError):
+                    pass
+        return self.received_msg
+
+
+class AsyncMessageCollector:
+    """Collect multiple responses to a single query asynchronously.
+
+    Mirrors the synchronous MessageCollector interface but uses asyncio
+    primitives so the event loop is never blocked.
+
+    Arguments:
+        bus: AsyncMessageBusClient instance
+        message: query message to send
+        min_timeout: minimum seconds to wait after sending
+        max_timeout: maximum seconds to wait for all handlers
+        direct_return_func: optional callable; if it returns True for a
+            response the collection ends immediately
+    """
+
+    def __init__(self, bus: "AsyncMessageBusClient", message: Message,
+                 min_timeout: float = 0.2, max_timeout: float = 3.0,
+                 direct_return_func: Callable[[Message], Any] = None):
+        self.bus = bus
+        self.min_timeout = min_timeout
+        self.max_timeout = max_timeout
+        self.direct_return_func = direct_return_func or (lambda msg: False)
+        self.collect_id = str(uuid4())
+        self.handlers: dict = {}
+        self.responses: dict = {}
+        self._lock = asyncio.Lock()
+        self._all_collected = asyncio.Event()
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.message = message
+        self.message.context["__collect_id__"] = self.collect_id
+
+    def _register_handler(self, msg: Message):
+        handler_id = msg.data["handler"]
+        timeout = msg.data["timeout"]
+        if (msg.data["query"] == self.collect_id and
+                handler_id not in self.handlers):
+            self.handlers[handler_id] = timeout
+
+    def _receive_response(self, msg: Message):
+        if msg.data["query"] == self.collect_id:
+            self.responses[msg.data["handler"]] = msg
+            self.handlers[msg.data["handler"]] = 0
+            self._queue.put_nowait(msg)
+            if (len(self.responses) == len(self.handlers) or
+                    self.direct_return_func(msg)):
+                self._queue.put_nowait(None)
+                self._all_collected.set()
+
+    def _setup(self):
+        base = self.message.msg_type
+        self.bus.on(base + ".handling", self._register_handler)
+        self.bus.on(base + ".response", self._receive_response)
+
+    def _teardown(self):
+        base = self.message.msg_type
+        self.bus.remove(base + ".handling", self._register_handler)
+        self.bus.remove(base + ".response", self._receive_response)
+
+    async def collect(self) -> List[Message]:
+        """Emit the query and wait for all registered handlers to respond."""
+        self._setup()
+        await self.bus.emit(self.message)
+        await asyncio.sleep(self.min_timeout)
+
+        if not self.handlers:
+            self._teardown()
+            return []
+
+        # Wait for all handlers up to max_timeout
+        time_waited = self.min_timeout
+        deadline = self.max_timeout - self.min_timeout
+        try:
+            await asyncio.wait_for(self._all_collected.wait(), deadline)
+        except asyncio.TimeoutError:
+            pass
+
+        self._teardown()
+        return list(self.responses.values())
+
+
+class AsyncMessageBusClient:
+    """Async (asyncio) OVOS MessageBus client.
+
+    Drop-in async equivalent of MessageBusClient.  All I/O methods are
+    coroutines; sync helpers (on/once/remove) remain synchronous so that
+    existing-style handler registration still works.
+
+    Usage::
+
+        async def main():
+            bus = AsyncMessageBusClient()
+            await bus.connect()
+            await bus.emit(Message("speak", {"utterance": "hello"}))
+            reply = await bus.wait_for_message("speak", timeout=5)
+            await bus.close()
+
+        asyncio.run(main())
+    """
+
+    _config_cache = None
+
+    def __init__(self, host: str = None, port: int = None,
+                 route: str = None, ssl: bool = None,
+                 cache: bool = False, session=None):
+        config_overrides = dict(host=host, port=port, route=route, ssl=ssl)
+        if cache and self._config_cache:
+            config = self._config_cache
+        else:
+            config = load_message_bus_config(**config_overrides)
+            if cache:
+                AsyncMessageBusClient._config_cache = config
+
+        self.config = MessageBusClientConf(config.host, config.port,
+                                           config.route, config.ssl)
+        self.emitter = AsyncIOEventEmitter()
+        self._ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._connected = asyncio.Event()
+        self._listen_task: Optional[asyncio.Task] = None
+        # same dual-emit (legacy intent/namespace twin) config as the sync
+        # MessageBusClient, so switching a producer onto the async client
+        # doesn't silently drop the V0-compat wire frames -- see
+        # ovos_bus_client.client.client for the flags' semantics.
+        self._translator = NamespaceTranslator(
+            modernize=_bus_flag("OVOS_BUS_MODERNIZE", "modernize", default=True),
+            emit_legacy=_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy", default=True))
+        self._wire_legacy_twins = _bus_flag(
+            "OVOS_BUS_WIRE_LEGACY_TWINS", "wire_legacy_twins", default=True)
+
+        if session:
+            SessionManager.update(session)
+        else:
+            session = SessionManager.default_session
+        self.session_id = session.session_id
+        self.on("ovos.session.update_default", self._on_default_session_update)
+
+    @staticmethod
+    def build_url(host: str, port: int, route: str, ssl: bool) -> str:
+        return f"{'wss' if ssl else 'ws'}://{host}:{port}{route}"
+
+    @property
+    def url(self) -> str:
+        return self.build_url(self.config.host, self.config.port,
+                              self.config.route, self.config.ssl)
+
+    @property
+    def connected(self) -> bool:
+        """Whether the websocket connection is currently up.
+
+        Same attribute name/semantics as ``MessageBusClient.connected_event``
+        being set — consumers that only know the sync client's name (e.g.
+        ovos-busmon's liveness check) can use ``getattr(bus, "connected",
+        None)`` against either client.
+        """
+        return self._connected.is_set()
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self, retry: bool = True, retry_delay: float = 5.0):
+        """Open the WebSocket connection and start the receive loop.
+
+        Arguments:
+            retry: keep retrying on ConnectionRefused
+            retry_delay: seconds between retry attempts
+        """
+        if websockets is None:
+            raise ImportError(
+                "AsyncMessageBusClient requires the 'websockets' package. "
+                "Install it with: pip install 'ovos-bus-client[async]'"
+            )
+        while True:
+            try:
+                self._ws = await websockets.connect(self.url)
+                self._connected.set()
+                LOG.debug("AsyncMessageBusClient connected to %s", self.url)
+                self.emitter.emit("open")
+                await self.emit(Message("ovos.session.sync"))
+                self._listen_task = asyncio.ensure_future(self._recv_loop())
+                return
+            except (ConnectionRefusedError, OSError) as e:
+                LOG.warning("Connection refused (%s). Retrying in %.1fs…", e, retry_delay)
+                if not retry:
+                    raise
+                await asyncio.sleep(retry_delay)
+
+    async def _recv_loop(self):
+        """Receive loop — runs until the connection closes."""
+        try:
+            async for raw in self._ws:
+                await self._on_message(raw)
+        except (ConnectionClosedOK, ConnectionClosedError):
+            pass
+        except Exception as e:
+            LOG.exception("AsyncMessageBusClient recv loop error: %s", e)
+        finally:
+            self._connected.clear()
+            self.emitter.emit("close")
+
+    async def _on_message(self, raw: str):
+        parsed = Message.deserialize(raw)
+        sess = Session.from_message(parsed)
+        if sess.session_id != "default":
+            SessionManager.update(sess)
+        self.emitter.emit("message", raw)
+        self.emitter.emit(parsed.msg_type, parsed)
+
+    def _on_default_session_update(self, message: Message):
+        new_session = message.data["session_data"]
+        sess = Session.deserialize(new_session)
+        SessionManager.update(sess, make_default=True)
+        LOG.debug("synced default_session")
+
+    async def close(self):
+        """Close the WebSocket connection."""
+        if self._ws:
+            await self._ws.close()
+        if self._listen_task:
+            self._listen_task.cancel()
+            try:
+                await self._listen_task
+            except asyncio.CancelledError:
+                pass
+        self._connected.clear()
+
+    # ------------------------------------------------------------------
+    # Emit / wait helpers
+    # ------------------------------------------------------------------
+
+    async def emit(self, message: Message):
+        """Send a message onto the message bus.
+
+        Puts the canonical frame on the wire, then the same legacy-compat
+        twins as :meth:`MessageBusClient.emit` — see
+        ``ovos_bus_client.client.client`` for what/why.
+
+        Arguments:
+            message: Message to send
+        """
+        if "session" not in message.context:
+            sess = (SessionManager.sessions.get(self.session_id)
+                    or Session(self.session_id))
+            message.context["session"] = sess.serialize()
+
+        try:
+            await asyncio.wait_for(self._wait_connected(), 10)
+        except asyncio.TimeoutError:
+            raise ValueError("Timed out waiting for connection")
+
+        await self._send(message)
+        await self._send_legacy_intent_twin(message)
+        await self._send_legacy_namespace_twin(message)
+
+    async def _send(self, message: Message):
+        """Serialize and send a single message over the websocket."""
+        if hasattr(message, "serialize"):
+            raw = message.serialize()
+        else:
+            raw = json_dumps(message.__dict__)
+        try:
+            await self._ws.send(raw)
+        except ConnectionClosedError:
+            LOG.warning("Could not send %s — connection closed", message.msg_type)
+        except Exception:
+            LOG.exception("Failed to emit %s", message.msg_type)
+
+    async def _send_legacy_intent_twin(self, message: Message):
+        twin = _compute_legacy_intent_twin(message, self._translator)
+        if twin is not None:
+            await self._send(twin)
+
+    async def _send_legacy_namespace_twin(self, message: Message):
+        twin = _compute_legacy_namespace_twin(
+            message, self._translator, self._wire_legacy_twins)
+        if twin is not None:
+            await self._send(twin)
+
+    async def _wait_connected(self):
+        await self._connected.wait()
+
+    async def wait_for_message(self, message_type: str,
+                               timeout: float = 3.0) -> Optional[Message]:
+        """Await a message of a specific type.
+
+        Arguments:
+            message_type: the message type to wait for
+            timeout: seconds before timeout
+
+        Returns:
+            The received Message or None on timeout.
+        """
+        return await AsyncMessageWaiter(self, message_type).wait(timeout)
+
+    async def wait_for_response(self, message: Message,
+                                reply_type: Optional[Union[str, List[str]]] = None,
+                                timeout: float = 3.0) -> Optional[Message]:
+        """Emit a message and await its response.
+
+        Arguments:
+            message: message to send
+            reply_type: expected response type(s). Defaults to
+                        ``<msg_type>.response``.
+            timeout: seconds before timeout
+
+        Returns:
+            The response Message or None on timeout.
+        """
+        if isinstance(reply_type, list):
+            message_types = reply_type
+        elif isinstance(reply_type, str):
+            message_types = [reply_type]
+        else:
+            message_types = [message.msg_type + ".response"]
+
+        waiter = AsyncMessageWaiter(self, message_types)
+        await self.emit(message)
+        return await waiter.wait(timeout)
+
+    async def collect_responses(self, message: Message,
+                                min_timeout: float = 0.2,
+                                max_timeout: float = 3.0,
+                                direct_return_func: Callable[[Message], Any] =
+                                None) -> List[Message]:
+        """Emit a query and collect responses from multiple handlers.
+
+        Arguments:
+            message: query message
+            min_timeout: minimum wait time after emitting
+            max_timeout: maximum wait time for all responses
+            direct_return_func: optional early-exit predicate
+
+        Returns:
+            List of response Messages.
+        """
+        collector = AsyncMessageCollector(self, message,
+                                          min_timeout, max_timeout,
+                                          direct_return_func)
+        return await collector.collect()
+
+    # ------------------------------------------------------------------
+    # Event registration (synchronous — mirrors MessageBusClient)
+    # ------------------------------------------------------------------
+
+    def on(self, event_name: str, func: Callable):
+        self.emitter.on(event_name, func)
+
+    def once(self, event_name: str, func: Callable):
+        self.emitter.once(event_name, func)
+
+    def remove(self, event_name: str, func: Callable):
+        try:
+            self.emitter.remove_listener(event_name, func)
+        except (ValueError, KeyError):
+            LOG.warning("Failed to remove listener %s: %s", event_name, func)
+
+    def remove_all_listeners(self, event_name: str):
+        self.emitter.remove_all_listeners(event_name)

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -237,6 +237,57 @@ def _maybe_decrypt(raw):
     return raw
 
 
+def _compute_legacy_intent_twin(message: Message,
+                                translator: NamespaceTranslator) -> Optional[Message]:
+    """Compute the ``.intent``-suffixed twin of an intent dispatch, or
+    ``None`` if this message doesn't need one.
+
+    Pure helper shared by :meth:`MessageBusClient._send_legacy_intent_twin`
+    and its async-client equivalent so both wire clients twin identically.
+    """
+    if not translator.emit_legacy:
+        return None
+    if not is_intent_topic(message.msg_type):
+        return None
+    topic = legacy_intent_topic(message.msg_type)
+    if topic == message.msg_type:
+        return None
+    twin = _verbatim_copy(message, topic)
+    twin.context[INTENT_COMPAT_TWIN_KEY] = True
+    return twin
+
+
+def _compute_legacy_namespace_twin(message: Message,
+                                   translator: NamespaceTranslator,
+                                   wire_legacy_twins: bool) -> Optional[Message]:
+    """Compute the legacy-spelled twin of a canonical namespace emit, or
+    ``None`` if this message doesn't need one.
+
+    Pure helper shared by :meth:`MessageBusClient._send_legacy_namespace_twin`
+    and its async-client equivalent so both wire clients twin identically.
+    """
+    if not translator.emit_legacy:
+        return None
+    if not wire_legacy_twins:
+        return None
+    if message.msg_type in MIGRATION_MAP:
+        return None
+    if is_intent_topic(message.msg_type):
+        return None
+    counterparts = translator.counterpart_topics(message.msg_type)
+    if not counterparts:
+        return None
+    topic = counterparts[0]
+    if topic == message.msg_type:
+        return None
+    payload = translator.translate_payload(
+        from_topic=message.msg_type, to_topic=topic, data=message.data)
+    twin = _verbatim_copy(message, topic)
+    twin.data = payload
+    twin.context[NAMESPACE_COMPAT_TWIN_KEY] = True
+    return twin
+
+
 class MessageBusClient:
     """The Mycroft Messagebus Client
 
@@ -559,16 +610,9 @@ class MessageBusClient:
         a few ignored bytes. An already-suffixed dispatch is never twinned, so
         the mirror cannot cascade.
         """
-        if not self._translator.emit_legacy:
-            return
-        if not is_intent_topic(message.msg_type):
-            return
-        topic = legacy_intent_topic(message.msg_type)
-        if topic == message.msg_type:
-            return
-        twin = _verbatim_copy(message, topic)
-        twin.context[INTENT_COMPAT_TWIN_KEY] = True
-        self._send(twin)
+        twin = _compute_legacy_intent_twin(message, self._translator)
+        if twin is not None:
+            self._send(twin)
 
     def _send_legacy_namespace_twin(self, message: Message):
         """Put the legacy-spelled twin of a canonical namespace emit on the wire.
@@ -586,31 +630,10 @@ class MessageBusClient:
         is left untouched -- including intent topics, which are twinned by
         :meth:`_send_legacy_intent_twin` instead.
         """
-        if not self._translator.emit_legacy:
-            return
-        if not self._wire_legacy_twins:
-            # escape hatch -- see OVOS_BUS_WIRE_LEGACY_TWINS. Default ON, for
-            # stable (<2.x) pre-spec-tools wire listeners, which are the
-            # supported compat target. Only flip this off when the operator
-            # knows no such listener is on the bus.
-            return
-        if message.msg_type in MIGRATION_MAP:
-            # already a legacy-spelled emit -- nothing to twin forward with.
-            return
-        if is_intent_topic(message.msg_type):
-            return
-        counterparts = self._translator.counterpart_topics(message.msg_type)
-        if not counterparts:
-            return
-        topic = counterparts[0]
-        if topic == message.msg_type:
-            return
-        payload = self._translator.translate_payload(
-            from_topic=message.msg_type, to_topic=topic, data=message.data)
-        twin = _verbatim_copy(message, topic)
-        twin.data = payload
-        twin.context[NAMESPACE_COMPAT_TWIN_KEY] = True
-        self._send(twin)
+        twin = _compute_legacy_namespace_twin(
+            message, self._translator, self._wire_legacy_twins)
+        if twin is not None:
+            self._send(twin)
 
     def _send(self, message: Message):
         """Serialize and send a single message over the websocket."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ test = [
     "pytest-cov",
     "langcodes",
     "language_data",
+    "websockets>=10.0",
 ]
+async = ["websockets>=10.0"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-bus-client"

--- a/test/unittests/test_async_client.py
+++ b/test/unittests/test_async_client.py
@@ -1,0 +1,264 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests for AsyncMessageBusClient, AsyncMessageWaiter, AsyncMessageCollector."""
+
+import asyncio
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ovos_bus_client.client.async_client import (
+    AsyncMessageBusClient,
+    AsyncMessageCollector,
+    AsyncMessageWaiter,
+)
+from ovos_bus_client.message import Message
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bus() -> AsyncMessageBusClient:
+    """Return a bus whose websocket connection is pre-mocked (no real network)."""
+    with patch("ovos_bus_client.client.async_client.load_message_bus_config") as mock_cfg:
+        mock_cfg.return_value = MagicMock(host="localhost", port=8181,
+                                          route="/core", ssl=False)
+        bus = AsyncMessageBusClient()
+    # Simulate an already-connected state
+    bus._connected.set()
+    ws_mock = AsyncMock()
+    ws_mock.send = AsyncMock()
+    bus._ws = ws_mock
+    return bus
+
+
+# ---------------------------------------------------------------------------
+# AsyncMessageBusClient tests
+# ---------------------------------------------------------------------------
+
+class TestAsyncMessageBusClientInit(unittest.TestCase):
+    def test_build_url_ws(self):
+        url = AsyncMessageBusClient.build_url("localhost", 8181, "/core", False)
+        self.assertEqual(url, "ws://localhost:8181/core")
+
+    def test_build_url_wss(self):
+        url = AsyncMessageBusClient.build_url("example.com", 443, "/core", True)
+        self.assertEqual(url, "wss://example.com:443/core")
+
+    def test_init_creates_emitter(self):
+        bus = _make_bus()
+        self.assertIsNotNone(bus.emitter)
+
+    def test_url_property(self):
+        bus = _make_bus()
+        self.assertTrue(bus.url.startswith("ws://"))
+
+    def test_connected_property_reflects_connection_state(self):
+        # same attribute name/semantics as MessageBusClient.connected_event
+        # being set -- ovos-busmon's _bus_is_connected() reads
+        # getattr(bus, "connected", None) against either client.
+        bus = _make_bus()
+        self.assertTrue(bus.connected)
+        bus._connected.clear()
+        self.assertFalse(bus.connected)
+
+
+class TestAsyncMessageBusClientEmit(unittest.IsolatedAsyncioTestCase):
+
+    async def test_emit_sends_serialized_message(self):
+        bus = _make_bus()
+        msg = Message("test.event", {"key": "value"})
+        await bus.emit(msg)
+        bus._ws.send.assert_awaited_once()
+        sent_raw = bus._ws.send.call_args[0][0]
+        parsed = json.loads(sent_raw)
+        self.assertEqual(parsed["type"], "test.event")
+        self.assertEqual(parsed["data"]["key"], "value")
+
+    async def test_emit_injects_session(self):
+        bus = _make_bus()
+        msg = Message("test.session.inject")
+        self.assertNotIn("session", msg.context)
+        await bus.emit(msg)
+        self.assertIn("session", msg.context)
+
+    async def test_emit_does_not_override_existing_session(self):
+        bus = _make_bus()
+        existing = {"session_id": "custom-123"}
+        msg = Message("test.session.keep", context={"session": existing})
+        await bus.emit(msg)
+        self.assertEqual(msg.context["session"], existing)
+
+    async def test_emit_connection_timeout_raises(self):
+        bus = _make_bus()
+        bus._connected.clear()
+        msg = Message("test.timeout")
+        # asyncio.wait_for fires before the internal 10s wait, so we get TimeoutError
+        with self.assertRaises((ValueError, TimeoutError, asyncio.TimeoutError)):
+            await asyncio.wait_for(bus.emit(msg), timeout=0.05)
+
+
+# ---------------------------------------------------------------------------
+# AsyncMessageWaiter tests
+# ---------------------------------------------------------------------------
+
+class TestAsyncMessageWaiter(unittest.IsolatedAsyncioTestCase):
+
+    async def test_wait_receives_message(self):
+        bus = _make_bus()
+        waiter = AsyncMessageWaiter(bus, "my.event")
+        msg = Message("my.event", {"x": 1})
+        # Simulate message arrival
+        bus.emitter.emit("my.event", msg)
+        result = await waiter.wait(timeout=1.0)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.msg_type, "my.event")
+
+    async def test_wait_returns_none_on_timeout(self):
+        bus = _make_bus()
+        waiter = AsyncMessageWaiter(bus, "never.arrives")
+        result = await waiter.wait(timeout=0.05)
+        self.assertIsNone(result)
+
+    async def test_wait_multiple_types(self):
+        bus = _make_bus()
+        waiter = AsyncMessageWaiter(bus, ["type.a", "type.b"])
+        msg = Message("type.b")
+        bus.emitter.emit("type.b", msg)
+        result = await waiter.wait(timeout=1.0)
+        self.assertEqual(result.msg_type, "type.b")
+
+    async def test_one_shot_handler_not_called_twice(self):
+        bus = _make_bus()
+        waiter = AsyncMessageWaiter(bus, "one.shot")
+        msg1 = Message("one.shot", {"n": 1})
+        msg2 = Message("one.shot", {"n": 2})
+        bus.emitter.emit("one.shot", msg1)
+        bus.emitter.emit("one.shot", msg2)
+        result = await waiter.wait(timeout=0.1)
+        # Should only have captured the first
+        self.assertEqual(result.data["n"], 1)
+
+
+# ---------------------------------------------------------------------------
+# on_message pipeline tests
+# ---------------------------------------------------------------------------
+
+class TestOnMessage(unittest.IsolatedAsyncioTestCase):
+
+    async def test_on_message_emits_msg_type(self):
+        bus = _make_bus()
+        received = []
+        bus.on("hello.world", lambda m: received.append(m))
+        raw = json.dumps({"type": "hello.world", "data": {}, "context": {}})
+        await bus._on_message(raw)
+        await asyncio.sleep(0)  # allow emitter callbacks to fire
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].msg_type, "hello.world")
+
+    async def test_on_message_emits_raw_message_event(self):
+        bus = _make_bus()
+        raw_received = []
+        bus.on("message", lambda r: raw_received.append(r))
+        raw = json.dumps({"type": "raw.test", "data": {}, "context": {}})
+        await bus._on_message(raw)
+        await asyncio.sleep(0)
+        self.assertEqual(len(raw_received), 1)
+
+
+# ---------------------------------------------------------------------------
+# Event registration tests
+# ---------------------------------------------------------------------------
+
+class TestEventRegistration(unittest.TestCase):
+
+    def test_on_and_remove(self):
+        bus = _make_bus()
+        calls = []
+        handler = lambda m: calls.append(m)
+        bus.on("test.on.remove", handler)
+        bus.emitter.emit("test.on.remove", Message("test.on.remove"))
+        self.assertEqual(len(calls), 1)
+        bus.remove("test.on.remove", handler)
+        bus.emitter.emit("test.on.remove", Message("test.on.remove"))
+        self.assertEqual(len(calls), 1)  # still 1 — handler was removed
+
+    def test_once_fires_once(self):
+        bus = _make_bus()
+        calls = []
+        bus.once("test.once", lambda m: calls.append(m))
+        bus.emitter.emit("test.once", Message("test.once"))
+        bus.emitter.emit("test.once", Message("test.once"))
+        self.assertEqual(len(calls), 1)
+
+    def test_remove_all_listeners(self):
+        bus = _make_bus()
+        calls = []
+        bus.on("ev", lambda m: calls.append(m))
+        bus.on("ev", lambda m: calls.append(m))
+        bus.remove_all_listeners("ev")
+        bus.emitter.emit("ev", Message("ev"))
+        self.assertEqual(calls, [])
+
+
+# ---------------------------------------------------------------------------
+# AsyncMessageCollector tests
+# ---------------------------------------------------------------------------
+
+class TestAsyncMessageCollector(unittest.IsolatedAsyncioTestCase):
+
+    async def test_collect_returns_empty_without_handlers(self):
+        bus = _make_bus()
+        msg = Message("query.no.handlers")
+        collector = AsyncMessageCollector(bus, msg,
+                                          min_timeout=0.01, max_timeout=0.1)
+        result = await collector.collect()
+        self.assertEqual(result, [])
+
+    async def test_collect_returns_responses(self):
+        """Collector receives one handler's ack+response fired from a background task."""
+        bus = _make_bus()
+        query = Message("query.with.handler")
+        collector = AsyncMessageCollector(bus, query,
+                                          min_timeout=0.05, max_timeout=2.0)
+
+        # Inject ack + response after a short delay (simulates a remote handler)
+        async def inject():
+            await asyncio.sleep(0.02)
+            cid = query.context["__collect_id__"]
+            handler_id = "h1"
+            ack = Message("query.with.handler.handling",
+                          data={"query": cid, "handler": handler_id, "timeout": 1.0})
+            bus.emitter.emit("query.with.handler.handling", ack)
+            resp = Message("query.with.handler.response",
+                           data={"query": cid, "handler": handler_id, "result": "ok"})
+            bus.emitter.emit("query.with.handler.response", resp)
+
+        asyncio.ensure_future(inject())
+        result = await asyncio.wait_for(collector.collect(), timeout=3.0)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].data["result"], "ok")
+
+    async def test_wait_for_response_integration(self):
+        """wait_for_response resolves when the response event is fired externally."""
+        bus = _make_bus()
+        request = Message("ping")
+
+        # Simulate a remote handler that fires the response after emit completes
+        async def inject_response():
+            await asyncio.sleep(0.02)
+            bus.emitter.emit("ping.response",
+                              Message("ping.response", {"pong": True}))
+
+        asyncio.ensure_future(inject_response())
+        response = await bus.wait_for_response(request, timeout=2.0)
+        self.assertIsNotNone(response)
+        self.assertTrue(response.data["pong"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_async_client_frame_parity.py
+++ b/test/unittests/test_async_client_frame_parity.py
@@ -1,0 +1,100 @@
+"""Frame-parity test: AsyncMessageBusClient.emit() must put the exact same
+wire frames as MessageBusClient.emit() -- including the legacy intent/
+namespace compat twins -- for the same Message.
+
+Confirmed defect (see docs/prerelease-quirks.md 2.8.5a2): the async client's
+emit() originally only sent the canonical frame, silently dropping the
+V0-compat dual-emit twins that the sync client's emit() sends via
+_send_legacy_intent_twin/_send_legacy_namespace_twin. This asserts frame-for-
+frame equality (as parsed JSON, so key ordering doesn't matter) between the
+two clients' wire output for both an intent topic and a MIGRATION_MAP
+namespace topic.
+"""
+import asyncio
+import json
+import unittest
+from threading import Event
+from unittest.mock import AsyncMock, MagicMock
+
+from pyee import EventEmitter
+
+from ovos_bus_client.client.async_client import AsyncMessageBusClient
+from ovos_bus_client.client.client import MessageBusClient
+from ovos_bus_client.message import Message
+
+
+def _sync_client() -> MessageBusClient:
+    c = MessageBusClient.__new__(MessageBusClient)
+    c.emitter = EventEmitter()
+    c.client = MagicMock()
+    from ovos_spec_tools import NamespaceTranslator
+    c._translator = NamespaceTranslator(modernize=True, emit_legacy=True)
+    c._wire_legacy_twins = True
+    c._handler_guards = {}
+    c._intent_pair_guards = {}
+    c._dedup_registrations = {}
+    c.wrapped_funcs = {}
+    c.connected_event = Event()
+    c.connected_event.set()
+    c.started_running = True
+    c.session_id = "default"
+    return c
+
+
+def _async_client() -> AsyncMessageBusClient:
+    bus = AsyncMessageBusClient.__new__(AsyncMessageBusClient)
+    bus.emitter = None
+    bus._ws = AsyncMock()
+    bus._ws.send = AsyncMock()
+    bus._connected = asyncio.Event()
+    bus._connected.set()
+    from ovos_spec_tools import NamespaceTranslator
+    bus._translator = NamespaceTranslator(modernize=True, emit_legacy=True)
+    bus._wire_legacy_twins = True
+    bus.session_id = "default"
+    return bus
+
+
+def _sync_frames(client, message):
+    client.emit(message)
+    return [json.loads(call.args[0]) for call in client.client.send.call_args_list]
+
+
+def _async_frames(bus, message):
+    async def _run():
+        await bus.emit(message)
+    asyncio.run(_run())
+    return [json.loads(call.args[0]) for call in bus._ws.send.call_args_list]
+
+
+class TestAsyncSyncFrameParity(unittest.TestCase):
+    def _assert_parity(self, message_factory):
+        sync = _sync_client()
+        sync_frames = _sync_frames(sync, message_factory())
+
+        aclient = _async_client()
+        async_frames = _async_frames(aclient, message_factory())
+
+        self.assertEqual(len(sync_frames), len(async_frames))
+        self.assertGreater(len(sync_frames), 0)
+        for s, a in zip(sync_frames, async_frames):
+            self.assertEqual(s, a)
+
+    def test_intent_topic_twin_parity(self):
+        self._assert_parity(
+            lambda: Message("skill:food.order", {"utterance": "pizza"},
+                            {"session": {"session_id": "default"}}))
+
+    def test_namespace_migration_topic_twin_parity(self):
+        self._assert_parity(
+            lambda: Message("ovos.utterance.speak", {"utterance": "hi"},
+                            {"session": {"session_id": "default"}}))
+
+    def test_plain_topic_no_twin_parity(self):
+        self._assert_parity(
+            lambda: Message("some.unrelated.topic", {"foo": "bar"},
+                            {"session": {"session_id": "default"}}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

This adds `AsyncMessageBusClient`, an asyncio-native counterpart to the existing threaded `MessageBusClient`. It speaks the same websocket protocol and offers coroutine equivalents of the sync client's emit/wait/collect helpers, so a process already running an asyncio event loop (ovos-busmon being the concrete example) can talk to the bus without paying the cost of bridging callbacks off a background thread.

The important property of a second client class is that it must not change what goes on the wire. `MessageBusClient.emit()` puts more than the canonical frame on the bus: it also sends the legacy intent-topic twin and the legacy namespace-migration twin, gated by the `OVOS_BUS_EMIT_LEGACY` and `OVOS_BUS_WIRE_LEGACY_TWINS` flags, so that pre-spec-tools listeners still get frames they can subscribe to. The async client's `emit()` now produces the identical sequence of frames for the identical `Message`, because both clients call the same two module-level helpers (`_compute_legacy_intent_twin` and `_compute_legacy_namespace_twin`, extracted from `client.py`) rather than each having its own copy of that logic. A new test, `test_async_client_frame_parity.py`, emits the same messages through both clients against a fake transport and asserts the serialized JSON frames match one-for-one, for an intent topic, a namespace-migration topic, and a plain topic that gets no twin at all.

`AsyncMessageBusClient` also exposes a `connected` boolean property with the same name and semantics as the sync client's `connected_event` being set. ovos-busmon's `_bus_is_connected()` reads `getattr(bus, "connected", None)` to decide whether the bus is alive; without this property it would silently assume "connected" for the async client and lose its liveness signal the moment this PR landed. ovos-busmon already carries a guarded, commented integration waiting specifically on this PR (`from ovos_bus_client.client import AsyncMessageBusClient`, falling back to a threaded adapter otherwise) — installing this branch's `ovos-bus-client` into ovos-busmon's own test environment and running its suite (`tests/test_bus_compat.py` and the rest) confirmed busmon now picks the async client, that it exposes `connected`, and that all 47 of busmon's existing tests still pass unmodified.

Verification: a fail-before check (reverting only the source change and keeping the new test) showed the parity test failing with 2 frames from the sync client against 1 from the async client for both twin-bearing topics, and passing after restoring the fix. The full `ovos-bus-client` suite runs at 830 passed / 6 skipped on this branch versus 806 passed / 6 skipped on a clean `origin/dev` checkout — the delta is exactly the new async-client and parity tests, with nothing else regressed.

This is rebased onto current `dev`, which since this branch was opened added the legacy dual-emit compat mechanism this PR now reuses instead of bypassing.
