### PR TITLE
docs: surface the architecture repo and state MSG-1 conformance precisely

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Python client for the OVOS messagebus. Connect to OVOS, emit messages, and rea
 
 The OVOS messagebus is the **nervous system** of an OVOS install. Every component — STT, intent parsing, skills, TTS, audio, GUI — talks over it. This package is the Python client.
 
+> **[OVOS-MSG-1](https://github.com/OpenVoiceOS/architecture/blob/dev/msg-1.md) conformance.** `ovos_bus_client.Message` re-exports the [`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools) reference implementation directly, so the envelope (`type` / `data` / `context`), unknown-key tolerance, and the `forward` / `reply` / `response` derivations — including the routing-pair swap on `reply` — match the spec. Two divergences remain open, tracked in the [architecture appendix](https://github.com/OpenVoiceOS/architecture/blob/dev/appendix/divergences.md#53-prescriptive-shape-changes): `destination` still accepts an array (spec: single string only) and this package still ships the `ovos.session.sync` / `ovos.session.update_default` session-push topics the spec defines no home for (removal scope: [§5.5](https://github.com/OpenVoiceOS/architecture/blob/dev/appendix/divergences.md#removed-mechanisms--session-push-topics)). Poll correlation via `context.utterance_id` (OVOS-PIPELINE-1 §9.1.1) is not yet implemented. This package supplies the websocket transport, the session manager, and the high-level APIs on top of the spec.
+
 > ⚠️ **The bus is private.** It has **no authentication** — every connected client can issue any natural-language command, speak through the speakers, take over any subsystem, and read every other client's traffic. **Keep it bound to `127.0.0.1`** (the default), never expose it on a network interface, and never put it behind a reverse proxy. For remote access, use [HiveMind](https://github.com/JarbasHiveMind), which adds encryption, identity, and policy enforcement on top.
 
 ## Install
@@ -89,6 +91,8 @@ Full developer docs live in [`docs/`](docs/):
 
 ## Related
 
+- [**OVOS Architecture**](https://github.com/OpenVoiceOS/architecture) — formal, implementation-agnostic specifications for OVOS. The Message-Object spec ([OVOS-MSG-1](https://github.com/OpenVoiceOS/architecture/blob/dev/msg-1.md)) is the contract this client conforms to.
+- [**ovos-spec-tools**](https://github.com/OpenVoiceOS/ovos-spec-tools) — reference implementations of the architecture specs. `ovos_bus_client.Message` re-exports `ovos_spec_tools.message.Message`.
 - [**ovos-pydantic-models**](https://github.com/OpenVoiceOS/ovos-pydantic-models) — authoritative Pydantic v2 index of every OVOS bus message type. Opt-in validation layer for typing, docs generation, and integration tests. Browsable docs: <https://openvoiceos.github.io/ovos-pydantic-models/>.
 - [**HiveMind**](https://github.com/JarbasHiveMind) — external-access layer in front of the bus; the right tool for remote clients.
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -153,9 +153,9 @@ applications generally do not instantiate it directly.
 
 ## Deprecated transport-edge encryption
 
-[OVOS-MSG-1](https://github.com/OpenVoiceOS/architecture/blob/master/message-object.md)
+[OVOS-MSG-1](https://github.com/OpenVoiceOS/architecture/blob/dev/msg-1.md)
 is transport-agnostic
-([§1 Scope](https://github.com/OpenVoiceOS/architecture/blob/master/message-object.md#1-scope)
+([§1 Scope](https://github.com/OpenVoiceOS/architecture/blob/dev/msg-1.md#1-scope)
 explicitly excludes encryption from the spec): the message envelope does not
 define encryption. `ovos-bus-client` bolts a legacy AES-GCM wrapper on top at
 the transport edge, controlled by `websocket.secret_key` in your OVOS config.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -3,6 +3,23 @@
 What the OVOS bus actually is, what travels over it, and which pieces live in
 `ovos-bus-client`.
 
+> **Specification.** The Message envelope, routing keys, session carrier and
+> derivations described on this page are normatively defined by
+> [**OVOS-MSG-1**](https://github.com/OpenVoiceOS/architecture/blob/dev/msg-1.md)
+> in the [OVOS Architecture](https://github.com/OpenVoiceOS/architecture) repo.
+> `ovos_bus_client.Message` re-exports the reference implementation in
+> [`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools) directly,
+> so the envelope shape, unknown-key tolerance, and the `forward` / `reply` /
+> `response` derivations match the spec. The session-carrier wire shape is now
+> normatively owned by [**OVOS-SESSION-1**](https://github.com/OpenVoiceOS/architecture/blob/dev/session-1.md),
+> and the `IntentContextManager` sub-object by
+> [**OVOS-CONTEXT-1**](https://github.com/OpenVoiceOS/architecture/blob/dev/intent-context.md) —
+> both merged. Known divergences from full conformance are catalogued in the
+> [architecture appendix §5](https://github.com/OpenVoiceOS/architecture/blob/dev/appendix/divergences.md#5-where-the-specs-differ-from-the-reference-implementation):
+> `destination` still accepts an array, the `ovos.session.sync` /
+> `ovos.session.update_default` push topics are slated for V1 removal, and
+> `context.utterance_id` poll correlation is not yet implemented.
+
 ## The bus is OVOS's nervous system — and it is private
 
 Before anything else: **the OVOS bus is the nervous system of the assistant**.

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -2,7 +2,7 @@
 
 Reference for the `Message` class and its helpers. The envelope shape, routing
 keys, session carrier and derivations are normatively defined by
-[**OVOS-MSG-1**](https://github.com/OpenVoiceOS/architecture/blob/master/message-object.md);
+[**OVOS-MSG-1**](https://github.com/OpenVoiceOS/architecture/blob/dev/msg-1.md);
 the implementation here is a re-export of
 [`ovos_spec_tools.message.Message`](https://github.com/OpenVoiceOS/ovos-spec-tools)
 with `publish` attached for back-compat.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -63,7 +63,7 @@ and consume pure JSON — they have never encrypted or decrypted the envelope.
 The legacy AES-GCM wrapper (controlled by
 [`websocket.secret_key`](configuration.md#deprecated-websocketsecret_key-and-websocketallow_unencrypted))
 was always a transport-level concern
-([OVOS-MSG-1 §1 Scope](https://github.com/OpenVoiceOS/architecture/blob/master/message-object.md#1-scope)
+([OVOS-MSG-1 §1 Scope](https://github.com/OpenVoiceOS/architecture/blob/dev/msg-1.md#1-scope)
 explicitly excludes encryption from the message-object spec); it is now
 explicitly placed at the transport edge inside
 [`MessageBusClient` and `GUIWebsocketClient`](client.md)

--- a/docs/session.md
+++ b/docs/session.md
@@ -2,6 +2,24 @@
 
 Session state is the primary mechanism by which OVOS tracks per-user, per-device conversation context across the intent pipeline, skills, chat agents, and HiveMind agents.
 
+`session` rides in `Message.context` per
+[OVOS-MSG-1 §4 The session carrier](https://github.com/OpenVoiceOS/architecture/blob/dev/msg-1.md#4-the-session-carrier),
+which fixes only its existence and propagation rule across `forward` /
+`reply` / `response`. Its wire shape and field set are owned by
+[**OVOS-SESSION-1**](https://github.com/OpenVoiceOS/architecture/blob/dev/session-1.md),
+which defines `session_id` and `lang` as the normative fields. Everything
+else on the `Session` class below (pipeline, site_id, `IntentContextManager`,
+persona, preferences) is a layer-2 extension carried in the same
+`context.session` dict; SESSION-1 treats those keys as opaque pass-through.
+The `IntentContextManager` sub-object is normatively covered by
+[**OVOS-CONTEXT-1**](https://github.com/OpenVoiceOS/architecture/blob/dev/intent-context.md).
+
+This package still ships two session-push mechanisms —
+`SessionManager.handle_session_sync` and the `_broadcast_default_session`
+bootstrap in `client.py` — that no spec defines a topic for; SESSION-2 makes
+the session client-authoritative instead. Both are in the V1 removal scope
+per the [architecture appendix](https://github.com/OpenVoiceOS/architecture/blob/dev/appendix/divergences.md#removed-mechanisms--session-push-topics).
+
 ## Session
 
 `Session` — `ovos_bus_client/session.py:263`


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting. The conformance statement below was checked against `ovos_bus_client/message.py` and `ovos_bus_client/session.py` at HEAD, and against the merged OVOS-MSG-1 / SESSION-1 / SESSION-2 specs and appendix divergence catalogue in OpenVoiceOS/architecture (dev). Not independently re-verified by a human.

Follow-up to #218. The OVOS-MSG-1 spec batch has now merged in the architecture repo, so this PR surfaces it — but the original blanket "conforms to OVOS-MSG-1" claim did not survive that merge intact. This revision states conformance precisely instead: what the code does today, and where the appendix tracks what it does not yet do.

## Changes

- **README.md** — top-level callout: `ovos_bus_client.Message` re-exports the `ovos-spec-tools` reference implementation directly, so the envelope, unknown-key tolerance, and `forward`/`reply`/`response` derivations (including the routing-pair swap) match OVOS-MSG-1. Lists the open divergences (destination arrays, session-push topics, `utterance_id` correlation) with a link to the appendix catalogue. Related section keeps OVOS Architecture and ovos-spec-tools alongside ovos-pydantic-models and HiveMind.
- **docs/concepts.md** — same precise statement, plus links to the now-merged OVOS-SESSION-1 and OVOS-CONTEXT-1 (previously linked as in-review PRs; both merged since).
- **docs/session.md** — session carrier ownership split between MSG-1 (existence/propagation) and SESSION-1 (wire shape); flags that this package still ships `handle_session_sync` / `_broadcast_default_session`, which the appendix scopes for V1 removal.

No code changes. Docs only; no docs-build CI in this repo to gate on (checked `.github/workflows/lint.yml` — ruff only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
