### PR TITLE
fix: emit stamps the live session for the message's own id

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -283,10 +283,13 @@ class MessageBusClient:
         Args:
             message (Message): Message to send
         """
-        if "session" not in message.context:
-            sess = SessionManager.sessions.get(self.session_id) or \
-                   Session(self.session_id)
-            message.context["session"] = sess.serialize()
+        # stamp the outgoing message with the freshest live session for its own
+        # id (not merely inject-when-missing). Components follow get->mutate->
+        # forward, and Message.forward/reply deep-copy the PRE-mutation session
+        # snapshot; re-stamping here keeps that stale copy from riding onto the
+        # wire and regressing the singleton when a consumer folds it back. See
+        # SessionManager.sync_message_session for the full rationale + safety.
+        SessionManager.sync_message_session(message, self.session_id)
 
         self._send(message)
 

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1016,6 +1016,53 @@ class SessionManager:
 
         return sess
 
+    @classmethod
+    def sync_message_session(cls, message: Message,
+                            default_session_id: str = "default") -> Message:
+        """Stamp an outgoing message with the freshest live session for *its own* id.
+
+        WHY THIS IS NECESSARY (and not a workaround):
+        The bus is value-passing and ``SessionManager`` keeps ONE live ``Session``
+        per id. The happy path for any component is
+        ``sess = SessionManager.get(message)`` -> mutate ``sess`` -> emit a
+        ``message.forward(...)`` (e.g. ``self.speak`` from a handler, or the
+        OVOS-PIPELINE-1 §8 lifecycle trio from the dispatcher / HandlerLifecycle).
+        But ``Message.forward`` / ``Message.reply`` DEEP-COPY the *originating*
+        message's ``context["session"]`` — the snapshot as it was BEFORE the
+        mutation. Without a fix, that stale snapshot rides onto the wire and, when
+        a consumer (or the FakeBus ``on_message`` hook) folds it back onto the
+        singleton, REGRESSES shared state (e.g. ``active_skills`` dropping a skill
+        that was just activated). Re-stamping every outgoing message with the live
+        session here closes that gap centrally, so individual emitters do not each
+        have to remember to re-serialize the session after every mutation.
+
+        This is SAFE — it never discards a legitimate update — because in-process
+        session mutations go through ``Session`` methods that ``touch()`` ->
+        ``SessionManager.update`` the singleton, so the singleton is always at
+        least as fresh as any message built in this process.
+
+        Safety guard: a ``session_id`` this process does NOT hold is left untouched
+        (e.g. a HiveMind relay forwarding a remote/authoritative session it never
+        folded locally) — we never overwrite a session we don't own. A message with
+        no session at all is stamped with the default session (matching the prior
+        inject-when-missing behaviour).
+
+        @param message: outgoing Message to stamp (mutated in place)
+        @param default_session_id: the emitting client's bound session id, used
+            when the message carries no session of its own
+        @return: the same Message, for chaining
+        """
+        incoming = message.context.get("session")
+        sid = incoming.get("session_id") if isinstance(incoming, dict) else None
+        sid = sid or default_session_id
+        live = cls.sessions.get(sid)
+        if live is not None:
+            message.context["session"] = live.serialize()
+        elif incoming is None:
+            sess = cls.sessions.get(default_session_id) or Session(default_session_id)
+            message.context["session"] = sess.serialize()
+        return message
+
     @staticmethod
     def touch(message: Message = None):
         """

--- a/test/unittests/test_session.py
+++ b/test/unittests/test_session.py
@@ -285,6 +285,44 @@ class TestSessionManager(unittest.TestCase):
         snapshot.active_handlers.clear()
         self.assertTrue(live.active_skills)
 
+    def test_sync_message_session_stamps_live_state(self):
+        # the singleton outbound half: an outgoing message carrying a STALE
+        # snapshot for an id we hold is re-stamped with the live state, so a
+        # stale reply/forward copy can't propagate onto the wire.
+        from ovos_bus_client.session import Session
+        from ovos_bus_client.message import Message
+        live = self.SessionManager.update(Session("sid-sync"))
+        live.activate_skill("skill.live")
+
+        stale = Session("sid-sync")  # no active skills — a pre-activation copy
+        msg = Message("x", context={"session": stale.serialize()})
+        self.SessionManager.sync_message_session(msg, "default")
+
+        stamped = msg.context["session"]["active_skills"]
+        self.assertEqual([s[0] for s in stamped], ["skill.live"])
+
+    def test_sync_message_session_leaves_unowned_id_untouched(self):
+        # safety guard: a session_id this process does NOT hold is never
+        # overwritten (e.g. a relay forwarding a remote session).
+        from ovos_bus_client.message import Message
+        # craft the dict directly: building a Session + activate_skill would
+        # auto-register it via touch()->update, which would own the id.
+        snapshot = {"session_id": "sid-remote-unowned",
+                    "active_skills": [["skill.remote", 1.0]]}
+        msg = Message("x", context={"session": dict(snapshot)})
+
+        self.assertNotIn("sid-remote-unowned", self.SessionManager.sessions)
+        self.SessionManager.sync_message_session(msg, "default")
+        self.assertEqual(msg.context["session"], snapshot)  # untouched
+
+    def test_sync_message_session_injects_default_when_absent(self):
+        # a message with no session at all gets the default-session stamp
+        # (matches the prior inject-when-missing behaviour).
+        from ovos_bus_client.message import Message
+        msg = Message("x", context={})
+        self.SessionManager.sync_message_session(msg, "default")
+        self.assertEqual(msg.context["session"]["session_id"], "default")
+
     def test_touch(self):
         # TODO
         pass


### PR DESCRIPTION
## Why

The bus is value-passing and `SessionManager` keeps **one live `Session` per id** (the singleton). The universal pattern for every component is:

```python
sess = SessionManager.get(message)   # folds the incoming snapshot, returns the singleton
sess.activate_skill(...)             # mutate
self.bus.emit(message.forward(...))  # e.g. self.speak, or the PIPELINE-1 §8 lifecycle trio
```

But `Message.forward`/`Message.reply` **deep-copy the originating message's `context["session"]`** — the snapshot as it was *before* the mutation. That stale copy then rides onto the wire and, when a consumer (or the FakeBus `on_message` hook) folds it back onto the singleton, **regresses shared state** (e.g. `active_skills` dropping a skill that was just activated). This is exactly what surfaced once the SessionManager became a per-id singleton (#249) — the old throwaway-per-message `get()` hid it.

## What

`MessageBusClient.emit()` now re-stamps every outgoing message with the freshest live session for the message's **own** `session_id`, via a new documented helper `SessionManager.sync_message_session(message, default_session_id)` — instead of injecting a session only when one is absent.

This is the **outbound half** of the singleton invariant; the inbound half is the existing fold in `get()`/`update()`. Together: the singleton is authoritative and the wire always reflects it.

### Safety
- **Never discards a legitimate update**: in-process session mutations go through `Session` methods that `touch() -> SessionManager.update` the singleton, so the singleton is always ≥ any message built in this process.
- **Own-the-id guard**: a `session_id` this process does *not* hold is left untouched (e.g. a HiveMind relay forwarding a remote/authoritative session it never folded locally) — we never overwrite a session we don't own.
- A message with no session at all still gets the default-session stamp (prior inject-when-missing behaviour preserved).

## Tests
3 new unit tests on `sync_message_session`: stamps live state over a stale snapshot; leaves an unowned id untouched; injects default when absent. Full unit suite green (one pre-existing, unrelated `test_00_init` scheduler-file flake).

Companion harness-parity change in ovos-utils FakeBus is a separate PR. Builds on #249 + #251 (session singleton + spec-compliant `update_from`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Outgoing messages now always carry the latest in-memory session data when available, reducing stale session information on the bus.
  * Messages without session context now receive a default session automatically.
  * Messages tied to sessions not managed locally are left unchanged.

* **Tests**
  * Added coverage for session refresh, non-owned sessions, and missing session context behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->