### PR TITLE
fix: emit mycroft.scheduler.update_event so update_scheduled_event reaches the scheduler

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,15 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `1.5.0 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## 2.8.5a2
+
+`EventSchedulerInterface.update_scheduled_event()` emitted
+`mycroft.schedule.update_event`, but the scheduler
+(`ovos_bus_client.util.scheduler.EventScheduler`) only ever listened on
+`mycroft.scheduler.update_event`. The topic mismatch made the call a silent
+no-op: no error, the event just never updated. Fixed by emitting the
+spelling the scheduler actually listens on.
+
 ## 2.8.4a3
 
 Importing `ovos_bus_client.session` no longer emits an ovos-config

--- a/ovos_bus_client/apis/events.py
+++ b/ovos_bus_client/apis/events.py
@@ -165,7 +165,7 @@ class EventSchedulerInterface:
             'data': data or {}
         }
         message = self._get_source_message()
-        self.bus.emit(message.forward('mycroft.schedule.update_event', data))
+        self.bus.emit(message.forward('mycroft.scheduler.update_event', data))
 
     def cancel_scheduled_event(self, name: str):
         """

--- a/test/unittests/test_events_api.py
+++ b/test/unittests/test_events_api.py
@@ -112,7 +112,7 @@ class TestUpdateAndCancel(TestCase):
     def test_update_scheduled_event(self):
         self.api.update_scheduled_event("t1", data={"new": True})
         emitted = self.bus.emit.call_args[0][0]
-        self.assertEqual(emitted.msg_type, "mycroft.schedule.update_event")
+        self.assertEqual(emitted.msg_type, "mycroft.scheduler.update_event")
         self.assertEqual(emitted.data["event"], "my.skill:t1")
         self.assertEqual(emitted.data["data"], {"new": True})
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

`EventSchedulerInterface.update_scheduled_event()` in `ovos_bus_client/apis/events.py` emitted the topic `mycroft.schedule.update_event` (missing the "r" in "scheduler"). The server-side listener in `ovos_bus_client/util/scheduler.py`, `EventScheduler`, registers its handler on `mycroft.scheduler.update_event`. Because the producer and the listener never agreed on a spelling, calling `update_scheduled_event()` was a silent no-op: no exception, the scheduled event just never got updated.

The fix changes the emitted topic to `mycroft.scheduler.update_event`, matching what the scheduler actually listens on. This is a one-line change plus the matching test-assertion update.

Fail-before evidence: reverting only the source-file hunk and running `test/unittests/test_events_api.py::TestUpdateAndCancel::test_update_scheduled_event` fails with `AssertionError: 'mycroft.schedule.update_event' != 'mycroft.scheduler.update_event'`. Restoring the fix makes it pass. The full unit test suite (`test/unittests`) passes with the fix applied: 806 passed, 6 skipped, 112 subtests passed, no failures.

Verified by reading and executing code on `origin/dev`: the emit call site and the scheduler's `bus.on(...)` registration both exist as described above, and the mismatch is real and unresolved on `dev` today. A `docs/prerelease-quirks.md` entry was added under the next alpha heading (`2.8.5a2`) describing the quirk and the fix.
