### PR TITLE
refactor: deprecate EnclosureAPI (moved to ovos-gui-api-client)

### DIFF
--- a/ovos_bus_client/apis/enclosure.py
+++ b/ovos_bus_client/apis/enclosure.py
@@ -1,20 +1,37 @@
+import warnings
+
+from ovos_utils.log import deprecated
+
 from ovos_bus_client.message import Message, dig_for_message
+from ovos_bus_client.version import VERSION_MAJOR
+
+_REMOVED_IN = f"{VERSION_MAJOR + 1}.0.0"
+_MOVED_TO = ("EnclosureAPI moved to ovos-gui-api-client; import it from "
+             "`ovos_gui_api_client` instead")
 
 
 class EnclosureAPI:
     """
-    This API is intended to be used to interface with the hardware
-    that is running Mycroft.  It exposes all possible commands which
-    can be sent to a Mycroft enclosure implementation.
+    DEPRECATED — use ``EnclosureAPI`` from ``ovos-gui-api-client``.
 
-    Different enclosure implementations may implement this differently
-    and/or may ignore certain API calls completely.  For example,
-    the eyes_color() API might be ignore on a Mycroft that uses simple
-    LEDs which only turn on/off, or not at all on an implementation
-    where there is no face at all.
+    It lives there alongside ``GUIInterface`` so a skill's ``self.gui`` and
+    ``self.enclosure`` come from the same client::
+
+        from ovos_gui_api_client import EnclosureAPI
+
+    The Mark-1 ``enclosure.*`` protocol it drives is consumed by hardware
+    plugins via ``EnclosureProtocolListener`` (``ovos-ui-enclosure-protocol``);
+    visual output goes through ``GUIInterface`` (OVOS-GUI-1).
+
+    This API exposes all commands that can be sent to a Mycroft-style enclosure.
+    Different enclosure implementations may implement this differently and/or
+    may ignore certain API calls completely.
     """
 
+    @deprecated(_MOVED_TO, _REMOVED_IN)
     def __init__(self, bus=None, skill_id=""):
+        warnings.warn(f"{_MOVED_TO} (removed in ovos-bus-client {_REMOVED_IN})",
+                      DeprecationWarning, stacklevel=2)
         self.bus = bus
         self.skill_id = skill_id
 

--- a/test/unittests/test_enclosure_api.py
+++ b/test/unittests/test_enclosure_api.py
@@ -1,5 +1,6 @@
 """Coverage tests for ovos_bus_client.apis.enclosure — EnclosureAPI emitters."""
 import unittest
+import warnings
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -9,6 +10,30 @@ from ovos_bus_client.message import Message
 
 def _last_emitted(bus) -> Message:
     return bus.emit.call_args[0][0]
+
+
+class TestEnclosureAPIDeprecation(TestCase):
+    def test_init_warns_pointing_at_new_home(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            EnclosureAPI(bus=MagicMock(), skill_id="s")
+        deprecations = [w for w in caught
+                        if issubclass(w.category, DeprecationWarning)]
+        self.assertTrue(deprecations)
+        msg = str(deprecations[0].message)
+        self.assertIn("ovos-gui-api-client", msg)
+        # removal version is derived from version.py (next major), not hardcoded
+        from ovos_bus_client.version import VERSION_MAJOR
+        self.assertIn(f"{VERSION_MAJOR + 1}.0.0", msg)
+
+    def test_shim_still_functional(self):
+        # the shim must keep working despite the deprecation
+        bus = MagicMock()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            api = EnclosureAPI(bus=bus, skill_id="s")
+        api.eyes_on()
+        self.assertEqual(_last_emitted(bus).msg_type, "enclosure.eyes.on")
 
 
 class TestEnclosureAPIBasics(TestCase):


### PR DESCRIPTION
`EnclosureAPI` moved to [`ovos-gui-api-client`](https://github.com/OpenVoiceOS/ovos-gui-api-client) alongside `GUIInterface`, so a skill's `self.gui` and `self.enclosure` come from one client.

This keeps `ovos_bus_client.apis.enclosure.EnclosureAPI` as a **working compatibility shim**: existing imports keep functioning, and instantiation now emits a `DeprecationWarning` pointing at the new home. It cannot simply re-export the new location because `ovos-gui-api-client` depends on `ovos-bus-client` — a re-export would be circular — so the implementation stays here, deprecated, until a future major release removes it.

Adds tests asserting the warning fires (pointing at `ovos-gui-api-client`) and that the shim still emits the `enclosure.*` messages. Full enclosure suite green (34 passed).

Scoped to enclosure only (1-file-1-PR); intentionally does **not** carry the separate template-GUI rework that the stale #197 branch entangles. Part of the enclosure→GUI migration.