### PR TITLE
fix: Session.update_from applies SESSION-1 deserialization semantics

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -836,14 +836,23 @@ class Session(_SpecSession):
         flow still observes writes made through a later snapshot of the same id
         (e.g. ``is_speaking`` flipped by an ``audio_output_*`` handler).
 
-        Last-writer-wins: ``other`` fully replaces this session's fields. The
-        ``session_id`` is preserved — it is the registry key and must not drift.
+        The snapshot is applied with full OVOS-SESSION-1 §2 deserialization
+        semantics rather than a raw ``__dict__`` merge: the incoming state is
+        round-tripped through :meth:`serialize` / :meth:`deserialize`, so a key
+        present on the wire overrides this session's value (even when empty) and
+        a null / omitted key resolves to the spec default — exactly as a freshly
+        received message would parse. Round-tripping also rebuilds the nested
+        state (``context``, handler lists, …) freshly, so the live object never
+        aliases ``other``'s mutable sub-objects.
+
+        The ``session_id`` is preserved — it is the registry key and must not
+        drift even if ``other`` carries a different one.
         """
         if other is self:
             return self
-        sid = self.session_id
-        self.__dict__.update(other.__dict__)
-        self.session_id = sid
+        rebuilt = Session.deserialize(other.serialize())
+        rebuilt.session_id = self.session_id
+        self.__dict__ = rebuilt.__dict__
         return self
 
     @staticmethod

--- a/test/unittests/test_session.py
+++ b/test/unittests/test_session.py
@@ -257,6 +257,34 @@ class TestSessionManager(unittest.TestCase):
         # the early reference observes the mutation without being re-fetched
         self.assertTrue(held.is_speaking)
 
+    def test_update_from_present_empty_overrides(self):
+        # SESSION-1 §2: a snapshot that carries an (empty) value for a field
+        # overrides the live session's value — folding is spec-deserialization,
+        # not a self-preserving merge that keeps stale state.
+        from ovos_bus_client.session import Session
+        from ovos_bus_client.message import Message
+        held = self.SessionManager.get(
+            Message("a", context={"session": Session("sid-clear").serialize()}))
+        held.activate_skill("skill.foo")
+        self.assertTrue(held.active_skills)
+
+        # a later snapshot with no active skills must clear the singleton
+        self.SessionManager.update(Session("sid-clear"))
+        self.assertEqual(held.active_skills, [])
+
+    def test_update_from_does_not_alias_nested_state(self):
+        # round-tripping through (de)serialize rebuilds nested objects, so the
+        # live singleton never shares mutable sub-objects with the snapshot.
+        from ovos_bus_client.session import Session
+        live = Session("sid-alias")
+        snapshot = Session("sid-alias")
+        snapshot.activate_skill("skill.bar")
+        live.update_from(snapshot)
+        self.assertTrue(live.active_skills)
+        # mutating the snapshot afterwards must not leak into the live object
+        snapshot.active_handlers.clear()
+        self.assertTrue(live.active_skills)
+
     def test_touch(self):
         # TODO
         pass


### PR DESCRIPTION
`Session.update_from` previously folded an incoming snapshot onto the live singleton with a raw `self.__dict__.update(other.__dict__)` merge. That is not OVOS-SESSION-1 §2 compliant:

- a present-but-empty wire field must **override** the live value (a snapshot that dropped all active skills must clear them), and
- a null/omitted field must resolve to the **spec default**.

This routes the fold through `serialize`/`deserialize` instead, so folding behaves exactly like parsing a freshly received message. As a bonus, the round-trip rebuilds nested state (`context`, handler lists), so the singleton never aliases the snapshot's mutable sub-objects.

Follow-up to #249 (singleton). Adds tests for present-empty-overrides and no-aliasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session updates so incoming snapshots fully refresh live session state, including nested context and handler data.
  * Empty values in snapshots now correctly clear previously stored active skills instead of leaving old data behind.
  * Updated session handling to prevent shared references, so later changes to a snapshot won’t unexpectedly affect the active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->