### PR TITLE
fix: ignore non-exception websocket on_error callbacks (#223)

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -178,6 +178,16 @@ class MessageBusClient:
             error = args[0]
         else:
             error = args[1]
+        # websocket-client may invoke on_error with a non-exception object
+        # (e.g. a websocket._abnf.ABNF control frame) that is not a connection
+        # error. Wrapping it in a RuntimeError and re-emitting used to trigger a
+        # spurious close()+reconnect cycle that could stall an in-progress
+        # handshake. A non-exception callback is not a fatal error: log and
+        # return without tearing the connection down.
+        if not isinstance(error, BaseException):
+            LOG.debug("ignoring non-exception websocket error callback: %r",
+                      error)
+            return
         if isinstance(error, WebSocketConnectionClosedException):
             LOG.warning('Could not send message because connection has closed')
         elif isinstance(error, ConnectionRefusedError):
@@ -186,8 +196,6 @@ class MessageBusClient:
             LOG.warning('Connection Reset. Did the Messagebus Service stop?')
         else:
             LOG.exception('=== %s ===', repr(error))
-            if not isinstance(error, BaseException):
-                error = RuntimeError(repr(error))
             try:
                 self.emitter.emit('error', error)
             except Exception as e:

--- a/test/unittests/test_client_more.py
+++ b/test/unittests/test_client_more.py
@@ -63,6 +63,26 @@ class TestOnError(TestCase):
         # websocket-client sometimes passes (ws, error); the code reads args[1]
         bus.on_error(MagicMock(), RuntimeError("from-two-args"))
 
+    @patch("ovos_bus_client.client.client.time.sleep", MagicMock())
+    def test_non_exception_is_ignored(self):
+        # regression for #223: websocket-client may invoke on_error with a
+        # non-exception object (e.g. a websocket._abnf.ABNF control frame).
+        # It must NOT raise, must NOT emit an 'error' event, and must NOT
+        # trigger a reconnect (no close, no 'reconnecting' event).
+        bus = _mocked_client()
+        bus.client.keep_running = True  # would close() if reconnect ran
+        bus.create_client = MagicMock(return_value=MagicMock())
+        bus.run_forever = MagicMock(side_effect=WebSocketException())
+        errors = []
+        reconnecting = []
+        bus.emitter.on("error", lambda e: errors.append(e))
+        bus.emitter.on("reconnecting", lambda *a: reconnecting.append(True))
+        for non_exc in (b"\x88\x02\x03\xe8", object(), "not-an-error", 42):
+            bus.on_error(non_exc)  # must not raise
+        self.assertEqual(errors, [])
+        self.assertEqual(reconnecting, [])
+        bus.client.close.assert_not_called()
+
 
 class TestOnDefaultSessionUpdate(TestCase):
     def test_replaces_default_session(self):


### PR DESCRIPTION
## Problem

`MessageBusClient.on_error` assumed its `error` argument was always an `Exception`. With current `websocket-client` (observed on 1.9.0), `on_error` can be invoked with a non-exception object — e.g. a `websocket._abnf.ABNF` control/close frame.

The old code wrapped that frame in `RuntimeError(repr(frame))` and re-emitted it; pyee's default error handling re-raised it on the read-loop thread, killing the client mid-handshake and triggering a spurious `close()` + reconnect cycle (a reconnect storm that stalls the connection).

## Fix

In `on_error` (`ovos_bus_client/client/client.py`), if `error` is not a `BaseException`, `LOG.debug(...)` and `return` early — a non-exception callback is not a fatal error and must not tear the connection down or reconnect. Also drops the now-dead `RuntimeError` wrap in the else branch.

## Test

Adds `test_non_exception_is_ignored` (regression for #223) in `test/unittests/test_client_more.py`: calling `on_error` with non-exception args (bytes ABNF frame, plain `object()`, str, int) must not raise, must not emit an `error` event, and must not trigger a reconnect (no `close()`, no `reconnecting` event).

Local: full suite green — 548 passed, 6 skipped (websocket-client 1.9.0, py3.13).

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed websocket error handler to gracefully handle non-exception control frames during handshake instead of triggering unnecessary reconnection cycles.

* **Tests**
  * Added regression test to verify non-exception values are properly handled without emitting error or reconnection events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->