### PR TITLE
feat: shared HandlerLifecycle done-signal helper for in-process dispatchers

### DIFF
--- a/ovos_bus_client/handler.py
+++ b/ovos_bus_client/handler.py
@@ -1,0 +1,196 @@
+"""Shared framework -> orchestrator handler-completion reporting.
+
+This module generalizes the *internal* done-signal that ovos-workshop has
+historically emitted around every skill handler invocation
+(``OVOSSkill._on_event_start`` / ``_on_event_end`` / ``_on_event_error``) so
+that **any** in-process dispatcher can report handler completion uniformly.
+
+Why this exists
+---------------
+ovos-core (the orchestrator) is the *sole* emitter of the authoritative
+PIPELINE-1 §8 handler-lifecycle trio
+(``ovos.intent.handler.{start,complete,error}``). It does **not** time handler
+execution directly; instead it observes a private *framework done-signal* — the
+legacy ``mycroft.skill.handler.{start,complete,error}`` topics — emitted around
+each handler invocation, and translates the observed completion into the spec
+trio (see ``ovos_core.intent_services.dispatcher``).
+
+Until now only ``OVOSSkill`` subclasses emitted that done-signal. Pipeline
+plugins that run handlers in-process **without** subclassing ``OVOSSkill``
+(converse, persona, fallback, common-query, stop — the "polymorphic
+dispatches" of PIPELINE-1 §7) emitted nothing, so the orchestrator could not
+observe their completion and fell back to a multi-minute timeout.
+
+Because ``ovos-bus-client`` is the common dependency of both ovos-workshop and
+every pipeline plugin, the shared reporting helper lives here. This is
+**implementation, NOT specification**: the topics emitted by this helper
+(``mycroft.skill.handler.*`` by default) are a private framework→orchestrator
+synchronization signal and are deliberately *excluded* from the
+ovos-spec-tools migration map. The orchestrator remains the only component that
+emits the spec ``ovos.intent.handler.*`` trio.
+
+Contract consumed by the orchestrator
+-------------------------------------
+``ovos_core.intent_services.dispatcher`` correlates a done-signal to an
+in-flight dispatch using:
+
+* ``message.context["skill_id"]`` — the dispatching skill/plugin id;
+* the session id carried in ``message.context`` (preserved via ``forward``);
+
+and, on the error path, reads the exception text from
+``message.data["exception"]`` (falling back to ``message.data["error"]``).
+
+This helper emits in exactly that shape, so the orchestrator needs no change.
+
+Example
+-------
+>>> from ovos_bus_client.handler import HandlerLifecycle
+>>> with HandlerLifecycle(bus, message, skill_id="ovos-persona",
+...                        handler_name="ask_persona"):
+...     handler(message)  # start emitted on enter, complete on clean exit,
+...                        # error emitted (and re-raised) on exception
+"""
+from functools import wraps
+from typing import Optional, Any, Callable
+
+from ovos_bus_client.message import Message
+
+#: Default base topic for the framework done-signal. Matches ovos-workshop's
+#: ``OVOSSkill.add_event(..., handler_info='mycroft.skill.handler')`` exactly,
+#: so emissions from this helper are indistinguishable to the orchestrator.
+DEFAULT_HANDLER_INFO = "mycroft.skill.handler"
+
+
+class HandlerLifecycle:
+    """Context manager that reports a handler's lifecycle to the orchestrator.
+
+    Emits the framework done-signal around a handler invocation:
+
+    * on ``__enter__``: ``<handler_info>.start``
+    * on clean ``__exit__``: ``<handler_info>.complete``
+    * on ``__exit__`` with an exception: ``<handler_info>.error`` (then the
+      exception is **re-raised** — this helper never suppresses it).
+
+    Every emission is derived from the triggering ``message`` via
+    :meth:`Message.forward`, so the originating ``context`` (including the
+    session) is preserved, and ``context["skill_id"]`` is stamped so the
+    orchestrator can correlate the signal to its in-flight dispatch.
+
+    This helper deliberately does **not** speak an error dialog or otherwise
+    influence user-facing control flow — callers keep their own error handling
+    (including the spoken-error UX). It only reports completion.
+
+    Args:
+        bus: anything exposing ``.emit(Message)`` (a real ``MessageBusClient``
+            or ``ovos_utils.fakebus.FakeBus``).
+        message: the triggering ``Message``; its context (and session) is
+            preserved through ``forward`` on every emission.
+        skill_id: the dispatching skill/plugin id, stamped into
+            ``context["skill_id"]`` so the orchestrator can correlate.
+        handler_name: human/diagnostic name of the handler, carried in the
+            payload (``data["handler"]``). Optional.
+        handler_info: base topic for the done-signal. Defaults to
+            ``mycroft.skill.handler`` to match ovos-workshop. An empty/false
+            value disables emission entirely (matching workshop semantics).
+    """
+
+    def __init__(self, bus: Any, message: Message,
+                 skill_id: Optional[str] = None,
+                 handler_name: Optional[str] = None,
+                 handler_info: str = DEFAULT_HANDLER_INFO):
+        self.bus = bus
+        self.message = message
+        self.skill_id = skill_id
+        self.handler_name = handler_name
+        self.handler_info = handler_info
+
+    def _payload(self, extra: Optional[dict] = None) -> dict:
+        data = {}
+        if self.handler_name is not None:
+            data["handler"] = self.handler_name
+        if extra:
+            data.update(extra)
+        return data
+
+    def _emit(self, suffix: str, data: dict) -> None:
+        """Forward a done-signal message, preserving context + session.
+
+        ``forward`` deep-copies ``self.message.context``; we stamp ``skill_id``
+        onto the *forwarded* message so the orchestrator's correlation key is
+        present without mutating the caller's original message context.
+        """
+        if not self.handler_info:
+            return
+        msg = self.message.forward(self.handler_info + suffix, data)
+        if self.skill_id is not None:
+            msg.context["skill_id"] = self.skill_id
+        self.bus.emit(msg)
+
+    def start(self) -> None:
+        """Emit ``<handler_info>.start``."""
+        self._emit(".start", self._payload())
+
+    def complete(self) -> None:
+        """Emit ``<handler_info>.complete``."""
+        self._emit(".complete", self._payload())
+
+    def error(self, exception: BaseException) -> None:
+        """Emit ``<handler_info>.error`` carrying the exception text.
+
+        The exception text rides in ``data["exception"]`` (the field
+        ``ovos_core.intent_services.dispatcher._on_skill_error`` reads first).
+        """
+        self._emit(".error", self._payload({"exception": repr(exception)}))
+
+    def __enter__(self) -> "HandlerLifecycle":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if exc_val is not None:
+            self.error(exc_val)
+        else:
+            self.complete()
+        # never suppress — callers own their error handling / spoken-error UX
+        return False
+
+
+def report_handler_lifecycle(bus: Any,
+                             skill_id: Optional[str] = None,
+                             handler_name: Optional[str] = None,
+                             handler_info: str = DEFAULT_HANDLER_INFO
+                             ) -> Callable:
+    """Decorator wrapping a ``handler(message)`` with :class:`HandlerLifecycle`.
+
+    The wrapped callable must accept the triggering ``Message`` as its first
+    positional argument (the standard OVOS handler signature). The done-signal
+    is reported around each invocation; exceptions are re-raised.
+
+    Example::
+
+        @report_handler_lifecycle(bus, skill_id="ovos-stop",
+                                  handler_name="handle_stop")
+        def handle_stop(message):
+            ...
+
+    Args:
+        bus: object exposing ``.emit(Message)``.
+        skill_id: dispatching skill/plugin id (``context["skill_id"]``).
+        handler_name: diagnostic handler name (``data["handler"]``); defaults
+            to the wrapped function's ``__name__`` when not given.
+        handler_info: base topic for the done-signal (default
+            ``mycroft.skill.handler``).
+    """
+    def decorator(func: Callable) -> Callable:
+        name = handler_name if handler_name is not None else getattr(
+            func, "__name__", None)
+
+        @wraps(func)
+        def wrapper(message: Message, *args, **kwargs):
+            with HandlerLifecycle(bus, message, skill_id=skill_id,
+                                  handler_name=name, handler_info=handler_info):
+                return func(message, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/ovos_bus_client/handler.py
+++ b/ovos_bus_client/handler.py
@@ -49,6 +49,13 @@ Example
 ...                        handler_name="ask_persona"):
 ...     handler(message)  # start emitted on enter, complete on clean exit,
 ...                        # error emitted (and re-raised) on exception
+
+Each adopter may preserve its own existing payload via ``data=...``. For
+example, ovos-workshop keeps its historical ``{"name": ...}`` shape:
+
+>>> with HandlerLifecycle(self.bus, message, skill_id=self.skill_id,
+...                        data={"name": get_handler_name(handler)}):
+...     handler(message)
 """
 from functools import wraps
 from typing import Optional, Any, Callable
@@ -87,8 +94,20 @@ class HandlerLifecycle:
             preserved through ``forward`` on every emission.
         skill_id: the dispatching skill/plugin id, stamped into
             ``context["skill_id"]`` so the orchestrator can correlate.
-        handler_name: human/diagnostic name of the handler, carried in the
-            payload (``data["handler"]``). Optional.
+        handler_name: human/diagnostic name of the handler. When ``data`` is
+            not supplied, this becomes the default payload (``{"handler":
+            handler_name}``). Ignored when ``data`` is given. Optional.
+        data: base payload for every emission, used **verbatim** (a fresh copy
+            is forwarded each time, so neither the caller's dict nor this base
+            is ever mutated; on the error path ``{"exception": ...}`` is merged
+            into that copy). This lets each adopter preserve its existing
+            payload — e.g. ovos-workshop passes
+            ``data={"name": get_handler_name(handler)}`` to keep its historical
+            ``{"name": ...}`` shape. When ``None`` (default), the payload falls
+            back to ``{"handler": handler_name}`` (or ``{}`` when no
+            ``handler_name`` is given). Core reads neither field — it correlates
+            on ``context["skill_id"]`` and reads ``data["exception"]`` on error —
+            so this is purely about preserving each adopter's payload.
         handler_info: base topic for the done-signal. Defaults to
             ``mycroft.skill.handler`` to match ovos-workshop. An empty/false
             value disables emission entirely (matching workshop semantics).
@@ -97,17 +116,24 @@ class HandlerLifecycle:
     def __init__(self, bus: Any, message: Message,
                  skill_id: Optional[str] = None,
                  handler_name: Optional[str] = None,
+                 data: Optional[dict] = None,
                  handler_info: str = DEFAULT_HANDLER_INFO):
         self.bus = bus
         self.message = message
         self.skill_id = skill_id
         self.handler_name = handler_name
+        self.data = data
         self.handler_info = handler_info
 
     def _payload(self, extra: Optional[dict] = None) -> dict:
-        data = {}
-        if self.handler_name is not None:
-            data["handler"] = self.handler_name
+        # build a fresh dict every call so neither the caller-supplied base
+        # (self.data) nor any forwarded payload is mutated across emissions
+        if self.data is not None:
+            data = dict(self.data)
+        elif self.handler_name is not None:
+            data = {"handler": self.handler_name}
+        else:
+            data = {}
         if extra:
             data.update(extra)
         return data
@@ -158,6 +184,7 @@ class HandlerLifecycle:
 def report_handler_lifecycle(bus: Any,
                              skill_id: Optional[str] = None,
                              handler_name: Optional[str] = None,
+                             data: Optional[dict] = None,
                              handler_info: str = DEFAULT_HANDLER_INFO
                              ) -> Callable:
     """Decorator wrapping a ``handler(message)`` with :class:`HandlerLifecycle`.
@@ -176,8 +203,11 @@ def report_handler_lifecycle(bus: Any,
     Args:
         bus: object exposing ``.emit(Message)``.
         skill_id: dispatching skill/plugin id (``context["skill_id"]``).
-        handler_name: diagnostic handler name (``data["handler"]``); defaults
-            to the wrapped function's ``__name__`` when not given.
+        handler_name: diagnostic handler name (``data["handler"]`` when ``data``
+            is not given); defaults to the wrapped function's ``__name__``.
+        data: base payload for every emission, used verbatim (see
+            :class:`HandlerLifecycle`). When ``None`` (default) the payload
+            falls back to ``{"handler": handler_name}``.
         handler_info: base topic for the done-signal (default
             ``mycroft.skill.handler``).
     """
@@ -188,7 +218,8 @@ def report_handler_lifecycle(bus: Any,
         @wraps(func)
         def wrapper(message: Message, *args, **kwargs):
             with HandlerLifecycle(bus, message, skill_id=skill_id,
-                                  handler_name=name, handler_info=handler_info):
+                                  handler_name=name, data=data,
+                                  handler_info=handler_info):
                 return func(message, *args, **kwargs)
 
         return wrapper

--- a/test/unittests/test_handler.py
+++ b/test/unittests/test_handler.py
@@ -182,6 +182,87 @@ def test_decorator_exception_path_reraises():
     assert "nope" in emitted[-1].data["exception"]
 
 
+def test_caller_data_emitted_verbatim_on_start_and_complete():
+    """A caller-supplied payload (e.g. workshop's {'name': ...}) is used as-is."""
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    base = {"name": "get_time", "extra": 1}
+    with HandlerLifecycle(bus, msg, skill_id="ovos-date-time", data=base):
+        pass
+
+    types = [m.msg_type for m in emitted]
+    assert types == ["mycroft.skill.handler.start",
+                     "mycroft.skill.handler.complete"]
+    for m in emitted:
+        assert m.data == {"name": "get_time", "extra": 1}
+        # default {"handler": ...} is NOT added when data is supplied
+        assert "handler" not in m.data
+        assert m.context["skill_id"] == "ovos-date-time"
+
+
+def test_caller_data_error_merges_exception_without_mutating():
+    """On error the exception merges into a COPY; caller's dict is untouched."""
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    base = {"name": "get_time"}
+    with pytest.raises(ValueError, match="kaboom"):
+        with HandlerLifecycle(bus, msg, skill_id="x", data=base):
+            raise ValueError("kaboom")
+
+    err = emitted[-1]
+    assert err.msg_type == "mycroft.skill.handler.error"
+    assert err.data["name"] == "get_time"
+    assert "kaboom" in err.data["exception"]
+    # the caller's original dict was NOT mutated
+    assert base == {"name": "get_time"}
+
+
+def test_caller_data_not_mutated_across_emissions():
+    """The same base dict is reused for start+complete without accumulating."""
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    base = {"name": "h"}
+    with HandlerLifecycle(bus, msg, skill_id="x", data=base):
+        pass
+
+    assert base == {"name": "h"}
+    for m in emitted:
+        assert m.data == {"name": "h"}
+
+
+def test_data_none_keeps_default_handler_payload():
+    """data=None falls back to the {'handler': handler_name} default."""
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    with HandlerLifecycle(bus, msg, skill_id="x", handler_name="h", data=None):
+        pass
+
+    for m in emitted:
+        assert m.data == {"handler": "h"}
+
+
+def test_decorator_caller_data_emitted_verbatim():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+
+    @report_handler_lifecycle(bus, skill_id="ovos-stop",
+                              data={"name": "handle_stop"})
+    def handle_stop(message):
+        return "ok"
+
+    assert handle_stop(_trigger()) == "ok"
+    for m in emitted:
+        assert m.data == {"name": "handle_stop"}
+
+
 def test_works_without_real_bus_duck_typed_emit():
     """Any object exposing .emit works (no MessageBusClient required)."""
     class FakeEmitter:

--- a/test/unittests/test_handler.py
+++ b/test/unittests/test_handler.py
@@ -1,0 +1,200 @@
+"""Tests for ovos_bus_client.handler (framework done-signal helper).
+
+These verify the helper emits in *exactly* the shape ovos-core's
+``intent_services.dispatcher`` consumes:
+
+* topics ``<handler_info>.{start,complete,error}``;
+* ``context["skill_id"]`` stamped for correlation;
+* session/context preserved through ``forward``;
+* exception text in ``data["exception"]`` on the error path;
+* exceptions re-raised, never suppressed.
+"""
+import pytest
+
+from ovos_utils.fakebus import FakeBus
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.handler import (
+    HandlerLifecycle,
+    report_handler_lifecycle,
+    DEFAULT_HANDLER_INFO,
+)
+
+
+def _recorder(bus):
+    """Attach a catch-all recorder to a FakeBus; return the emitted list."""
+    emitted = []
+    bus.on("message", lambda m: emitted.append(
+        m if isinstance(m, Message) else Message.deserialize(m)))
+    return emitted
+
+
+def _trigger():
+    return Message("test:intent",
+                   {"utterance": "hello"},
+                   {"session": {"session_id": "sess-123"},
+                    "source": "unit-test"})
+
+
+def test_success_path_start_then_complete():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    with HandlerLifecycle(bus, msg, skill_id="ovos-persona",
+                          handler_name="ask_persona"):
+        pass
+
+    types = [m.msg_type for m in emitted]
+    assert types == ["mycroft.skill.handler.start",
+                     "mycroft.skill.handler.complete"]
+    for m in emitted:
+        assert m.data["handler"] == "ask_persona"
+        assert m.context["skill_id"] == "ovos-persona"
+
+
+def test_exception_path_start_then_error_and_reraise():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    with pytest.raises(ValueError, match="boom"):
+        with HandlerLifecycle(bus, msg, skill_id="ovos-stop",
+                              handler_name="handle_stop"):
+            raise ValueError("boom")
+
+    types = [m.msg_type for m in emitted]
+    assert types == ["mycroft.skill.handler.start",
+                     "mycroft.skill.handler.error"]
+    err = emitted[-1]
+    # the dispatcher reads message.data["exception"] first
+    assert "boom" in err.data["exception"]
+    assert err.context["skill_id"] == "ovos-stop"
+
+
+def test_skill_id_rides_in_context_and_session_preserved():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    with HandlerLifecycle(bus, msg, skill_id="ovos-fallback",
+                          handler_name="fallback_handler"):
+        pass
+
+    for m in emitted:
+        # skill_id stamped for correlation
+        assert m.context["skill_id"] == "ovos-fallback"
+        # session preserved through forward (deep copy)
+        assert m.context["session"] == {"session_id": "sess-123"}
+        # other context preserved too
+        assert m.context["source"] == "unit-test"
+
+
+def test_original_message_context_not_mutated():
+    bus = FakeBus()
+    _recorder(bus)
+    msg = _trigger()
+
+    assert "skill_id" not in msg.context
+    with HandlerLifecycle(bus, msg, skill_id="ovos-persona"):
+        pass
+    # forward deep-copies context; caller's original is untouched
+    assert "skill_id" not in msg.context
+
+
+def test_custom_handler_info_base():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    with HandlerLifecycle(bus, msg, skill_id="x",
+                          handler_name="h",
+                          handler_info="ovos.converse.handler"):
+        pass
+
+    types = [m.msg_type for m in emitted]
+    assert types == ["ovos.converse.handler.start",
+                     "ovos.converse.handler.complete"]
+
+
+def test_empty_handler_info_disables_emission():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    with HandlerLifecycle(bus, msg, skill_id="x", handler_info=""):
+        pass
+
+    assert emitted == []
+
+
+def test_no_handler_name_omits_handler_field():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+    msg = _trigger()
+
+    with HandlerLifecycle(bus, msg, skill_id="x"):
+        pass
+
+    for m in emitted:
+        assert "handler" not in m.data
+
+
+def test_default_handler_info_constant():
+    assert DEFAULT_HANDLER_INFO == "mycroft.skill.handler"
+
+
+def test_decorator_success_path():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+
+    @report_handler_lifecycle(bus, skill_id="ovos-common-query")
+    def handle_query(message):
+        return "answered"
+
+    result = handle_query(_trigger())
+    assert result == "answered"
+
+    types = [m.msg_type for m in emitted]
+    assert types == ["mycroft.skill.handler.start",
+                     "mycroft.skill.handler.complete"]
+    # handler_name defaults to the wrapped function name
+    for m in emitted:
+        assert m.data["handler"] == "handle_query"
+        assert m.context["skill_id"] == "ovos-common-query"
+
+
+def test_decorator_exception_path_reraises():
+    bus = FakeBus()
+    emitted = _recorder(bus)
+
+    @report_handler_lifecycle(bus, skill_id="ovos-stop",
+                              handler_name="handle_stop")
+    def handle_stop(message):
+        raise RuntimeError("nope")
+
+    with pytest.raises(RuntimeError, match="nope"):
+        handle_stop(_trigger())
+
+    types = [m.msg_type for m in emitted]
+    assert types == ["mycroft.skill.handler.start",
+                     "mycroft.skill.handler.error"]
+    assert "nope" in emitted[-1].data["exception"]
+
+
+def test_works_without_real_bus_duck_typed_emit():
+    """Any object exposing .emit works (no MessageBusClient required)."""
+    class FakeEmitter:
+        def __init__(self):
+            self.messages = []
+
+        def emit(self, message):
+            self.messages.append(message)
+
+    emitter = FakeEmitter()
+    msg = _trigger()
+    with HandlerLifecycle(emitter, msg, skill_id="x", handler_name="h"):
+        pass
+
+    assert [m.msg_type for m in emitter.messages] == [
+        "mycroft.skill.handler.start", "mycroft.skill.handler.complete"]


### PR DESCRIPTION
Generalizes the internal ovos-workshop framework->orchestrator handler done-signal into a reusable helper so **any** in-process dispatcher (ovos-workshop skills AND pipeline plugins like converse/persona/fallback/common-query/stop) can report handler completion uniformly.

## Why
ovos-core is the sole emitter of the authoritative PIPELINE-1 §8 trio (`ovos.intent.handler.{start,complete,error}`). It does not time handlers directly; it **observes** a private framework done-signal — the legacy `mycroft.skill.handler.{start,complete,error}` — emitted around each handler invocation, and translates it into the spec trio.

Today only `OVOSSkill._on_event_start/_on_event_end/_on_event_error` emit that signal. Pipeline plugins that run handlers in-process **without** subclassing `OVOSSkill` (the PIPELINE-1 §7 polymorphic dispatches) emit nothing, so core cannot observe their completion and falls back to a multi-minute timeout. Since `ovos-bus-client` is the common dependency of workshop and every pipeline plugin, the shared helper lives here.

## What (additive only)
`ovos_bus_client/handler.py`:
- `HandlerLifecycle(bus, message, skill_id=..., handler_name=..., data=..., handler_info="mycroft.skill.handler")` context manager — emits `.start` on enter, `.complete` on clean exit, `.error` (carrying the exception, then **re-raises**) on exception.
- `report_handler_lifecycle(...)` decorator wrapping a `handler(message)`.
- `handler_info` base is configurable (default `mycroft.skill.handler`, matching workshop exactly); empty value disables emission.
- `data` lets each adopter preserve its existing payload **verbatim** (a fresh copy is forwarded each emission, so the caller's dict is never mutated; on error `{"exception": repr(exc)}` is merged into the copy). When `data=None` (default) the payload falls back to `{"handler": handler_name}` (or `{}`). Core reads neither field, so this is purely about payload preservation.
- Emissions derive from `message.forward(...)`, preserving `context`/session; `context["skill_id"]` is stamped on the forwarded copy (caller's original message is not mutated). Works with any object exposing `.emit` (incl. `FakeBus`).

## Contract preserved (core needs no change)
`ovos_core.intent_services.dispatcher` consumes:
- `message.context["skill_id"]` + session — to correlate to its in-flight dispatch;
- `message.data["exception"]` (then `error`) — on the error path.

The helper emits in exactly that shape. This is **implementation, NOT spec**: the orchestrator remains the sole emitter of the `ovos.intent.handler.*` trio; the `mycroft.skill.handler.*` names stay deliberately excluded from the ovos-spec-tools migration map.

## Tests
`test/unittests/test_handler.py` (16 tests) — success path (start->complete), exception path (start->error + re-raise), skill_id-in-context, session/context preserved through forward, original-message-not-mutated, custom `handler_info` base, emission-disabled, decorator paths, duck-typed `.emit`, **caller-supplied `data` emitted verbatim on start/complete, exception merged into a copy without mutating the caller dict on error, and `data=None` keeping the default payload**. All pass; full existing suite green (644 passed, 6 pre-existing skips).

## Follow-ups (separate PRs, NOT in this one)
- **ovos-workshop**: refactor `OVOSSkill._on_event_*` to delegate to `HandlerLifecycle`, passing its historical payload so the emitted shape is byte-identical:
  ```python
  with HandlerLifecycle(self.bus, message, skill_id=self.skill_id,
                        data={"name": get_handler_name(handler)}):
      handler(message)
  ```
  (the spoken-error UX stays in workshop — the util deliberately omits it).
- **pipeline plugins** (converse / persona / fallback / common-query / stop): wrap their in-process handler dispatch in `HandlerLifecycle(self.bus, message, skill_id=<plugin id>, handler_name=<fn>)` (or pass their own `data=...`) so core observes completion instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)