### PR TITLE
refactor: migrate language matching to ovos-spec-tools

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from ovos_config.config import Configuration
 from ovos_config.locale import get_default_lang
 from ovos_utils.log import LOG, log_deprecation
-from ovos_utils.lang import standardize_lang_tag
+from ovos_spec_tools import standardize_lang
 from ovos_bus_client.message import dig_for_message, Message
 
 
@@ -313,7 +313,7 @@ class Session:
                                    Configuration().get("skills", {}).get("blacklisted_skills", []))
         self.blacklisted_intents = (blacklisted_intents or
                                     Configuration().get("intents", {}).get("blacklisted_intents", []))
-        self.lang = standardize_lang_tag(lang or get_default_lang())
+        self.lang = standardize_lang(lang or get_default_lang())
         self.system_unit = system_unit or Configuration().get("system_unit", "metric")
         self.date_format = date_format or Configuration().get("date_format", "DMY")
         self.time_format = time_format or Configuration().get("time_format", "full")

--- a/ovos_bus_client/util/__init__.py
+++ b/ovos_bus_client/util/__init__.py
@@ -20,7 +20,7 @@ from ovos_utils import json_loads
 from ovos_config.config import read_mycroft_config
 from ovos_config.locale import get_default_lang
 from ovos_utils.json_helper import merge_dict
-from ovos_utils.lang import standardize_lang_tag
+from ovos_spec_tools import standardize_lang
 from ovos_bus_client import MessageBusClient
 from ovos_bus_client.message import dig_for_message, Message
 from ovos_bus_client.session import SessionManager
@@ -40,14 +40,14 @@ def get_message_lang(message=None):
     # old style lang param
     lang = message.data.get("lang") or message.context.get("lang")
     if lang:
-        return standardize_lang_tag(lang)
+        return standardize_lang(lang)
 
     # new style session lang
     if "session_id" in message.context or "session" in message.context:
         sess = SessionManager.get(message)
         return sess.lang
 
-    return standardize_lang_tag(get_default_lang())
+    return standardize_lang(get_default_lang())
 
 
 def get_websocket(host, port, route='/', ssl=False, threaded=True):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-utils>=0.8.2,<1.0.0",
+    "ovos-spec-tools[langcodes]>=0.0.1a2",
     "websocket-client>=0.54.0",
     "pyee>=8.1.0,<13.0.0",
 ]


### PR DESCRIPTION
Part of the OVOS migration onto **ovos-spec-tools** (OpenVoiceOS/architecture#7).

`get_message_lang` and `Session.lang` called the now-deprecated
`ovos_utils.lang.standardize_lang_tag`. They now use
`ovos_spec_tools.standardize_lang` directly — the conformant language-tag
normalizer, which keeps the region (a message / session language must stay
region-ful, e.g. `de-DE`).

- `util/__init__.py`, `session.py` — `standardize_lang_tag` → `standardize_lang`.
- `pyproject.toml` — adds `ovos-spec-tools[langcodes]`.

## Verification

Full suite passes (548 tests). `get_message_lang(Message(lang="de-de"))`
returns `de-DE` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)