### PR TITLE
feat: namespace migration via MessageBusClient — both flags on + handler dedup

### DIFF
--- a/docs/namespace-migration.md
+++ b/docs/namespace-migration.md
@@ -1,0 +1,43 @@
+# Bus namespace migration
+
+OVOS is moving its bus topics to the canonical `ovos.*` namespace defined by the
+specifications (see `ovos_spec_tools.SpecMessage` and `MIGRATION_MAP`). To let a
+mixed fleet — where services and HiveMind satellites upgrade at different times —
+interoperate during the transition, `MessageBusClient` can translate topics
+**on emit**, in either direction. The goal is for every service to emit and
+listen on the `ovos.*` topics; these flags bridge the gap until then.
+
+Both flags are **off by default** and **orthogonal** — enable whichever a node
+needs. They operate purely on emit; `on()` is unchanged.
+
+## `modernize` — legacy → spec
+
+When a node still emits a *legacy* topic (e.g. it runs older code), also emit the
+`ovos.*` spec counterpart, so spec-native listeners receive the event.
+
+- env: `OVOS_BUS_MODERNIZE=true`
+- config: `{"websocket": {"modernize": true}}`
+
+Emitting `speak` also puts `ovos.utterance.speak` on the bus.
+
+## `emit_legacy` — spec → legacy
+
+When a node emits a *spec* topic (it has migrated), also emit the legacy
+counterpart, so not-yet-migrated listeners still receive the event.
+
+- env: `OVOS_BUS_EMIT_LEGACY=true`
+- config: `{"websocket": {"emit_legacy": true}}`
+
+Emitting `ovos.utterance.handle` also puts `recognizer_loop:utterance` on the bus.
+
+## Important: listen on one namespace
+
+There is **no listener-side translation and no de-duplication**. Each listener
+must subscribe to exactly one namespace for a given event. If a single handler is
+registered on *both* the legacy and the spec topic while the matching emit flag is
+on, it will run **twice** per event. Migrate a listener by switching its
+subscription from the legacy topic to the spec topic — do not subscribe to both.
+
+Only payload-compatible renames are translated (`MIGRATION_MAP`); topics whose
+payload shape also changes (e.g. the handler-lifecycle trio) are not translated
+and must be migrated at the call site.

--- a/docs/namespace-migration.md
+++ b/docs/namespace-migration.md
@@ -1,43 +1,46 @@
 # Bus namespace migration
 
 OVOS is moving its bus topics to the canonical `ovos.*` namespace defined by the
-specifications (see `ovos_spec_tools.SpecMessage` and `MIGRATION_MAP`). To let a
-mixed fleet — where services and HiveMind satellites upgrade at different times —
-interoperate during the transition, `MessageBusClient` can translate topics
-**on emit**, in either direction. The goal is for every service to emit and
-listen on the `ovos.*` topics; these flags bridge the gap until then.
+specifications (see `ovos_spec_tools.SpecMessage` and `MIGRATION_MAP`).
+`MessageBusClient` bridges the transition so a mixed fleet — services and
+HiveMind satellites that upgrade at different times — keeps working, and so
+**any repo can migrate its emit or its listen to `ovos.*` independently, in any
+order, with no coordination.**
 
-Both flags are **off by default** and **orthogonal** — enable whichever a node
-needs. They operate purely on emit; `on()` is unchanged.
+## Two emit-side flags (both ON by default)
 
-## `modernize` — legacy → spec
+During the migration window both are on, so every migrated event travels on
+**both** the legacy and the `ovos.*` topic.
 
-When a node still emits a *legacy* topic (e.g. it runs older code), also emit the
-`ovos.*` spec counterpart, so spec-native listeners receive the event.
-
-- env: `OVOS_BUS_MODERNIZE=true`
-- config: `{"websocket": {"modernize": true}}`
-
-Emitting `speak` also puts `ovos.utterance.speak` on the bus.
-
-## `emit_legacy` — spec → legacy
-
-When a node emits a *spec* topic (it has migrated), also emit the legacy
-counterpart, so not-yet-migrated listeners still receive the event.
-
-- env: `OVOS_BUS_EMIT_LEGACY=true`
-- config: `{"websocket": {"emit_legacy": true}}`
-
-Emitting `ovos.utterance.handle` also puts `recognizer_loop:utterance` on the bus.
-
-## Important: listen on one namespace
-
-There is **no listener-side translation and no de-duplication**. Each listener
-must subscribe to exactly one namespace for a given event. If a single handler is
-registered on *both* the legacy and the spec topic while the matching emit flag is
-on, it will run **twice** per event. Migrate a listener by switching its
-subscription from the legacy topic to the spec topic — do not subscribe to both.
+| Flag | env | config (`websocket`) | Effect |
+|---|---|---|---|
+| `modernize` | `OVOS_BUS_MODERNIZE` | `modernize` | emitting a *legacy* topic also emits the `ovos.*` spec topic |
+| `emit_legacy` | `OVOS_BUS_EMIT_LEGACY` | `emit_legacy` | emitting an `ovos.*` spec topic also emits the legacy topic |
 
 Only payload-compatible renames are translated (`MIGRATION_MAP`); topics whose
-payload shape also changes (e.g. the handler-lifecycle trio) are not translated
-and must be migrated at the call site.
+payload shape also changes are never translated and must be migrated at the call
+site.
+
+## Handler de-duplication
+
+Because both namespaces carry the event, a handler that is subscribed to **both**
+the legacy and the spec topic would otherwise run twice. The client wraps
+handlers on migrated topics so the **mirror** copy is dropped — the second
+delivery of the *same payload via the counterpart topic* within a short window is
+suppressed. This makes dual-listening safe (no need to coordinate which namespace
+a handler uses while migrating).
+
+It does **not** suppress two genuine events on the *same* topic: only a delivery
+via the counterpart topic is treated as a mirror. Dedup state is per handler,
+shared across its registrations, so two `bus.on(...)` calls for the same callback
+collapse correctly.
+
+## Rollout
+
+1. **Now** — both flags on by default; every migrated event is on both
+   namespaces. Migrate each repo's emit and/or listen to `ovos.*` independently;
+   dual-listening callbacks are deduped, single-namespace callbacks are always
+   reached.
+2. **Later** — once services predominantly use `ovos.*`, reverse the defaults
+   (flags off) so the legacy copies stop.
+3. **Eventually** — drop the translation entirely; `ovos.*` only.

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -426,36 +426,69 @@ class MessageBusClient:
             event_name (str): message type to map to the callback
             func (callable): callback function
         """
+        # Topics that participate in the namespace migration are wrapped for
+        # de-duplication; everything else registers straight through.
         if event_name in MIGRATION_MAP or event_name in SPEC_TO_LEGACY:
-            # a migrated topic: wrap so that if this handler also ends up on the
-            # counterpart topic, the mirror copy is dropped (handle once).
             wrapped = self._dedup_wrap(func)
             self.emitter.on(event_name, wrapped)
+            # remember the wrapper so remove() can unsubscribe and drop state
             self._dedup_registrations.setdefault(func, []).append((event_name, wrapped))
             return
         self.emitter.on(event_name, func)
 
     def _dedup_wrap(self, func: Callable[[Message], Any]):
-        """Wrap a handler so a payload arriving via the COUNTERPART topic within
-        the window is dropped — collapsing the legacy/ovos.* mirror pair without
-        suppressing two genuine same-topic events. State is shared per handler.
+        """Wrap ``func`` so the legacy/``ovos.*`` mirror of one event is dropped.
+
+        Why this is needed
+        ------------------
+        With ``modernize`` / ``emit_legacy`` on, emitting one logical event puts
+        it on the bus on BOTH its legacy and its ``ovos.*`` topic (the original
+        and a "mirror" with identical ``data``). A handler subscribed to BOTH
+        topics — which is allowed, so a repo can migrate without coordinating —
+        would then run twice. This wrapper drops the mirror so it runs once.
+
+        What counts as a mirror (and what does not)
+        -------------------------------------------
+        A delivery is the mirror of a recent one only if it has the **same
+        payload** AND arrives on the **counterpart topic** (legacy<->ovos.*).
+        Crucially, two genuine events on the *same* topic with identical payload
+        (e.g. a skill saying "ok" twice) are NOT treated as duplicates — only a
+        cross-namespace counterpart is. There is no per-message id to rely on
+        (OVOS-MSG-1 §5.4 forbids one), so this content+counterpart+window
+        heuristic is the discriminator.
+
+        State
+        -----
+        ``seen`` maps ``payload -> (topic, timestamp)`` and is shared per handler
+        (``self._handler_dedup[func]``) so the handler's two registrations — its
+        legacy ``on()`` and its ``ovos.*`` ``on()`` — dedupe against each other.
+        Entries older than ``_migration_window`` seconds are pruned each call.
         """
         seen = self._handler_dedup.setdefault(func, {})
 
         def wrapper(message=None):
             try:
                 mtype = message.msg_type
+                # canonicalize the payload to a stable string for comparison
                 payload = _json.dumps(message.data, sort_keys=True, default=str)
             except Exception:
+                # never let dedup bookkeeping break delivery
                 return func(message)
+
             now = time.monotonic()
-            for k in [k for k, (_, ts) in seen.items()
-                      if now - ts >= self._migration_window]:
-                seen.pop(k, None)
+            # drop expired entries so memory stays bounded and the window resets
+            for key in [k for k, (_, ts) in seen.items()
+                        if now - ts >= self._migration_window]:
+                seen.pop(key, None)
+
             prev = seen.get(payload)
-            if prev is not None and prev[0] != mtype \
-                    and migration_counterpart(prev[0]) == mtype:
-                return  # same payload via the counterpart topic = the mirror
+            # same payload seen recently, on the OTHER namespace's topic => mirror
+            is_mirror = (prev is not None
+                         and prev[0] != mtype
+                         and migration_counterpart(prev[0]) == mtype)
+            if is_mirror:
+                return  # already handled via the counterpart topic; drop this one
+
             seen[payload] = (mtype, now)
             return func(message)
 

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -24,7 +24,8 @@ from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf, 
 from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import SessionManager, Session
-from ovos_spec_tools.messages import MIGRATION_MAP, SPEC_TO_LEGACY
+from ovos_spec_tools.messages import (MIGRATION_MAP, SPEC_TO_LEGACY,
+                                       migration_counterpart)
 
 # --- Layer-2 encryption at the transport edge (deprecated) -----------------
 #
@@ -40,20 +41,20 @@ import warnings as _warnings
 from os import environ
 
 
-def _bus_flag(env_var: str, config_key: str) -> bool:
+def _bus_flag(env_var: str, config_key: str, default: bool = False) -> bool:
     """Read a boolean bus flag from an env var, else the websocket config.
 
-    The env var wins when set; otherwise ``websocket.<config_key>`` is read;
-    default ``False``.
+    The env var wins when set; otherwise ``websocket.<config_key>`` is read,
+    falling back to ``default``.
     """
     val = environ.get(env_var)
     if val is not None:
         return val.strip().lower() in ("1", "true", "yes", "on")
     try:
         from ovos_config import Configuration
-        return bool(Configuration().get("websocket", {}).get(config_key, False))
+        return bool(Configuration().get("websocket", {}).get(config_key, default))
     except Exception:
-        return False
+        return default
 
 
 def _encryption_keys():
@@ -142,13 +143,17 @@ class MessageBusClient:
         self.connected_event = Event()
         self.started_running = False
         self.wrapped_funcs = {}
-        # opt-in namespace translation on emit (both off by default, orthogonal):
-        #  modernize  : also emit the ovos.* spec topic when a legacy topic is
-        #               emitted, so spec-native listeners receive it.
-        #  emit_legacy: also emit the legacy topic when an ovos.* spec topic is
-        #               emitted, so not-yet-migrated listeners receive it.
-        self._modernize = _bus_flag("OVOS_BUS_MODERNIZE", "modernize")
-        self._emit_legacy = _bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy")
+        # namespace translation on emit (orthogonal, both ON by default during
+        # the migration window so every migrated event travels on BOTH the
+        # legacy and the ovos.* topic — any repo can flip its emit OR its listen
+        # to ovos.* in any order, with no coordination):
+        #  emit_legacy: emitting an ovos.* spec topic also emits the legacy one.
+        #  modernize  : emitting a legacy topic also emits the ovos.* spec one.
+        self._emit_legacy = _bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy", default=True)
+        self._modernize = _bus_flag("OVOS_BUS_MODERNIZE", "modernize", default=True)
+        self._migration_window = 1.0
+        self._handler_dedup = {}         # func -> {payload: (topic, timestamp)}
+        self._dedup_registrations = {}   # func -> [(event_name, wrapped), ...]
         if session:
             SessionManager.update(session)
         else:
@@ -421,7 +426,40 @@ class MessageBusClient:
             event_name (str): message type to map to the callback
             func (callable): callback function
         """
+        if event_name in MIGRATION_MAP or event_name in SPEC_TO_LEGACY:
+            # a migrated topic: wrap so that if this handler also ends up on the
+            # counterpart topic, the mirror copy is dropped (handle once).
+            wrapped = self._dedup_wrap(func)
+            self.emitter.on(event_name, wrapped)
+            self._dedup_registrations.setdefault(func, []).append((event_name, wrapped))
+            return
         self.emitter.on(event_name, func)
+
+    def _dedup_wrap(self, func: Callable[[Message], Any]):
+        """Wrap a handler so a payload arriving via the COUNTERPART topic within
+        the window is dropped — collapsing the legacy/ovos.* mirror pair without
+        suppressing two genuine same-topic events. State is shared per handler.
+        """
+        seen = self._handler_dedup.setdefault(func, {})
+
+        def wrapper(message=None):
+            try:
+                mtype = message.msg_type
+                payload = _json.dumps(message.data, sort_keys=True, default=str)
+            except Exception:
+                return func(message)
+            now = time.monotonic()
+            for k in [k for k, (_, ts) in seen.items()
+                      if now - ts >= self._migration_window]:
+                seen.pop(k, None)
+            prev = seen.get(payload)
+            if prev is not None and prev[0] != mtype \
+                    and migration_counterpart(prev[0]) == mtype:
+                return  # same payload via the counterpart topic = the mirror
+            seen[payload] = (mtype, now)
+            return func(message)
+
+        return wrapper
 
     def once(self, event_name: str, func: Callable[[Message], Any]):
         """Register callback with event emitter for a single call.
@@ -439,7 +477,15 @@ class MessageBusClient:
             event_name (str): message type to map to the callback
             func (callable): callback function
         """
-        if func in self.wrapped_funcs:
+        if func in self._dedup_registrations:
+            regs = self._dedup_registrations[func]
+            for ev, wrapped in [r for r in regs if r[0] == event_name]:
+                self._remove_normal(ev, wrapped)
+                regs.remove((ev, wrapped))
+            if not regs:
+                self._dedup_registrations.pop(func, None)
+                self._handler_dedup.pop(func, None)
+        elif func in self.wrapped_funcs:
             self._remove_wrapped(event_name, func)
         else:
             self._remove_normal(event_name, func)

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -469,8 +469,13 @@ class MessageBusClient:
         def wrapper(message=None):
             try:
                 mtype = message.msg_type
-                # canonicalize the payload to a stable string for comparison
-                payload = _json.dumps(message.data, sort_keys=True, default=str)
+                # Fingerprint BOTH data and context: emit() builds the mirror with
+                # Message.forward(), which deep-copies the context unchanged, so a
+                # true mirror has an identical fingerprint. Two distinct events
+                # that happen to share data but differ in context (e.g. different
+                # sessions) keep distinct fingerprints and are NOT collapsed.
+                fingerprint = _json.dumps([message.data, message.context],
+                                          sort_keys=True, default=str)
             except Exception:
                 # never let dedup bookkeeping break delivery
                 return func(message)
@@ -481,15 +486,15 @@ class MessageBusClient:
                         if now - ts >= self._migration_window]:
                 seen.pop(key, None)
 
-            prev = seen.get(payload)
-            # same payload seen recently, on the OTHER namespace's topic => mirror
+            prev = seen.get(fingerprint)
+            # same fingerprint seen recently, on the OTHER namespace's topic => mirror
             is_mirror = (prev is not None
                          and prev[0] != mtype
                          and migration_counterpart(prev[0]) == mtype)
             if is_mirror:
                 return  # already handled via the counterpart topic; drop this one
 
-            seen[payload] = (mtype, now)
+            seen[fingerprint] = (mtype, now)
             return func(message)
 
         return wrapper
@@ -510,14 +515,21 @@ class MessageBusClient:
             event_name (str): message type to map to the callback
             func (callable): callback function
         """
-        if func in self._dedup_registrations:
-            regs = self._dedup_registrations[func]
+        # on_collect() registers a collector wrapper (tracked in wrapped_funcs);
+        # resolve it so a migrated on_collect() subscription is also torn down at
+        # the dedup layer (whose registration is keyed by the collector wrapper,
+        # not the public func).
+        target = self.wrapped_funcs.get(func, func)
+        if target in self._dedup_registrations:
+            regs = self._dedup_registrations[target]
             for ev, wrapped in [r for r in regs if r[0] == event_name]:
                 self._remove_normal(ev, wrapped)
                 regs.remove((ev, wrapped))
             if not regs:
-                self._dedup_registrations.pop(func, None)
-                self._handler_dedup.pop(func, None)
+                self._dedup_registrations.pop(target, None)
+                self._handler_dedup.pop(target, None)
+                if target is not func:
+                    self.wrapped_funcs.pop(func, None)
         elif func in self.wrapped_funcs:
             self._remove_wrapped(event_name, func)
         else:

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -24,7 +24,7 @@ from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf, 
 from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import SessionManager, Session
-from ovos_spec_tools.messages import MIGRATION_MAP, migration_counterpart
+from ovos_spec_tools.messages import MIGRATION_MAP, SPEC_TO_LEGACY
 
 # --- Layer-2 encryption at the transport edge (deprecated) -----------------
 #
@@ -40,18 +40,18 @@ import warnings as _warnings
 from os import environ
 
 
-def _namespace_migration_enabled() -> bool:
-    """Whether transparent legacy<->ovos.* namespace migration is on (opt-in).
+def _bus_flag(env_var: str, config_key: str) -> bool:
+    """Read a boolean bus flag from an env var, else the websocket config.
 
-    Enabled by the ``OVOS_BUS_NAMESPACE_MIGRATION`` env var, else by the
-    ``namespace_migration`` config key; default off.
+    The env var wins when set; otherwise ``websocket.<config_key>`` is read;
+    default ``False``.
     """
-    val = environ.get("OVOS_BUS_NAMESPACE_MIGRATION")
+    val = environ.get(env_var)
     if val is not None:
         return val.strip().lower() in ("1", "true", "yes", "on")
     try:
         from ovos_config import Configuration
-        return bool(Configuration().get("namespace_migration", False))
+        return bool(Configuration().get("websocket", {}).get(config_key, False))
     except Exception:
         return False
 
@@ -142,10 +142,13 @@ class MessageBusClient:
         self.connected_event = Event()
         self.started_running = False
         self.wrapped_funcs = {}
-        # opt-in transparent legacy<->ovos.* namespace migration (off by default)
-        self._namespace_migration = _namespace_migration_enabled()
-        self._migration_window = 1.0
-        self._migration_handlers = {}  # (event_name, func) -> (counterpart, wrapped)
+        # opt-in namespace translation on emit (both off by default, orthogonal):
+        #  modernize  : also emit the ovos.* spec topic when a legacy topic is
+        #               emitted, so spec-native listeners receive it.
+        #  emit_legacy: also emit the legacy topic when an ovos.* spec topic is
+        #               emitted, so not-yet-migrated listeners receive it.
+        self._modernize = _bus_flag("OVOS_BUS_MODERNIZE", "modernize")
+        self._emit_legacy = _bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy")
         if session:
             SessionManager.update(session)
         else:
@@ -280,12 +283,14 @@ class MessageBusClient:
 
         self._send(message)
 
-        # transparent migration: also put the counterpart topic on the wire so
-        # nodes on either namespace receive the event (consumers dedupe).
-        if self._namespace_migration:
-            counterpart = migration_counterpart(message.msg_type)
-            if counterpart:
-                self._send(message.forward(counterpart, message.data))
+        # one-shot namespace translation on emit (never re-translates the mirror)
+        mtype = message.msg_type
+        if self._modernize and mtype in MIGRATION_MAP:
+            # legacy topic emitted -> also emit the ovos.* spec topic
+            self._send(message.forward(MIGRATION_MAP[mtype].value, message.data))
+        elif self._emit_legacy and mtype in SPEC_TO_LEGACY:
+            # ovos.* spec topic emitted -> also emit the legacy topic
+            self._send(message.forward(SPEC_TO_LEGACY[mtype], message.data))
 
     def _send(self, message: Message):
         """Serialize and send a single message over the websocket."""
@@ -416,44 +421,7 @@ class MessageBusClient:
             event_name (str): message type to map to the callback
             func (callable): callback function
         """
-        if self._namespace_migration:
-            counterpart = migration_counterpart(event_name)
-            if counterpart:
-                # listen on both namespaces; the wrapper dedupes so the dual
-                # wire copies invoke the callback once.
-                wrapped = self._migration_wrapper(func)
-                self.emitter.on(event_name, wrapped)
-                self.emitter.on(counterpart, wrapped)
-                self._migration_handlers[(event_name, func)] = (counterpart, wrapped)
-                return
         self.emitter.on(event_name, func)
-
-    def _migration_wrapper(self, func: Callable[[Message], Any]):
-        """Wrap a handler so duplicate legacy/ovos.* copies fire it once.
-
-        Dedup key is the canonical (spec) topic plus the message payload, so the
-        two copies of one logical event collapse. State is per-registration.
-        """
-        seen = {}
-
-        def wrapper(message=None):
-            key = None
-            try:
-                mtype = message.msg_type
-                canonical = MIGRATION_MAP[mtype].value if mtype in MIGRATION_MAP else mtype
-                key = (canonical, _json.dumps(message.data, sort_keys=True, default=str))
-            except Exception:
-                key = None
-            if key is not None:
-                now = time.monotonic()
-                for k in [k for k, t in seen.items() if now - t >= self._migration_window]:
-                    seen.pop(k, None)
-                if key in seen:
-                    return
-                seen[key] = now
-            return func(message)
-
-        return wrapper
 
     def once(self, event_name: str, func: Callable[[Message], Any]):
         """Register callback with event emitter for a single call.
@@ -471,12 +439,7 @@ class MessageBusClient:
             event_name (str): message type to map to the callback
             func (callable): callback function
         """
-        migration_key = (event_name, func)
-        if migration_key in self._migration_handlers:
-            counterpart, wrapped = self._migration_handlers.pop(migration_key)
-            self._remove_normal(event_name, wrapped)
-            self._remove_normal(counterpart, wrapped)
-        elif func in self.wrapped_funcs:
+        if func in self.wrapped_funcs:
             self._remove_wrapped(event_name, func)
         else:
             self._remove_normal(event_name, func)

--- a/test/unittests/test_client_extra.py
+++ b/test/unittests/test_client_extra.py
@@ -72,11 +72,12 @@ class TestEmit(TestCase):
         self.client.connected_event.set()
 
     def test_emit_sends_serialized_message(self):
-        self.client.emit(Message("speak", {"utterance": "hi"}))
+        # a non-migrated topic, so namespace translation does not add a second send
+        self.client.emit(Message("test.message", {"utterance": "hi"}))
         self.assertTrue(self.client.client.send.called)
         payload = self.client.client.send.call_args[0][0]
         decoded = json.loads(payload)
-        self.assertEqual(decoded["type"], "speak")
+        self.assertEqual(decoded["type"], "test.message")
         self.assertEqual(decoded["data"]["utterance"], "hi")
 
 

--- a/test/unittests/test_namespace_migration.py
+++ b/test/unittests/test_namespace_migration.py
@@ -1,11 +1,11 @@
-"""Tests for opt-in namespace translation on emit in MessageBusClient.
+"""Tests for namespace translation + handler dedup in MessageBusClient.
 
-Two orthogonal, emit-side flags (both default off):
+Two orthogonal emit-side flags, both ON by default during the migration window:
   modernize   : emitting a legacy topic also emits the ovos.* spec topic.
   emit_legacy : emitting an ovos.* spec topic also emits the legacy topic.
-
-There is no listener-side magic: on()/remove() are unchanged, and each listener
-subscribes to exactly one namespace.
+So every migrated event travels on BOTH namespaces. A handler registered on the
+legacy AND the spec topic is deduped (the mirror copy is dropped) so it fires
+once — without suppressing two genuine same-topic events.
 """
 import json
 import unittest
@@ -16,12 +16,15 @@ from ovos_bus_client.client.client import MessageBusClient, _bus_flag
 from ovos_bus_client.message import Message
 
 
-def _client(modernize=False, emit_legacy=False):
+def _client(modernize=True, emit_legacy=True):
     c = MessageBusClient.__new__(MessageBusClient)
     c.emitter = MagicMock()
     c.client = MagicMock()
     c._modernize = modernize
     c._emit_legacy = emit_legacy
+    c._migration_window = 1.0
+    c._handler_dedup = {}
+    c._dedup_registrations = {}
     c.wrapped_funcs = {}
     c.connected_event = Event()
     c.connected_event.set()
@@ -34,73 +37,112 @@ def _sent_types(c):
     return [json.loads(call.args[0])["type"] for call in c.client.send.call_args_list]
 
 
-class TestFlagReading(unittest.TestCase):
-    def test_env_enables(self):
-        with patch.dict("os.environ", {"OVOS_BUS_MODERNIZE": "true"}):
-            self.assertTrue(_bus_flag("OVOS_BUS_MODERNIZE", "modernize"))
+class TestDefaultsOn(unittest.TestCase):
+    def test_both_flags_default_on(self):
+        with patch.dict("os.environ", {}, clear=False):
+            for k in ("OVOS_BUS_MODERNIZE", "OVOS_BUS_EMIT_LEGACY"):
+                patch.dict("os.environ", {}, clear=False)
+            # no env, no config -> default True
+            with patch("ovos_config.Configuration", return_value={}):
+                self.assertTrue(_bus_flag("OVOS_BUS_MODERNIZE", "modernize", default=True))
+                self.assertTrue(_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy", default=True))
 
-    def test_env_disables(self):
-        with patch.dict("os.environ", {"OVOS_BUS_EMIT_LEGACY": "0"}):
-            self.assertFalse(_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy"))
+    def test_env_can_disable(self):
+        with patch.dict("os.environ", {"OVOS_BUS_EMIT_LEGACY": "false"}):
+            self.assertFalse(_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy", default=True))
 
 
-class TestModernize(unittest.TestCase):
-    def test_legacy_emit_also_sends_spec(self):
-        c = _client(modernize=True)
+class TestEmitTranslation(unittest.TestCase):
+    def test_legacy_emit_adds_spec(self):
+        c = _client()
         c.emit(Message("speak", {"utterance": "hi"}))
         self.assertEqual(_sent_types(c), ["speak", "ovos.utterance.speak"])
 
-    def test_spec_emit_not_translated_to_legacy(self):
-        c = _client(modernize=True)  # modernize does NOT add legacy
-        c.emit(Message("ovos.utterance.speak", {"utterance": "hi"}))
-        self.assertEqual(_sent_types(c), ["ovos.utterance.speak"])
-
-
-class TestEmitLegacy(unittest.TestCase):
-    def test_spec_emit_also_sends_legacy(self):
-        c = _client(emit_legacy=True)
+    def test_spec_emit_adds_legacy(self):
+        c = _client()
         c.emit(Message("ovos.utterance.handle", {"utterances": ["hi"]}))
         self.assertEqual(_sent_types(c),
                          ["ovos.utterance.handle", "recognizer_loop:utterance"])
 
-    def test_legacy_emit_not_translated_to_spec(self):
-        c = _client(emit_legacy=True)  # emit_legacy does NOT add spec
-        c.emit(Message("recognizer_loop:utterance", {"utterances": ["hi"]}))
-        self.assertEqual(_sent_types(c), ["recognizer_loop:utterance"])
-
-
-class TestBothAndNeither(unittest.TestCase):
-    def test_both_off_sends_once(self):
+    def test_unmapped_never_translated(self):
         c = _client()
+        c.emit(Message("some.topic", {"x": 1}))
+        self.assertEqual(_sent_types(c), ["some.topic"])
+
+    def test_flags_off_send_once(self):
+        c = _client(modernize=False, emit_legacy=False)
         c.emit(Message("speak", {"utterance": "hi"}))
         self.assertEqual(_sent_types(c), ["speak"])
 
-    def test_unmapped_topic_never_translated(self):
-        c = _client(modernize=True, emit_legacy=True)
-        c.emit(Message("some.random.topic", {"x": 1}))
-        self.assertEqual(_sent_types(c), ["some.random.topic"])
 
-    def test_both_on_translate_each_direction_once(self):
-        c = _client(modernize=True, emit_legacy=True)
-        c.emit(Message("speak", {"utterance": "hi"}))          # legacy -> +spec
-        c.emit(Message("ovos.utterance.handle", {"u": 1}))     # spec   -> +legacy
-        self.assertEqual(_sent_types(c), [
-            "speak", "ovos.utterance.speak",
-            "ovos.utterance.handle", "recognizer_loop:utterance",
-        ])
+class TestHandlerDedup(unittest.TestCase):
+    def _wrappers(self, c, func):
+        return [w for _, w in c._dedup_registrations[func]]
 
-
-class TestNoListenerSideMagic(unittest.TestCase):
-    def test_on_is_plain_subscribe(self):
-        c = _client(modernize=True, emit_legacy=True)
+    def test_dual_registered_handler_fires_once_on_mirror_pair(self):
+        c = _client()
         handler = MagicMock()
         c.on("speak", handler)
-        c.emitter.on.assert_called_once_with("speak", handler)
+        c.on("ovos.utterance.speak", handler)
+        w_legacy, w_spec = self._wrappers(c, handler)
+        data = {"utterance": "hi", "lang": "en-us"}
+        w_legacy(Message("speak", data))               # original
+        w_spec(Message("ovos.utterance.speak", data))  # mirror -> dropped
+        handler.assert_called_once()
 
-    def test_no_migration_attributes(self):
+    def test_same_topic_repeats_not_suppressed(self):
         c = _client()
-        self.assertFalse(hasattr(c, "_migration_wrapper"))
-        self.assertFalse(hasattr(c, "_migration_handlers"))
+        handler = MagicMock()
+        c.on("speak", handler)
+        (w,) = self._wrappers(c, handler)
+        data = {"utterance": "ok"}
+        w(Message("speak", data))
+        w(Message("speak", data))  # genuine repeat on the SAME topic -> fires
+        self.assertEqual(handler.call_count, 2)
+
+    def test_single_namespace_handler_always_fires(self):
+        c = _client()
+        handler = MagicMock()
+        c.on("ovos.utterance.speak", handler)
+        (w,) = self._wrappers(c, handler)
+        w(Message("ovos.utterance.speak", {"utterance": "a"}))
+        w(Message("ovos.utterance.speak", {"utterance": "b"}))
+        self.assertEqual(handler.call_count, 2)
+
+    def test_dedup_expires_after_window(self):
+        c = _client()
+        handler = MagicMock()
+        c.on("speak", handler)
+        c.on("ovos.utterance.speak", handler)
+        w_legacy, w_spec = self._wrappers(c, handler)
+        data = {"utterance": "hi"}
+        with patch("ovos_bus_client.client.client.time.monotonic") as clk:
+            clk.return_value = 0.0
+            w_legacy(Message("speak", data))
+            clk.return_value = 2.0  # window elapsed -> mirror no longer collapsed
+            w_spec(Message("ovos.utterance.speak", data))
+        self.assertEqual(handler.call_count, 2)
+
+    def test_unmapped_topic_handler_not_wrapped(self):
+        c = _client()
+        handler = MagicMock()
+        c.on("some.topic", handler)
+        c.emitter.on.assert_called_once_with("some.topic", handler)
+        self.assertNotIn(handler, c._dedup_registrations)
+
+
+class TestRemove(unittest.TestCase):
+    def test_remove_cleans_dedup_state(self):
+        c = _client()
+        c._remove_normal = MagicMock()
+        handler = MagicMock()
+        c.on("speak", handler)
+        c.on("ovos.utterance.speak", handler)
+        c.remove("speak", handler)
+        c.remove("ovos.utterance.speak", handler)
+        self.assertNotIn(handler, c._dedup_registrations)
+        self.assertNotIn(handler, c._handler_dedup)
+        self.assertEqual(c._remove_normal.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_namespace_migration.py
+++ b/test/unittests/test_namespace_migration.py
@@ -39,13 +39,13 @@ def _sent_types(c):
 
 class TestDefaultsOn(unittest.TestCase):
     def test_both_flags_default_on(self):
-        with patch.dict("os.environ", {}, clear=False):
-            for k in ("OVOS_BUS_MODERNIZE", "OVOS_BUS_EMIT_LEGACY"):
-                patch.dict("os.environ", {}, clear=False)
-            # no env, no config -> default True
-            with patch("ovos_config.Configuration", return_value={}):
-                self.assertTrue(_bus_flag("OVOS_BUS_MODERNIZE", "modernize", default=True))
-                self.assertTrue(_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy", default=True))
+        # no env var and empty config -> the default (True) is returned
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k not in ("OVOS_BUS_MODERNIZE", "OVOS_BUS_EMIT_LEGACY")}
+        with patch.dict("os.environ", env, clear=True), \
+                patch("ovos_config.Configuration", return_value={}):
+            self.assertTrue(_bus_flag("OVOS_BUS_MODERNIZE", "modernize", default=True))
+            self.assertTrue(_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy", default=True))
 
     def test_env_can_disable(self):
         with patch.dict("os.environ", {"OVOS_BUS_EMIT_LEGACY": "false"}):
@@ -131,6 +131,34 @@ class TestHandlerDedup(unittest.TestCase):
         self.assertNotIn(handler, c._dedup_registrations)
 
 
+class TestContextInFingerprint(unittest.TestCase):
+    def test_same_payload_different_session_not_collapsed(self):
+        # two distinct events, same data, different session context, on the
+        # counterpart topics -> must BOTH fire (not treated as a mirror pair)
+        c = _client()
+        handler = MagicMock()
+        c.on("speak", handler)
+        c.on("ovos.utterance.speak", handler)
+        w_legacy, w_spec = [w for _, w in c._dedup_registrations[handler]]
+        data = {"utterance": "hi"}
+        w_legacy(Message("speak", data, context={"session": {"session_id": "A"}}))
+        w_spec(Message("ovos.utterance.speak", data,
+                       context={"session": {"session_id": "B"}}))
+        self.assertEqual(handler.call_count, 2)
+
+    def test_mirror_same_context_collapsed(self):
+        c = _client()
+        handler = MagicMock()
+        c.on("speak", handler)
+        c.on("ovos.utterance.speak", handler)
+        w_legacy, w_spec = [w for _, w in c._dedup_registrations[handler]]
+        ctx = {"session": {"session_id": "A"}}
+        data = {"utterance": "hi"}
+        w_legacy(Message("speak", data, context=dict(ctx)))
+        w_spec(Message("ovos.utterance.speak", data, context=dict(ctx)))
+        handler.assert_called_once()
+
+
 class TestRemove(unittest.TestCase):
     def test_remove_cleans_dedup_state(self):
         c = _client()
@@ -143,6 +171,20 @@ class TestRemove(unittest.TestCase):
         self.assertNotIn(handler, c._dedup_registrations)
         self.assertNotIn(handler, c._handler_dedup)
         self.assertEqual(c._remove_normal.call_count, 2)
+
+    def test_remove_resolves_on_collect_wrapper(self):
+        # an on_collect-style wrapper on a migrated topic must be removed at the
+        # dedup layer too (registration is keyed by the collector wrapper)
+        c = _client()
+        c._remove_normal = MagicMock()
+        public = MagicMock()
+        collector = MagicMock()        # the wrapper on_collect() would build
+        c.wrapped_funcs[public] = collector
+        c.on("ovos.utterance.speak", collector)   # registers dedup wrapper
+        c.remove("ovos.utterance.speak", public)  # remove by the PUBLIC func
+        self.assertNotIn(collector, c._dedup_registrations)
+        self.assertNotIn(public, c.wrapped_funcs)
+        self.assertEqual(c._remove_normal.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_namespace_migration.py
+++ b/test/unittests/test_namespace_migration.py
@@ -1,25 +1,27 @@
-"""Tests for the opt-in transparent legacy<->ovos.* namespace migration in
-MessageBusClient (emit dual-send, on dual-listen + dedup, remove cleanup)."""
+"""Tests for opt-in namespace translation on emit in MessageBusClient.
+
+Two orthogonal, emit-side flags (both default off):
+  modernize   : emitting a legacy topic also emits the ovos.* spec topic.
+  emit_legacy : emitting an ovos.* spec topic also emits the legacy topic.
+
+There is no listener-side magic: on()/remove() are unchanged, and each listener
+subscribes to exactly one namespace.
+"""
 import json
 import unittest
 from threading import Event
 from unittest.mock import MagicMock, patch
 
-from ovos_bus_client.client.client import (
-    MessageBusClient,
-    _namespace_migration_enabled,
-)
+from ovos_bus_client.client.client import MessageBusClient, _bus_flag
 from ovos_bus_client.message import Message
 
 
-def _client(migration=True):
-    """A MessageBusClient with the migration machinery, no real websocket."""
+def _client(modernize=False, emit_legacy=False):
     c = MessageBusClient.__new__(MessageBusClient)
     c.emitter = MagicMock()
     c.client = MagicMock()
-    c._namespace_migration = migration
-    c._migration_window = 1.0
-    c._migration_handlers = {}
+    c._modernize = modernize
+    c._emit_legacy = emit_legacy
     c.wrapped_funcs = {}
     c.connected_event = Event()
     c.connected_event.set()
@@ -28,101 +30,77 @@ def _client(migration=True):
     return c
 
 
+def _sent_types(c):
+    return [json.loads(call.args[0])["type"] for call in c.client.send.call_args_list]
+
+
 class TestFlagReading(unittest.TestCase):
     def test_env_enables(self):
-        with patch.dict("os.environ", {"OVOS_BUS_NAMESPACE_MIGRATION": "true"}):
-            self.assertTrue(_namespace_migration_enabled())
+        with patch.dict("os.environ", {"OVOS_BUS_MODERNIZE": "true"}):
+            self.assertTrue(_bus_flag("OVOS_BUS_MODERNIZE", "modernize"))
 
     def test_env_disables(self):
-        with patch.dict("os.environ", {"OVOS_BUS_NAMESPACE_MIGRATION": "0"}):
-            self.assertFalse(_namespace_migration_enabled())
+        with patch.dict("os.environ", {"OVOS_BUS_EMIT_LEGACY": "0"}):
+            self.assertFalse(_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy"))
 
 
-class TestEmitDualSend(unittest.TestCase):
-    def _sent_types(self, c):
-        return [json.loads(call.args[0])["type"]
-                for call in c.client.send.call_args_list]
-
+class TestModernize(unittest.TestCase):
     def test_legacy_emit_also_sends_spec(self):
-        c = _client(migration=True)
-        c.emit(Message("speak", {"utterance": "hi", "lang": "en-us"}))
-        self.assertEqual(self._sent_types(c), ["speak", "ovos.utterance.speak"])
+        c = _client(modernize=True)
+        c.emit(Message("speak", {"utterance": "hi"}))
+        self.assertEqual(_sent_types(c), ["speak", "ovos.utterance.speak"])
 
+    def test_spec_emit_not_translated_to_legacy(self):
+        c = _client(modernize=True)  # modernize does NOT add legacy
+        c.emit(Message("ovos.utterance.speak", {"utterance": "hi"}))
+        self.assertEqual(_sent_types(c), ["ovos.utterance.speak"])
+
+
+class TestEmitLegacy(unittest.TestCase):
     def test_spec_emit_also_sends_legacy(self):
-        c = _client(migration=True)
+        c = _client(emit_legacy=True)
         c.emit(Message("ovos.utterance.handle", {"utterances": ["hi"]}))
-        self.assertEqual(self._sent_types(c),
+        self.assertEqual(_sent_types(c),
                          ["ovos.utterance.handle", "recognizer_loop:utterance"])
 
-    def test_unmapped_topic_sends_once(self):
-        c = _client(migration=True)
-        c.emit(Message("some.random.topic", {"x": 1}))
-        self.assertEqual(self._sent_types(c), ["some.random.topic"])
+    def test_legacy_emit_not_translated_to_spec(self):
+        c = _client(emit_legacy=True)  # emit_legacy does NOT add spec
+        c.emit(Message("recognizer_loop:utterance", {"utterances": ["hi"]}))
+        self.assertEqual(_sent_types(c), ["recognizer_loop:utterance"])
 
-    def test_migration_off_sends_once(self):
-        c = _client(migration=False)
+
+class TestBothAndNeither(unittest.TestCase):
+    def test_both_off_sends_once(self):
+        c = _client()
         c.emit(Message("speak", {"utterance": "hi"}))
-        self.assertEqual(self._sent_types(c), ["speak"])
+        self.assertEqual(_sent_types(c), ["speak"])
+
+    def test_unmapped_topic_never_translated(self):
+        c = _client(modernize=True, emit_legacy=True)
+        c.emit(Message("some.random.topic", {"x": 1}))
+        self.assertEqual(_sent_types(c), ["some.random.topic"])
+
+    def test_both_on_translate_each_direction_once(self):
+        c = _client(modernize=True, emit_legacy=True)
+        c.emit(Message("speak", {"utterance": "hi"}))          # legacy -> +spec
+        c.emit(Message("ovos.utterance.handle", {"u": 1}))     # spec   -> +legacy
+        self.assertEqual(_sent_types(c), [
+            "speak", "ovos.utterance.speak",
+            "ovos.utterance.handle", "recognizer_loop:utterance",
+        ])
 
 
-class TestOnDualListenAndDedup(unittest.TestCase):
-    def test_on_registers_both_namespaces(self):
-        c = _client(migration=True)
+class TestNoListenerSideMagic(unittest.TestCase):
+    def test_on_is_plain_subscribe(self):
+        c = _client(modernize=True, emit_legacy=True)
         handler = MagicMock()
         c.on("speak", handler)
-        topics = {call.args[0] for call in c.emitter.on.call_args_list}
-        self.assertEqual(topics, {"speak", "ovos.utterance.speak"})
-        # same wrapped function on both
-        wrappers = {id(call.args[1]) for call in c.emitter.on.call_args_list}
-        self.assertEqual(len(wrappers), 1)
+        c.emitter.on.assert_called_once_with("speak", handler)
 
-    def test_on_unmapped_topic_registers_plain(self):
-        c = _client(migration=True)
-        handler = MagicMock()
-        c.on("some.topic", handler)
-        c.emitter.on.assert_called_once_with("some.topic", handler)
-
-    def test_wrapper_dedupes_dual_copies(self):
-        c = _client(migration=True)
-        handler = MagicMock()
-        wrapper = c._migration_wrapper(handler)
-        legacy = Message("speak", {"utterance": "hi", "lang": "en-us"})
-        spec = Message("ovos.utterance.speak", {"utterance": "hi", "lang": "en-us"})
-        wrapper(legacy)
-        wrapper(spec)  # same content, canonical topic -> deduped
-        handler.assert_called_once()
-
-    def test_wrapper_distinct_content_both_fire(self):
-        c = _client(migration=True)
-        handler = MagicMock()
-        wrapper = c._migration_wrapper(handler)
-        wrapper(Message("speak", {"utterance": "one"}))
-        wrapper(Message("speak", {"utterance": "two"}))
-        self.assertEqual(handler.call_count, 2)
-
-    def test_wrapper_expires_after_window(self):
-        c = _client(migration=True)
-        c._migration_window = 1.0
-        handler = MagicMock()
-        wrapper = c._migration_wrapper(handler)
-        with patch("ovos_bus_client.client.client.time.monotonic") as clk:
-            clk.return_value = 0.0
-            wrapper(Message("speak", {"utterance": "hi"}))
-            clk.return_value = 2.0
-            wrapper(Message("speak", {"utterance": "hi"}))
-        self.assertEqual(handler.call_count, 2)
-
-
-class TestRemoveCleansBoth(unittest.TestCase):
-    def test_remove_unsubscribes_both_namespaces(self):
-        c = _client(migration=True)
-        c._remove_normal = MagicMock()
-        handler = MagicMock()
-        c.on("speak", handler)
-        c.remove("speak", handler)
-        removed = {call.args[0] for call in c._remove_normal.call_args_list}
-        self.assertEqual(removed, {"speak", "ovos.utterance.speak"})
-        self.assertEqual(c._migration_handlers, {})
+    def test_no_migration_attributes(self):
+        c = _client()
+        self.assertFalse(hasattr(c, "_migration_wrapper"))
+        self.assertFalse(hasattr(c, "_migration_handlers"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactors the namespace migration (merged in #228) into its intended shape: two orthogonal **emit-side flags**, both **on by default** during the migration window, plus **counterpart-aware handler de-duplication**. Lets any repo move its emit and/or listen to `ovos.*` **independently, in any order, with no coordination**.

## Flags (both default on)
- **`modernize`** (`OVOS_BUS_MODERNIZE` / `websocket.modernize`) — emitting a *legacy* topic also emits the `ovos.*` spec topic.
- **`emit_legacy`** (`OVOS_BUS_EMIT_LEGACY` / `websocket.emit_legacy`) — emitting an `ovos.*` spec topic also emits the legacy topic.

So every migrated event travels on **both** namespaces; a single-namespace listener is always reached.

## Handler dedup (the key to safe partial updates)
A callback subscribed to **both** the legacy and the spec topic would run twice. The client wraps handlers on migrated topics and drops the **mirror**: a payload re-delivered via the *counterpart* topic within a short window is suppressed. It does **not** suppress two genuine events on the *same* topic. State is per-handler, shared across its registrations — so e.g. ovos-audio's dual-listen for `speak`/`ovos.utterance.speak` fires once. This makes dual-listening safe, so no repo has to coordinate its migration with others.

## Rollout
both-on now → reverse defaults later → drop translation eventually. Documented in `docs/namespace-migration.md`.

Only payload-compatible renames translate (`MIGRATION_MAP`). Stacked on ovos-spec-tools#26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for the bus namespace migration to the canonical `ovos.*` topic space.
  * Enabled optional dual-topic publishing so migrated messages can be sent to both legacy and canonical topics during rollout.

* **Bug Fixes**
  * Improved handling of duplicate events from mirrored topics so handlers no longer fire twice.
  * Kept unmapped topics unchanged and ensured cleanup works correctly when handlers are removed.

* **Documentation**
  * Added a migration guide covering rollout phases, flags, and translation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->