### PR TITLE
fix: keep an unset site_id absent instead of fabricating "unknown" (BRIDGE-1 §3.3)

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -345,7 +345,7 @@ class Session(_SpecSession):
                  response_mode: Optional[Dict] = None,
                  lang: str = None,
                  context: IntentContextManager = None,
-                 site_id: str = "unknown",
+                 site_id: Optional[str] = None,
                  pipeline: List[str] = None,
                  stt_prefs: Dict = None,
                  tts_prefs: Dict = None,
@@ -415,7 +415,13 @@ class Session(_SpecSession):
         blacklisted_intents = (blacklisted_intents or
                                Configuration().get("intents", {}).get("blacklisted_intents", []))
         lang = standardize_lang(lang or get_default_lang())
-        site_id = site_id or Configuration().get("site_id") or "unknown"
+        # OVOS-BRIDGE-1 §3.3: site_id is the opaque group identifier. A deployer
+        # MAY configure one (the bridge's own determination, step 1), but an
+        # unset site_id MUST stay absent — it is NOT fabricated as a sentinel
+        # such as "unknown". `None` round-trips as an omitted wire field via the
+        # canonical parent's omit-when-None serialization, and consumers MUST
+        # treat an absent site_id as an unknown group (§3.3 step 3).
+        site_id = site_id or Configuration().get("site_id") or None
         pipeline = pipeline or Configuration().get('intents', {}).get("pipeline") or [
             "stop_high",
             "converse",
@@ -770,7 +776,9 @@ class Session(_SpecSession):
         # canonical bag so they are not also passed via **canonical_kwargs.
         uid = canonical_kwargs.pop("session_id", None)
         lang = canonical_kwargs.pop("lang", None)
-        site_id = canonical_kwargs.pop("site_id", "unknown")
+        # OVOS-BRIDGE-1 §3.3: an absent site_id on the wire stays absent through
+        # the deserialize derivation — it is not fabricated as a sentinel here.
+        site_id = canonical_kwargs.pop("site_id", None)
         pipeline = canonical_kwargs.pop("pipeline", [])
         blacklisted_skills = canonical_kwargs.pop("blacklisted_skills", [])
         blacklisted_intents = canonical_kwargs.pop("blacklisted_intents", [])

--- a/test/unittests/test_session_extra.py
+++ b/test/unittests/test_session_extra.py
@@ -242,6 +242,51 @@ class TestSessionSerialization(TestCase):
         sess = Session.from_message(msg)
         self.assertEqual(sess.session_id, "default")
 
+
+class TestSiteIdAbsence(TestCase):
+    """OVOS-BRIDGE-1 §3.3: an unset site_id MUST stay absent (not fabricated
+    as a sentinel such as "unknown"), and a present site_id MUST survive every
+    forward / reply / response derivation unchanged."""
+
+    def setUp(self):
+        _reset_session_manager()
+
+    def test_unset_site_id_is_none_not_sentinel(self):
+        s = Session("sid")
+        self.assertIsNone(s.site_id)
+        self.assertNotEqual(s.site_id, "unknown")
+
+    def test_unset_site_id_omitted_from_wire(self):
+        # §3.3: an absent site_id MUST NOT be emitted as a value (not as
+        # JSON null, not as a fabricated sentinel) — the key is omitted.
+        s = Session("sid")
+        self.assertNotIn("site_id", s.serialize())
+
+    def test_absent_site_id_stays_absent_through_deserialize(self):
+        s = Session("sid")
+        restored = Session.deserialize(s.serialize())
+        self.assertIsNone(restored.site_id)
+        self.assertNotIn("site_id", restored.serialize())
+
+    def test_deserialize_payload_without_site_id_stays_absent(self):
+        # a wire payload that never carried site_id must not gain "unknown"
+        restored = Session.deserialize({"session_id": "sid"})
+        self.assertIsNone(restored.site_id)
+
+    def test_present_site_id_survives_forward(self):
+        s = Session("sid", site_id="kitchen")
+        msg = Message("orig", context={"session": s.serialize()})
+        fwd = msg.forward("downstream")
+        sess = Session.from_message(fwd)
+        self.assertEqual(sess.site_id, "kitchen")
+
+    def test_present_site_id_survives_reply_and_response(self):
+        s = Session("sid", site_id="lab")
+        msg = Message("orig", context={"session": s.serialize()})
+        for derived in (msg.reply("answer"), msg.response()):
+            sess = Session.from_message(derived)
+            self.assertEqual(sess.site_id, "lab")
+
     def test_from_message_falls_back_when_none(self):
         _reset_session_manager()
         sess = Session.from_message(None)


### PR DESCRIPTION
## What

`Session` defaulted `site_id` to the sentinel string `"unknown"` (both in
`__init__` and `deserialize()`) whenever neither a caller nor config supplied
one. Per **OVOS-BRIDGE-1 §3.3** `site_id` is an opaque group identifier and:

> If neither provides a `site_id`, the field is absent; consumers **MUST**
> treat an absent `site_id` as an unknown group and **MUST NOT** infer a
> default.
>
> The value travels unchanged through every `forward` / `reply` / `response`
> derivation per **OVOS-MSG-1 §5**.

Fabricating `"unknown"` put a value on the wire for what should be an absent
field.

## Change

- Default `site_id` to `None` instead of `"unknown"` in the constructor and in
  `deserialize()`. A deployer-configured `site_id` is still honoured (§3.3
  step 1).
- The canonical `ovos_spec_tools.Session` parent already omits a `None`
  `site_id` from the serialized wire dict and preserves a present value
  verbatim, so absence now round-trips and a present value survives every
  derivation.

## Why it's safe

Grepped consumers across the ecosystem: nothing reads `site_id == "unknown"`
as a sentinel. The canonical spec implementation (`ovos-spec-tools`) already
uses `None` as the absent default.

## Tests

New `TestSiteIdAbsence` asserts: unset → `None` (not `"unknown"`), omitted from
the wire, absence preserved through `deserialize()`, and a present `site_id`
survives `forward()` / `reply()` / `response()`. Full suite green (618 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)