### PR TITLE
fix: emit GUI-1-conformant wire shapes from GUIInterface (GUI-1 §3.3, §3.5)

### DIFF
--- a/ovos_bus_client/apis/gui.py
+++ b/ovos_bus_client/apis/gui.py
@@ -1,3 +1,5 @@
+import base64
+import mimetypes
 import os
 import shutil
 from os.path import splitext, isfile
@@ -251,7 +253,10 @@ class GUIInterface:
             return
         if not self.bus:
             raise RuntimeError("bus not set, did you call self.bind() ?")
-        data = self.__session_data.copy()
+        # OVOS-GUI-1 §3.3: omit None-valued keys instead of emitting them as
+        # JSON null. Skill code may assign None to an optional key; it is kept
+        # in the local session-data map but never placed on the wire.
+        data = {k: v for k, v in self.__session_data.items() if v is not None}
         data.update({'__from': self.skill_id})
         self.bus.emit(Message("gui.value.set", data))
 
@@ -389,18 +394,25 @@ class GUIInterface:
         if self.gui_disabled:
             return
         # First sync any data...
-        data = self.__session_data.copy()
+        # OVOS-GUI-1 §3.3: a producer MUST NOT emit a key as JSON null to mean
+        # "absent" — it omits the key instead. Skill code may assign None to an
+        # optional key (e.g. `self["title"] = None`); drop those before the wire.
+        data = {k: v for k, v in self.__session_data.items() if v is not None}
         data.update({'__from': self.skill_id})
         LOG.debug(f"Updating gui data: {data}")
         self.bus.emit(Message("gui.value.set", data))
 
         # finally tell gui what to show
-        self.bus.emit(Message("gui.page.show",
-                              {"page_names": page_names,
-                               "index": index,
-                               "__from": self.skill_id,
-                               "__idle": override_idle,
-                               "__animations": override_animations}))
+        # OVOS-GUI-1 §3.3 / §4.1: omit the reserved __idle key when unset
+        # rather than emitting it as null (an absent __idle means "use the
+        # namespace default", §4.3).
+        show_data = {"page_names": page_names,
+                     "index": index,
+                     "__from": self.skill_id,
+                     "__animations": override_animations}
+        if override_idle is not None:
+            show_data["__idle"] = override_idle
+        self.bus.emit(Message("gui.page.show", show_data))
 
     def remove_page(self, page: str):
         """
@@ -628,6 +640,31 @@ class GUIInterface:
                         return gui_cache
         return url
 
+    @staticmethod
+    def _to_wire_image(url: str) -> str:
+        """Coerce an image reference to an OVOS-GUI-1 §3.5 wire form.
+
+        §3.5 / §8.1: an image-bearing key carries **either** an ``http(s)`` URL
+        or a ``data:`` URI. A producer that holds a **local** asset MUST resolve
+        it to a ``data:`` URI before emission and MUST NOT place a bare
+        filesystem path on the wire (a render backend MUST NOT be required to
+        read the producer's filesystem). ``http(s)`` URLs and pre-formed
+        ``data:`` URIs pass through unchanged; a local file is base64-encoded
+        into a ``data:`` URI.
+        """
+        if not url or not isinstance(url, str):
+            return url
+        if url.startswith("http") or url.startswith("data:"):
+            return url
+        if os.path.isfile(url):
+            mime = mimetypes.guess_type(url)[0] or "application/octet-stream"
+            with open(url, "rb") as f:
+                payload = base64.b64encode(f.read()).decode("ascii")
+            return f"data:{mime};base64,{payload}"
+        # not resolvable to a self-contained wire form; return as-is so the
+        # caller's existence check can reject it
+        return url
+
     def show_image(self, url: str, caption: Optional[str] = None,
                    title: Optional[str] = None,
                    fill: str = None, background_color: str = None,
@@ -656,7 +693,9 @@ class GUIInterface:
         if not url.startswith("http") and not os.path.isfile(url):
             LOG.error(f"Provided image file does not exist! '{url}'")
             return
-        self["image"] = url
+        # OVOS-GUI-1 §3.5: never put a bare filesystem path on the wire — a
+        # local asset is resolved to a self-contained data: URI.
+        self["image"] = self._to_wire_image(url)
         self["title"] = title
         self["caption"] = caption
         self["fill"] = fill
@@ -692,7 +731,9 @@ class GUIInterface:
         if not url.startswith("http") and not os.path.isfile(url):
             LOG.error(f"Provided image file does not exist! '{url}'")
             return
-        self["image"] = url
+        # OVOS-GUI-1 §3.5: never put a bare filesystem path on the wire — a
+        # local asset is resolved to a self-contained data: URI.
+        self["image"] = self._to_wire_image(url)
         self["title"] = title
         self["caption"] = caption
         self["fill"] = fill

--- a/test/unittests/test_gui_api.py
+++ b/test/unittests/test_gui_api.py
@@ -426,5 +426,110 @@ class TestGUISet(TestCase):
         self.assertEqual(called, [True])
 
 
+def _value_sets(bus):
+    return [c.args[0] for c in bus.emit.call_args_list
+            if c.args[0].msg_type == "gui.value.set"]
+
+
+def _page_shows(bus):
+    return [c.args[0] for c in bus.emit.call_args_list
+            if c.args[0].msg_type == "gui.page.show"]
+
+
+class TestGUI1NoneKeyOmission(TestCase):
+    """OVOS-GUI-1 §3.3 / §8.1: a producer MUST omit absent optional keys
+    rather than emit them as JSON null."""
+
+    def setUp(self):
+        self.bus = MagicMock()
+        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
+
+    def test_value_set_omits_none_valued_keys(self):
+        # show_text assigns title=None when no title is supplied
+        self.gui.show_text("hello")
+        data = _value_sets(self.bus)[-1].data
+        self.assertIn("text", data)
+        self.assertNotIn("title", data)        # was None -> omitted
+        self.assertNotIn(None, data.values())  # no null on the wire
+
+    def test_value_set_keeps_present_keys(self):
+        self.gui.show_text("hello", title="Greeting")
+        data = _value_sets(self.bus)[-1].data
+        self.assertEqual(data["text"], "hello")
+        self.assertEqual(data["title"], "Greeting")
+
+    def test_page_show_omits_idle_when_unset(self):
+        self.gui.show_page("SYSTEM_TextFrame")
+        data = _page_shows(self.bus)[-1].data
+        self.assertNotIn("__idle", data)       # was null -> omitted
+        self.assertNotIn(None, data.values())
+
+    def test_page_show_keeps_idle_when_set(self):
+        self.gui.show_page("SYSTEM_TextFrame", override_idle=30)
+        data = _page_shows(self.bus)[-1].data
+        self.assertEqual(data["__idle"], 30)
+
+    def test_sync_data_omits_none(self):
+        self.gui._pages = ["SYSTEM_TextFrame"]  # so __setitem__ triggers a sync
+        self.bus.reset_mock()
+        self.gui["caption"] = None
+        self.gui["title"] = "x"
+        data = _value_sets(self.bus)[-1].data
+        self.assertNotIn("caption", data)
+        self.assertEqual(data["title"], "x")
+
+
+class TestGUI1ImageWireShape(TestCase):
+    """OVOS-GUI-1 §3.5 / §8.1: an image-bearing key carries an http(s) URL or a
+    data: URI; a producer MUST NOT place a bare filesystem path on the wire."""
+
+    def setUp(self):
+        self.bus = MagicMock()
+        self.gui = GUIInterface(skill_id="t.skill", bus=self.bus)
+
+    def test_http_url_passthrough(self):
+        self.assertEqual(
+            self.gui._to_wire_image("http://example.com/a.png"),
+            "http://example.com/a.png")
+
+    def test_data_uri_passthrough(self):
+        uri = "data:image/png;base64,Zm9v"
+        self.assertEqual(self.gui._to_wire_image(uri), uri)
+
+    def test_local_file_becomes_data_uri(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(b"\x89PNG\r\n\x1a\n")
+            path = f.name
+        try:
+            wire = self.gui._to_wire_image(path)
+            self.assertTrue(wire.startswith("data:image/png;base64,"))
+            self.assertNotIn(path, wire)
+        finally:
+            import os
+            os.unlink(path)
+
+    def test_show_image_emits_data_uri_for_local_file(self):
+        import os
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(b"\x89PNG\r\n\x1a\n")
+            path = f.name
+        try:
+            self.gui.show_image(path)
+            img = _value_sets(self.bus)[-1].data["image"]
+            self.assertTrue(img.startswith("data:image/png;base64,"))
+            self.assertNotIn(path, img)
+        finally:
+            os.unlink(path)
+
+    def test_show_image_keeps_http_url(self):
+        with patch("ovos_bus_client.apis.gui.GUIInterface._resolve_url",
+                   return_value="https://example.com/a.png"):
+            self.gui.show_image("https://example.com/a.png")
+        img = _value_sets(self.bus)[-1].data["image"]
+        self.assertEqual(img, "https://example.com/a.png")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

The `GUIInterface` producer emitted wire shapes that violate **OVOS-GUI-1**:

### §3.3 / §8.1 — null instead of omission
> a producer **MUST NOT** emit a key as JSON `null` to mean "absent" — it omits the key instead

`show_text` / `show_image` / friends assign `None` to unset optional keys
(`self["title"] = None`), which were emitted in `gui.value.set` as JSON null.
`gui.page.show` carried `__idle: null` when no override was given.

**Fix:** both `gui.value.set` emission paths (`_sync_data` and `show_pages`)
drop `None`-valued keys; `__idle` is included only when set. The local
session-data map is unchanged — only the wire is filtered.

### §3.5 / §8.1 — bare filesystem path
> A producer that holds a **local** asset **MUST** resolve it to a `data:` URI before emission. A producer **MUST NOT** place a bare filesystem path on the wire

`show_image` / `show_animated_image` put the resolved local path straight on
the wire.

**Fix:** a new `_to_wire_image` helper base64-encodes a local file into a
`data:<mime>;base64,...` URI; `http(s)` URLs and pre-formed `data:` URIs pass
through unchanged.

## Deferred — needs a coordinated ovos-gui change (§3.1 / §3.4 / §8.1)

The producer still names the legacy CamelCase frames (`SYSTEM_TextFrame`,
`SYSTEM_ImageFrame`, `SYSTEM_Face`, `SYSTEM_Loading`, …), which are **outside**
the closed §3.4 vocabulary (`SYSTEM_text`, `SYSTEM_image`, `SYSTEM_face`,
`SYSTEM_loading`, …). The ovos-gui service and its QML render backends dispatch
on the exact legacy names, so remapping here alone would break rendering. The
rename must land together with the service-side change; it is intentionally not
done in this PR to avoid half-breaking the GUI contract.

## Tests

New `TestGUI1NoneKeyOmission` (null-omission on both emit paths + `__idle`) and
`TestGUI1ImageWireShape` (http/data passthrough, local file → `data:` URI, no
bare path on the wire). Full suite green (622 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)