### PR TITLE
refactor: use SpecMessage.SESSION_SYNC for the ovos.session.sync topic

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -24,7 +24,7 @@ from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf, 
 from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import SessionManager, Session
-from ovos_spec_tools.messages import NamespaceTranslator
+from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
 
 # --- Layer-2 encryption at the transport edge (deprecated) -----------------
 #
@@ -190,7 +190,7 @@ class MessageBusClient:
         self.emitter.emit("open")
         # Restore reconnect timer to 5 seconds on sucessful connect
         self.retry = 5
-        self.emit(Message("ovos.session.sync")) # request default session update
+        self.emit(Message(SpecMessage.SESSION_SYNC)) # request default session update
 
     def on_close(self, *args):
         """

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from ovos_config.config import Configuration
 from ovos_config.locale import get_default_lang
 from ovos_utils.log import LOG, log_deprecation
-from ovos_spec_tools import standardize_lang
+from ovos_spec_tools import standardize_lang, SpecMessage
 from ovos_spec_tools.session import (Session as _SpecSession,
                                      DEFAULT_CONVERSE_HANDLERS_CAP,
                                      SESSION1_REGISTERED_FIELDS)
@@ -862,7 +862,7 @@ class SessionManager:
     @classmethod
     def sync(cls, message=None):
         if cls.bus:
-            message = message or Message("ovos.session.sync")
+            message = message or Message(SpecMessage.SESSION_SYNC)
             cls.bus.emit(message.reply("ovos.session.update_default",
                                        {"session_data": cls.default_session.serialize()}))
 
@@ -873,7 +873,7 @@ class SessionManager:
         cls.bus.on("recognizer_loop:record_end", cls.handle_recording_end)
         cls.bus.on("recognizer_loop:audio_output_start", cls.handle_audio_output_start)
         cls.bus.on("recognizer_loop:audio_output_end", cls.handle_audio_output_end)
-        cls.bus.on("ovos.session.sync", cls.handle_session_sync)
+        cls.bus.on(SpecMessage.SESSION_SYNC, cls.handle_session_sync)
         cls.sync()
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-utils>=0.8.2,<1.0.0",
-    "ovos-spec-tools[langcodes]>=0.16.1a2",
+    "ovos-spec-tools[langcodes]>=1.1.0a1",
     "websocket-client>=0.54.0",
     "pyee>=8.1.0,<13.0.0",
 ]


### PR DESCRIPTION
`ovos.session.sync` is spec-defined (OVOS-SESSION-2 §2.7 / CONTEXT-1 §5.3) and now has a `SpecMessage.SESSION_SYNC` member (spec-tools #65 → published 1.1.0a1). Reference the enum instead of the raw string in `session.py` (×2) and `client.py` (×1) — single source of truth for spec topics.

`ovos.session.update_default` stays a bare string: it is **not** spec-defined (SESSION-2 §1 explicitly defers session-lifecycle observability topics), so it has no enum member by design.

Floor: `ovos-spec-tools[langcodes]>=1.1.0a1` (carries SESSION_SYNC). Behaviour-identical (enum `.value` == the literal).