### PR TITLE
fix: restore legacy AES encryption at the websocket transport edge

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -153,7 +153,10 @@ applications generally do not instantiate it directly.
 
 ## Deprecated transport-edge encryption
 
-OVOS-MSG-1 is transport-agnostic (§7 non-goals): the message envelope does not
+[OVOS-MSG-1](https://github.com/OpenVoiceOS/architecture/blob/master/message-object.md)
+is transport-agnostic
+([§1 Scope](https://github.com/OpenVoiceOS/architecture/blob/master/message-object.md#1-scope)
+explicitly excludes encryption from the spec): the message envelope does not
 define encryption. `ovos-bus-client` bolts a legacy AES-GCM wrapper on top at
 the transport edge, controlled by `websocket.secret_key` in your OVOS config.
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -99,8 +99,9 @@ when you want to log or intercept every single message.
 bus.emit(Message("speak", {"utterance": "hi"}))
 ```
 
-`emit` serialises the message, waits up to 10 seconds for the socket to be
-up, then `socket.send`s the JSON (`client.py:166-197`).
+`emit` serialises the message (pure JSON), optionally wraps it in the
+deprecated AES envelope (see below), waits up to 10 seconds for the socket to
+be up, then `socket.send`s the result (`ovos_bus_client/client/client.py:261`).
 
 There is no `emit`-with-return; if you want a reply, use one of the helpers
 below.
@@ -149,6 +150,52 @@ A specialised `MessageBusClient` that talks to the **GUI** bus rather than the
 core bus. It deals in `GUIMessage` objects rather than `Message`, and the
 default port is different (typically 18181). Used by `GUIInterface` —
 applications generally do not instantiate it directly.
+
+## Deprecated transport-edge encryption
+
+OVOS-MSG-1 is transport-agnostic (§7 non-goals): the message envelope does not
+define encryption. `ovos-bus-client` bolts a legacy AES-GCM wrapper on top at
+the transport edge, controlled by `websocket.secret_key` in your OVOS config.
+
+**This scheme is deprecated.** Its matching key-setup half was never formally
+implemented. A `DeprecationWarning` fires every time it engages. Remove
+`websocket.secret_key` from your config to suppress the warning and opt out.
+
+### How it works
+
+Two module-level helpers in `ovos_bus_client/client/client.py` do the work:
+
+| Helper | Direction | Source |
+|---|---|---|
+| `_maybe_encrypt(serialized: str) -> str` | outbound (post-serialize, pre-send) | `client.py:52` |
+| `_maybe_decrypt(raw) -> str` | inbound (post-receive, pre-deserialize) | `client.py:67` |
+
+Both are no-ops when `websocket.secret_key` is absent or empty. When a
+non-empty key is present, `_maybe_encrypt` wraps the JSON string in an AES-GCM
+envelope and `_maybe_decrypt` unwraps it.
+
+`_maybe_decrypt` also reads `websocket.allow_unencrypted` (defaults to `True`
+when no key is set, `False` when a key is set). If `allow_unencrypted` is
+`False` and an incoming frame is not encrypted, a `RuntimeError` is raised.
+
+### Where it is wired
+
+| Call path | Hook point |
+|---|---|
+| `MessageBusClient.emit` | `_maybe_encrypt` called post-`serialize()`, pre-`socket.send` (`client.py:261`) |
+| `MessageBusClient.on_message` | `_maybe_decrypt` called post-receive, pre-`Message.deserialize` (`client.py:223`) |
+| `GUIWebsocketClient.emit` | same `_maybe_encrypt` hook (`client.py:480,482`) |
+| `GUIWebsocketClient.on_message` | same `_maybe_decrypt` hook (`client.py:505`) |
+
+`send_func.py` does **not** apply encryption; deployments that need the scheme
+must route traffic through `MessageBusClient`.
+
+### Config keys (deprecated)
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `websocket.secret_key` | `str` | *(absent)* | AES-GCM key. Empty string or missing both disable encryption. |
+| `websocket.allow_unencrypted` | `bool` | `True` when no key; `False` when a key is set | Allow plaintext frames through when a key is configured. |
 
 ## Subclassing
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -197,6 +197,9 @@ must route traffic through `MessageBusClient`.
 | `websocket.secret_key` | `str` | *(absent)* | AES-GCM key. Empty string or missing both disable encryption. |
 | `websocket.allow_unencrypted` | `bool` | `True` when no key; `False` when a key is set | Allow plaintext frames through when a key is configured. |
 
+See [Configuration → Deprecated: `websocket.secret_key` and `websocket.allow_unencrypted`](configuration.md#deprecated-websocketsecret_key-and-websocketallow_unencrypted)
+for the same keys in context of the wider config block.
+
 ## Subclassing
 
 The standard customisation point is the constructor's callback overrides plus

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,26 @@ robust against missing config, either:
 - Construct `MessageBusClient(host="127.0.0.1", port=8181, route="/core",
   ssl=False)` explicitly so the loader is never consulted.
 
+## Deprecated: `websocket.secret_key` and `websocket.allow_unencrypted`
+
+These two keys activate a legacy AES-GCM envelope encryption scheme applied at
+the WebSocket transport edge. The scheme is **deprecated** — a
+`DeprecationWarning` fires every time encryption or decryption engages, and the
+wrapper will be removed in a future major release.
+
+| Key | Type | Behaviour |
+|---|---|---|
+| `websocket.secret_key` | `str` | AES-GCM key. An empty string and an absent key are both treated as falsy — encryption is disabled in either case. |
+| `websocket.allow_unencrypted` | `bool` | When a key is set, controls whether plaintext inbound frames are accepted (`True`) or rejected with `RuntimeError` (`False`). Defaults to `False` when a key is configured, `True` when no key is configured. |
+
+To opt out, remove `secret_key` from the `websocket` block (or set it to an
+empty string). For remote-access security, use
+[HiveMind](https://github.com/JarbasHiveMind), which provides proper
+authentication and encryption at a higher layer.
+
+See [The client → Deprecated transport-edge encryption](client.md#deprecated-transport-edge-encryption)
+for implementation details.
+
 ## Environment variables
 
 `ovos-bus-client` does not read environment variables directly. `ovos-config`

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -35,8 +35,10 @@ Both `data` and `context` default to `{}` if omitted.
 
 `serialize()` and `deserialize()` are pure JSON — they neither encrypt nor
 decrypt. Any envelope encryption is a separate, deprecated layer applied at the
-transport edge by `MessageBusClient`. `MessageBusClient.emit` calls
-`serialize()` for you; you rarely call it directly.
+transport edge by [`MessageBusClient`](client.md) — see
+[The client → Deprecated transport-edge encryption](client.md#deprecated-transport-edge-encryption).
+[`MessageBusClient.emit`](client.md#emitting) calls `serialize()` for you; you
+rarely call it directly.
 
 ### Reply helpers
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -1,6 +1,11 @@
 # Messages
 
-Reference for the `Message` class and its helpers.
+Reference for the `Message` class and its helpers. The envelope shape, routing
+keys, session carrier and derivations are normatively defined by
+[**OVOS-MSG-1**](https://github.com/OpenVoiceOS/architecture/blob/master/message-object.md);
+the implementation here is a re-export of
+[`ovos_spec_tools.message.Message`](https://github.com/OpenVoiceOS/ovos-spec-tools)
+with `publish` attached for back-compat.
 
 > **Looking for the catalogue of valid message types?** That lives in
 > [**ovos-pydantic-models**](https://github.com/OpenVoiceOS/ovos-pydantic-models)

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -33,8 +33,10 @@ Both `data` and `context` default to `{}` if omitted.
 | `m.as_dict()` | `dict` | Plain dict form (`message.py:90`) |
 | `Message.deserialize(str)` | `Message` | Parse JSON text back into a `Message` (`message.py:127`) |
 
-`MessageBusClient.emit` calls `serialize()` for you; you rarely call it
-directly.
+`serialize()` and `deserialize()` are pure JSON — they neither encrypt nor
+decrypt. Any envelope encryption is a separate, deprecated layer applied at the
+transport edge by `MessageBusClient`. `MessageBusClient.emit` calls
+`serialize()` for you; you rarely call it directly.
 
 ### Reply helpers
 
@@ -108,9 +110,14 @@ shape but it serialises arguments directly at the top level rather than under
 ## Encryption helpers
 
 `encrypt_as_dict(key, data, nonce=None)` and `decrypt_from_dict(key, data)` —
-`message.py:241,248` — wrap an AES-GCM symmetric cipher for use by transport
-plugins that need to encrypt the JSON payload on the wire (HiveMind being the
-primary consumer). They are not used inside the OVOS bus loop itself.
+`ovos_bus_client/message.py:128,148` — wrap an AES-GCM symmetric cipher. They
+are exported from `ovos_bus_client.message` for any direct importer (e.g.
+HiveMind), but **are not called by `Message.serialize` or
+`Message.deserialize`**, which produce and consume plain JSON.
+
+The OVOS core bus loop wires these helpers at the **transport edge** inside
+`MessageBusClient`, not inside `Message`. See
+[The client → Deprecated transport encryption](client.md#deprecated-transport-edge-encryption).
 
 ## Validating against the protocol spec
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -62,8 +62,11 @@ No old entry point is preserved. Update any persona or pipeline configuration th
 and consume pure JSON — they have never encrypted or decrypted the envelope.
 The legacy AES-GCM wrapper (controlled by
 [`websocket.secret_key`](configuration.md#deprecated-websocketsecret_key-and-websocketallow_unencrypted))
-was always a transport-level concern; it is now explicitly placed at the
-transport edge inside [`MessageBusClient` and `GUIWebsocketClient`](client.md)
+was always a transport-level concern
+([OVOS-MSG-1 §1 Scope](https://github.com/OpenVoiceOS/architecture/blob/master/message-object.md#1-scope)
+explicitly excludes encryption from the message-object spec); it is now
+explicitly placed at the transport edge inside
+[`MessageBusClient` and `GUIWebsocketClient`](client.md)
 via `_maybe_encrypt` / `_maybe_decrypt`
 (`ovos_bus_client/client/client.py:52,67`). See
 [The client → Deprecated transport-edge encryption](client.md#deprecated-transport-edge-encryption)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -53,3 +53,18 @@ The replacement implements the modern `ChatEngine` interface (`opm.agents.chat`)
 | `neon.plugin.solver` | `opm.agents.chat` |
 
 No old entry point is preserved. Update any persona or pipeline configuration that referenced `ovos-solver-bus-plugin` under the solver group to use the chat-engine group instead.
+
+---
+
+### Encryption: moved from `Message` to the transport edge
+
+`Message.serialize` and `Message.deserialize` produce and consume pure JSON —
+they have never encrypted or decrypted the envelope. The legacy AES-GCM wrapper
+(controlled by `websocket.secret_key`) was always a transport-level concern; it
+is now explicitly placed at the transport edge inside `MessageBusClient` and
+`GUIWebsocketClient` via `_maybe_encrypt` / `_maybe_decrypt`
+(`ovos_bus_client/client/client.py:52,67`).
+
+The scheme is deprecated. If your deployment set `websocket.secret_key`, you
+will see `DeprecationWarning` on every encrypted send or receive. Remove the
+key to suppress the warning. For remote-access security, use HiveMind instead.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -58,12 +58,16 @@ No old entry point is preserved. Update any persona or pipeline configuration th
 
 ### Encryption: moved from `Message` to the transport edge
 
-`Message.serialize` and `Message.deserialize` produce and consume pure JSON —
-they have never encrypted or decrypted the envelope. The legacy AES-GCM wrapper
-(controlled by `websocket.secret_key`) was always a transport-level concern; it
-is now explicitly placed at the transport edge inside `MessageBusClient` and
-`GUIWebsocketClient` via `_maybe_encrypt` / `_maybe_decrypt`
-(`ovos_bus_client/client/client.py:52,67`).
+[`Message.serialize` and `Message.deserialize`](messages.md#serialisation) produce
+and consume pure JSON — they have never encrypted or decrypted the envelope.
+The legacy AES-GCM wrapper (controlled by
+[`websocket.secret_key`](configuration.md#deprecated-websocketsecret_key-and-websocketallow_unencrypted))
+was always a transport-level concern; it is now explicitly placed at the
+transport edge inside [`MessageBusClient` and `GUIWebsocketClient`](client.md)
+via `_maybe_encrypt` / `_maybe_decrypt`
+(`ovos_bus_client/client/client.py:52,67`). See
+[The client → Deprecated transport-edge encryption](client.md#deprecated-transport-edge-encryption)
+for the full hook layout.
 
 The scheme is deprecated. If your deployment set `websocket.secret_key`, you
 will see `DeprecationWarning` on every encrypted send or receive. Remove the

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -21,8 +21,76 @@ from websocket import (WebSocketApp,
 from ovos_bus_client.client.collector import MessageCollector
 from ovos_bus_client.client.waiter import MessageWaiter
 from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf, load_gui_message_bus_config
-from ovos_bus_client.message import Message, CollectionMessage, GUIMessage
+from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
+                                     encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import SessionManager, Session
+
+# --- Layer-2 encryption at the transport edge (deprecated) -----------------
+#
+# OVOS-MSG-1 is transport-agnostic (§7 non-goals): the on-the-wire envelope
+# does not define encryption. The client below bolts an AES (GCM) wrapper
+# on top of the spec at its send/receive edges, controlled by the
+# ``websocket.secret_key`` config. Its matching key-setup half was never
+# formally implemented, so the scheme is **deprecated** — a
+# :class:`DeprecationWarning` fires whenever it engages.
+
+import json as _json
+import warnings as _warnings
+
+
+def _encryption_keys():
+    """Return ``(secret_key, allow_unencrypted)`` from current config."""
+    from ovos_config.config import Configuration
+    cfg = Configuration().get("websocket", {})
+    secret = cfg.get("secret_key")
+    allow_clear = cfg.get("allow_unencrypted", secret is None)
+    return secret, allow_clear
+
+
+def _maybe_encrypt(serialized: str) -> str:
+    """Wrap ``serialized`` in the legacy AES envelope when
+    ``websocket.secret_key`` is configured; otherwise pass through."""
+    secret, _ = _encryption_keys()
+    if not secret:
+        return serialized
+    _warnings.warn(
+        "Layer-2 envelope encryption on the websocket transport is "
+        "deprecated; its key-setup half was never formally implemented "
+        "and the wrapper will be removed in a future major. Suppress by "
+        "unsetting `websocket.secret_key`.",
+        DeprecationWarning, stacklevel=3)
+    return json_dumps(encrypt_as_dict(secret, serialized))
+
+
+def _maybe_decrypt(raw):
+    """Unwrap the legacy AES envelope on inbound frames when
+    ``websocket.secret_key`` is configured. Returns a plain JSON string
+    suitable for :meth:`Message.deserialize`. Honours
+    ``websocket.allow_unencrypted``."""
+    secret, allow_clear = _encryption_keys()
+    if secret is None:
+        return raw
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8")
+    try:
+        obj = _json.loads(raw) if isinstance(raw, str) else raw
+    except _json.JSONDecodeError:
+        if allow_clear:
+            return raw
+        raise
+    if isinstance(obj, dict) and "ciphertext" in obj:
+        _warnings.warn(
+            "Layer-2 envelope decryption on the websocket transport is "
+            "deprecated; its key-setup half was never formally "
+            "implemented and the wrapper will be removed in a future "
+            "major.",
+            DeprecationWarning, stacklevel=3)
+        return decrypt_from_dict(secret, obj)
+    if not allow_clear:
+        raise RuntimeError(
+            "received an unencrypted Message but "
+            "`websocket.allow_unencrypted` is False")
+    return raw
 
 
 class MessageBusClient:
@@ -150,7 +218,7 @@ class MessageBusClient:
             message = args[0]
         else:
             message = args[1]
-        parsed_message = Message.deserialize(message)
+        parsed_message = Message.deserialize(_maybe_decrypt(message))
         sess = Session.from_message(parsed_message)
         if sess.session_id != "default": # 'default' can only be updated by core
             SessionManager.update(sess)
@@ -188,6 +256,7 @@ class MessageBusClient:
             msg = message.serialize()
         else:
             msg = json_dumps(message.__dict__)
+        msg = _maybe_encrypt(msg)
         try:
             self.client.send(msg)
         except WebSocketConnectionClosedException:
@@ -406,9 +475,9 @@ class GUIWebsocketClient(MessageBusClient):
 
         try:
             if hasattr(message, 'serialize'):
-                self.client.send(message.serialize())
+                self.client.send(_maybe_encrypt(message.serialize()))
             else:
-                self.client.send(json_dumps(message.__dict__))
+                self.client.send(_maybe_encrypt(json_dumps(message.__dict__)))
         except WebSocketConnectionClosedException:
             LOG.warning('Could not send %s message because connection '
                         'has been closed', message.msg_type)
@@ -431,5 +500,5 @@ class GUIWebsocketClient(MessageBusClient):
 
         self.emitter.emit('message', message)
 
-        parsed_message = GUIMessage.deserialize(message)
+        parsed_message = GUIMessage.deserialize(_maybe_decrypt(message))
         self.emitter.emit(parsed_message.msg_type, parsed_message)

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -43,7 +43,9 @@ def _encryption_keys():
     from ovos_config.config import Configuration
     cfg = Configuration().get("websocket", {})
     secret = cfg.get("secret_key")
-    allow_clear = cfg.get("allow_unencrypted", secret is None)
+    # Empty/missing secret are equivalent — both disable the scheme;
+    # honour the same default for ``allow_unencrypted`` in either case.
+    allow_clear = cfg.get("allow_unencrypted", not secret)
     return secret, allow_clear
 
 
@@ -68,7 +70,7 @@ def _maybe_decrypt(raw):
     suitable for :meth:`Message.deserialize`. Honours
     ``websocket.allow_unencrypted``."""
     secret, allow_clear = _encryption_keys()
-    if secret is None:
+    if not secret:
         return raw
     if isinstance(raw, (bytes, bytearray)):
         raw = raw.decode("utf-8")

--- a/ovos_bus_client/message.py
+++ b/ovos_bus_client/message.py
@@ -6,23 +6,25 @@
 
 The OVOS-MSG-1 envelope lives in :mod:`ovos_spec_tools.message`; this
 module re-exports it directly — no subclass, no wrapping — and attaches
-the legacy bus-client conveniences downstream still uses
-(:meth:`Message.publish`, plus encryption-aware ``serialize`` /
-``deserialize``) to the class at import time. Everything else
-(:class:`CollectionMessage`, :class:`GUIMessage`,
-:func:`dig_for_message`, the encryption helpers) stays in this module
-on top of the same class.
+exactly one legacy bus-client convenience (:meth:`Message.publish`) to
+the class at import time. ``Message.serialize`` / ``Message.deserialize``
+are inherited unchanged from the spec implementation: they produce and
+consume plain JSON, with no transport-layer concerns mixed in.
+Everything else (:class:`CollectionMessage`, :class:`GUIMessage`,
+:func:`dig_for_message`, the encryption helpers below) stays in this
+module on top of the same class.
 
+OVOS-MSG-1 is transport-agnostic and says nothing about encryption (§7).
 An optional **layer-2 encryption scheme** ships with this package, but it
 lives at the **transport edge** (:class:`ovos_bus_client.client.MessageBusClient`
-``emit`` / ``on_message``), not on the :class:`Message` class itself.
-OVOS-MSG-1 is transport-agnostic and says nothing about encryption (§7);
-bolting AES (GCM) onto the JSON envelope is purely additive on top of the
-spec, and the matching key-setup / key-exchange side was never formally
-implemented — so the scheme is **deprecated** and the websocket client
-emits a ``DeprecationWarning`` whenever it fires. The
-:func:`encrypt_as_dict` / :func:`decrypt_from_dict` helpers stay at module
-level for any consumer that imported them directly.
+``emit`` / ``on_message`` — see ``_maybe_encrypt`` / ``_maybe_decrypt``
+there), not on :class:`Message`. Bolting AES (GCM) onto the JSON
+envelope is purely additive on top of the spec, and the matching
+key-setup / key-exchange side was never formally implemented — so the
+scheme is **deprecated** and the websocket client emits a
+``DeprecationWarning`` whenever it fires. The :func:`encrypt_as_dict` /
+:func:`decrypt_from_dict` helpers stay at module level for any consumer
+that imported them directly.
 """
 import inspect
 import json

--- a/ovos_bus_client/message.py
+++ b/ovos_bus_client/message.py
@@ -6,17 +6,23 @@
 
 The OVOS-MSG-1 envelope lives in :mod:`ovos_spec_tools.message`; this
 module re-exports it directly — no subclass, no wrapping — and attaches
-the one legacy convenience method downstream still uses
-(:meth:`Message.publish`) to the class at import time. Everything else
-(:class:`CollectionMessage`, :class:`GUIMessage`, :func:`dig_for_message`,
-the encryption helpers) stays in this module on top of the same class.
+the legacy bus-client conveniences downstream still uses
+(:meth:`Message.publish`, plus encryption-aware ``serialize`` /
+``deserialize``) to the class at import time. Everything else
+(:class:`CollectionMessage`, :class:`GUIMessage`,
+:func:`dig_for_message`, the encryption helpers) stays in this module
+on top of the same class.
 
-Transport-layer encryption is no longer wired into :meth:`Message.serialize`
-/ :meth:`Message.deserialize` — encryption is a transport concern that
-belongs in the websocket :class:`~ovos_bus_client.client.client.MessageBusClient`,
-not on the envelope (OVOS-MSG-1 §7 non-goals). The
-:func:`encrypt_as_dict` / :func:`decrypt_from_dict` helpers stay at
-module level for any consumer that imported them directly.
+An optional **layer-2 encryption scheme** ships with this package, but it
+lives at the **transport edge** (:class:`ovos_bus_client.client.MessageBusClient`
+``emit`` / ``on_message``), not on the :class:`Message` class itself.
+OVOS-MSG-1 is transport-agnostic and says nothing about encryption (§7);
+bolting AES (GCM) onto the JSON envelope is purely additive on top of the
+spec, and the matching key-setup / key-exchange side was never formally
+implemented — so the scheme is **deprecated** and the websocket client
+emits a ``DeprecationWarning`` whenever it fires. The
+:func:`encrypt_as_dict` / :func:`decrypt_from_dict` helpers stay at module
+level for any consumer that imported them directly.
 """
 import inspect
 import json
@@ -106,6 +112,15 @@ def _publish(self, msg_type: str, data: Dict[str, Any],
 # or from ovos_utils.fakebus — without forcing a subclass or breaking
 # isinstance checks across the ecosystem.
 Message.publish = _publish
+
+
+# --- legacy envelope-level encryption helpers (deprecated) -----------------
+#
+# These are kept at module level for any consumer that imported them
+# directly. The websocket transport (:class:`ovos_bus_client.client.
+# MessageBusClient`) uses them at its send/receive edges when
+# ``websocket.secret_key`` is configured; the :class:`Message` class
+# itself stays pure JSON.
 
 
 def encrypt_as_dict(key: str, data: str, nonce=None) -> dict:
@@ -357,14 +372,10 @@ class GUIMessage(Message):
         super().__init__(msg_type, data=kwargs)
 
     def serialize(self) -> str:
-        """
-        Serialize the message into the GUI wire-format with message fields flattened to the top level.
-        
-        Nested objects that implement a `.serialize()`-compatible representation are converted via Message._to_jsonable before flattening.
-        
-        Returns:
-            JSON string where `type` is the message type and the message `data` fields are top-level keys.
-        """
+        """Serialize the message into the GUI wire-format with message
+        fields flattened to the top level. Returns plain JSON; the
+        transport layer applies the deprecated envelope encryption when
+        ``websocket.secret_key`` is configured."""
         data = Message._to_jsonable(self.data)
         return json_dumps({"type": self.msg_type, **data})
 

--- a/test/unittests/test_client_encryption.py
+++ b/test/unittests/test_client_encryption.py
@@ -1,0 +1,87 @@
+"""Layer-2 envelope encryption at the websocket transport edge.
+
+OVOS-MSG-1 is transport-agnostic; the encryption scheme tested here is
+bolted on top by ``ovos_bus_client.client.client`` and is deprecated.
+These tests pin the deprecated-but-supported behaviour: with
+``websocket.secret_key`` set, outbound frames are AES-wrapped and
+inbound AES-wrapped frames round-trip back. With no key set, the wire
+remains plain JSON and no warning fires.
+"""
+import json
+import unittest
+import warnings
+from unittest import TestCase
+
+from ovos_bus_client.message import Message
+
+try:
+    import pycryptodomex  # noqa: F401
+    _HAS_CRYPTO = True
+except ImportError:  # pragma: no cover
+    try:
+        import Cryptodome  # noqa: F401
+        _HAS_CRYPTO = True
+    except ImportError:
+        _HAS_CRYPTO = False
+
+
+@unittest.skipUnless(_HAS_CRYPTO, "pycryptodomex not installed")
+class TestTransportEncryption(TestCase):
+    """Monkey-patches :func:`_encryption_keys` on the client module to
+    avoid touching the global ``Configuration()`` singleton (which does
+    not restore cleanly across tests)."""
+
+    def _patch_keys(self, secret, allow_clear):
+        from ovos_bus_client.client import client as _cli
+        self._orig = _cli._encryption_keys
+        _cli._encryption_keys = lambda: (secret, allow_clear)
+        self.addCleanup(setattr, _cli, "_encryption_keys", self._orig)
+
+    def test_maybe_encrypt_wraps_when_secret_set(self):
+        from ovos_bus_client.client.client import _maybe_encrypt
+        self._patch_keys("0123456789abcdef", False)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            wire = _maybe_encrypt('{"type":"t","data":{},"context":{}}')
+        env = json.loads(wire)
+        self.assertIn("ciphertext", env)
+        self.assertIn("nonce", env)
+        deps = [w for w in caught
+                if issubclass(w.category, DeprecationWarning)
+                and "envelope encryption" in str(w.message).lower()]
+        self.assertTrue(deps)
+
+    def test_round_trip_through_transport_helpers(self):
+        from ovos_bus_client.client.client import (_maybe_encrypt,
+                                                    _maybe_decrypt)
+        self._patch_keys("0123456789abcdef", False)
+        m = Message("ovos.test", {"k": "v"}, {"source": "S"})
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            wire = _maybe_encrypt(m.serialize())
+            recovered = Message.deserialize(_maybe_decrypt(wire))
+        self.assertEqual(recovered.msg_type, "ovos.test")
+        self.assertEqual(recovered.data, {"k": "v"})
+        self.assertEqual(recovered.context["source"], "S")
+
+    def test_maybe_decrypt_refuses_plaintext_when_disallowed(self):
+        from ovos_bus_client.client.client import _maybe_decrypt
+        self._patch_keys("0123456789abcdef", False)
+        with self.assertRaises(RuntimeError):
+            _maybe_decrypt('{"type":"t","data":{},"context":{}}')
+
+    def test_no_secret_is_passthrough_and_silent(self):
+        from ovos_bus_client.client.client import (_maybe_encrypt,
+                                                    _maybe_decrypt)
+        self._patch_keys(None, True)
+        plaintext = '{"type":"t","data":{},"context":{}}'
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self.assertEqual(_maybe_encrypt(plaintext), plaintext)
+            self.assertEqual(_maybe_decrypt(plaintext), plaintext)
+        self.assertFalse([w for w in caught
+                          if issubclass(w.category, DeprecationWarning)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
OVOS-MSG-1 is transport-agnostic (§7) — the spec envelope says nothing about encryption. The pre-spec-tools envelope-level AES wrapper (triggered when `websocket.secret_key` is set) was dropped in #215; this PR restores it, but at its correct home: the **websocket transport** (`MessageBusClient.emit` / `on_message` and the matching `GUIWebsocketClient` overrides), not on `Message.serialize` / `Message.deserialize`.

## What lives where now

- `ovos_bus_client.message.Message` stays a pure re-export of `ovos_spec_tools.message.Message`. Only `publish` remains attached (with its existing deprecation).
- `encrypt_as_dict` / `decrypt_from_dict` still exported from `ovos_bus_client.message` for any direct importer.
- `MessageBusClient` and `GUIWebsocketClient` gain two small helpers — `_maybe_encrypt` (post-serialize, pre-send) and `_maybe_decrypt` (post-receive, pre-deserialize). When `websocket.secret_key` is configured both emit a `DeprecationWarning` and apply the legacy AES envelope; otherwise they pass through unchanged.

## Behavioural compatibility

For websocket consumers: identical to pre-#215 — outbound frames are AES-wrapped and inbound encrypted frames round-trip back, controlled by `websocket.secret_key` + `websocket.allow_unencrypted` exactly as before.

Direct callers of `Message.serialize()` no longer get AES-wrapped output. Acceptable break under the existing deprecation: encryption is a transport concern (the spec is transport-agnostic), and the matching key-setup half of this scheme was never formally implemented — hence the deprecation.

## Tests

`test/unittests/test_client_encryption.py` pins:
- `_maybe_encrypt` wraps when secret is set + fires DeprecationWarning
- full round-trip through the transport helpers
- `_maybe_decrypt` refuses plaintext when `allow_unencrypted=False`
- no secret ⇒ passthrough, no warning

Full suite: 553 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional encryption support for websocket transport communication (deprecated feature with backward compatibility)

* **Documentation**
  * Updated module documentation to clarify encryption behavior and configuration options at the transport layer

* **Tests**
  * Added comprehensive test suite validating encryption functionality, including round-trip validation and configuration handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-bus-client/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->