### PR TITLE
feat: unify legacy Session.context onto canonical intent_context

### DIFF
--- a/docs/session.md
+++ b/docs/session.md
@@ -36,11 +36,11 @@ malformed and is treated as absent. So `blacklisted_intents: []` does not assert
 "this session blacklists nothing"; to do that, the deployment default must itself be
 empty.
 
-§3.4 states the omit-when-empty rule as a SHOULD, not a MUST — emitting a field that
-already holds the deployment default is conformant, and consumers must tolerate it.
-`Session.serialize()` therefore always emits `pipeline`, `blacklisted_skills` and
-`blacklisted_intents` carrying their config-resolved values, so readers indexing the
-raw dict always find a concrete list rather than having to re-derive the default.
+`Session.serialize()` therefore omits these fields when they are empty, rather than
+restating the deployment default on every Message — §3.4 exists precisely to keep the
+session from adding hundreds of bytes to every `forward`, `reply`, and cross-process
+hop. Read them off a deserialized `Session`, whose attributes are always concrete
+lists, rather than indexing the raw serialized dict, where an absent key is normal.
 
 ### Session.from_message
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -26,6 +26,22 @@ Each `Session` holds:
 
 Sessions serialize to/from plain dicts via `Session.serialize()` / `Session.deserialize()` — `ovos_bus_client/session.py:441,493`. They are carried inside `message.context["session"]` on every bus message.
 
+### Omitted and empty override fields
+
+On the list-valued override fields — `pipeline`, the three `blacklisted_*`, and the
+`*_transformers` chains — an empty list is wire-equivalent to an absent key
+(OVOS-SESSION-1 §3.4). Both mean *"let the orchestrator decide"*, and a consumer
+resolves them to its own deployment default from `ovos-config`. An explicit `null` is
+malformed and is treated as absent. So `blacklisted_intents: []` does not assert
+"this session blacklists nothing"; to do that, the deployment default must itself be
+empty.
+
+§3.4 states the omit-when-empty rule as a SHOULD, not a MUST — emitting a field that
+already holds the deployment default is conformant, and consumers must tolerate it.
+`Session.serialize()` therefore always emits `pipeline`, `blacklisted_skills` and
+`blacklisted_intents` carrying their config-resolved values, so readers indexing the
+raw dict always find a concrete list rather than having to re-derive the default.
+
 ### Session.from_message
 
 `Session.from_message(message)` — `ovos_bus_client/session.py:537`

--- a/docs/session.md
+++ b/docs/session.md
@@ -42,6 +42,21 @@ session from adding hundreds of bytes to every `forward`, `reply`, and cross-pro
 hop. Read them off a deserialized `Session`, whose attributes are always concrete
 lists, rather than indexing the raw serialized dict, where an absent key is normal.
 
+#### Emitting the defaults anyway
+
+A lean wire shape is the default, but a deployment can ask for the resolved values to
+travel on every Message — useful when the reader cannot see the producer's config, as
+with a bus monitor or a captured replay. §3.4 calls this "non-optimal but conformant",
+and consumers must tolerate it either way.
+
+| | |
+|---|---|
+| Environment variable | `OVOS_SESSION_EMIT_DEFAULTS=true` |
+| Config key | `session.emit_defaults: true` |
+
+The environment variable wins when set. Both wire shapes deserialize to identical
+`Session` objects; only the number of bytes on the bus differs.
+
 ### Session.from_message
 
 `Session.from_message(message)` — `ovos_bus_client/session.py:537`

--- a/docs/session.md
+++ b/docs/session.md
@@ -42,20 +42,23 @@ session from adding hundreds of bytes to every `forward`, `reply`, and cross-pro
 hop. Read them off a deserialized `Session`, whose attributes are always concrete
 lists, rather than indexing the raw serialized dict, where an absent key is normal.
 
-#### Emitting the defaults anyway
+### Intent-context removal tombstones
 
-A lean wire shape is the default, but a deployment can ask for the resolved values to
-travel on every Message — useful when the reader cannot see the producer's config, as
-with a bus monitor or a captured replay. §3.4 calls this "non-optimal but conformant",
-and consumers must tolerate it either way.
+`Session.remove_intent_context()` / `clear_intent_context()` (and the legacy
+`Session.context` view's `remove_context` / `clear_context`) do not pop entries from
+`session.intent_context` — they replace them **in place** with a `null` **tombstone**.
+OVOS-CONTEXT-1 §5.3 propagates deletions as null entries in the `ovos.session.sync`
+payload, and a popped key would simply be *absent* from the payload, which §5.3
+defines as "unchanged" — the orchestrator would keep the entry alive. The tombstone
+keeps the deletion visible in every serialized snapshot of the session until it is
+applied.
 
-| | |
-|---|---|
-| Environment variable | `OVOS_SESSION_EMIT_DEFAULTS=true` |
-| Config key | `session.emit_defaults: true` |
-
-The environment variable wins when set. Both wire shapes deserialize to identical
-`Session` objects; only the number of bytes on the bus differs.
+A tombstone is never *live* (§2): CONTEXT-1 gating, §7 slot fill, and the legacy
+frame-stack projection all treat it as absent, the receiving `ovos.session.sync`
+merge deletes the key, and the orchestrator's §4 pre-match prune reaps it locally.
+Consequence for readers: test an entry for **liveness** (`ovos_spec_tools.context.is_live`)
+or truthiness, never bare key membership — `"person" in session.intent_context` is
+`True` while a removal is still propagating.
 
 ### Session.from_message
 

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1,5 +1,6 @@
 import enum
 import time
+from os import environ
 from threading import Event
 from typing import Optional, List, Tuple, Union, Iterable, Dict, Any
 from uuid import uuid4
@@ -60,6 +61,38 @@ _CANONICAL_LIST_FIELDS = (
 _CANONICAL_DICT_FIELDS = (
     "intent_context",
 )
+
+# SESSION-1 §3.4: on these list-valued override fields an empty array is
+# wire-equivalent to omission, and a producer SHOULD NOT restate a value the
+# consumer would compute as the deployment default anyway. They are dropped when
+# empty so the session does not add wire weight to every Message.
+_DEFERRABLE_LIST_FIELDS = (
+    "blacklisted_skills",
+    "blacklisted_intents",
+    "pipeline",
+)
+
+
+def _emit_session_defaults() -> bool:
+    """Whether serialize() should spell out deferrable fields it may omit.
+
+    Off by default: §3.4's omit rule is a SHOULD, so a lean wire shape is the
+    conformant default. Turning this on makes every Message carry the resolved
+    deployment defaults instead of deferring them to the consumer -- redundant
+    but still conformant (§3.4: "non-optimal but conformant"), and useful when
+    inspecting or replaying a bus where the reader has no access to the
+    producer's config.
+
+    ``OVOS_SESSION_EMIT_DEFAULTS`` wins when set; otherwise the
+    ``session.emit_defaults`` config key is read.
+    """
+    val = environ.get("OVOS_SESSION_EMIT_DEFAULTS")
+    if val is not None:
+        return val.strip().lower() in ("1", "true", "yes", "on")
+    try:
+        return bool(Configuration().get("session", {}).get("emit_defaults", False))
+    except Exception:
+        return False
 
 
 class UtteranceState(str, enum.Enum):
@@ -1067,6 +1100,14 @@ class Session(_SpecSession):
         # omission-not-null — empty values are absent, never serialized as null
         # or forced ``[]``.
         data = super().to_dict()
+
+        # Opt-in: spell out the deferrable fields the parent dropped, carrying
+        # the value already resolved from ovos-config. Redundant on the wire but
+        # conformant, and it lets a reader that cannot see the producer's config
+        # (a bus monitor, a replay) observe what the session actually resolved to.
+        if _emit_session_defaults():
+            for _name in _DEFERRABLE_LIST_FIELDS:
+                data[_name] = list(getattr(self, _name) or [])
 
         # Legacy back-compat wire keys, DERIVED from the canonical state (never a
         # parallel store) so old ecosystem readers parsing the raw dict keep

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -8,6 +8,7 @@ from ovos_config.config import Configuration
 from ovos_config.locale import get_default_lang
 from ovos_utils.log import LOG, log_deprecation
 from ovos_spec_tools import standardize_lang, SpecMessage
+from ovos_spec_tools.context import resolve_key
 from ovos_spec_tools.session import (Session as _SpecSession,
                                      SessionManager as _SpecSessionManager,
                                      DEFAULT_CONVERSE_HANDLERS_CAP,
@@ -782,6 +783,74 @@ class Session(_SpecSession):
     def clear_response_mode(self, skill_id: Optional[str] = None):
         super().clear_response_mode(skill_id)
         self.touch()
+
+    # ------------------------------------------------------------------
+    # OVOS-CONTEXT-1 §2/§3.1 intent-context mutators — the CANONICAL write
+    # path into ``intent_context``. Every entry lands on the flat §2 map at
+    # its §3.1 resolved stored key; the legacy ``Session.context`` frame stack
+    # (``_IntentContextView``) is a derived read/fold view over this same map,
+    # never a parallel store. All three mutate the map in place so the
+    # singleton Session — and the map object other views hold — keep identity.
+    # ------------------------------------------------------------------
+    def set_intent_context(self, key: str, value: Any = None, *,
+                           scope: str = "private",
+                           owner_id: Optional[str] = None,
+                           expires_at: Optional[float] = None,
+                           turns_remaining: Optional[int] = None):
+        """Write/replace one OVOS-CONTEXT-1 §2 intent-context entry.
+
+        The caller-chosen ``key`` is resolved to its stored form per §3.1
+        (``private`` -> ``<owner_id>:<key>``, ``shared`` -> the bare ``<key>``)
+        and mapped to the §2 entry ``{value, expires_at?, turns_remaining?}``
+        (the optional decay fields are omitted when unset, per §2). A private
+        write with no ``owner_id`` cannot resolve a key and is a no-op.
+
+        @param key: the caller-chosen sub-key (unprefixed).
+        @param value: the entry value; ``None`` marks a valueless gate (§6).
+        @param scope: ``"private"`` (default) or ``"shared"``.
+        @param owner_id: the declaring ``skill_id`` / ``pipeline_id``;
+            required for private scope.
+        @param expires_at: optional §2/§4 wall-clock expiry.
+        @param turns_remaining: optional §2/§4 turn-count decay budget.
+        """
+        stored = resolve_key(key, scope, owner_id)
+        if stored is None:
+            LOG.warning(f"cannot set private intent_context '{key}' without "
+                        f"an owner_id; ignoring")
+            return
+        entry: Dict[str, Any] = {"value": value}
+        if expires_at is not None:
+            entry["expires_at"] = expires_at
+        if turns_remaining is not None:
+            entry["turns_remaining"] = turns_remaining
+        if self.intent_context is None:
+            self.intent_context = {}
+        self.intent_context[stored] = entry
+        self.touch()
+
+    def remove_intent_context(self, key: str, *,
+                              scope: str = "private",
+                              owner_id: Optional[str] = None):
+        """Drop one OVOS-CONTEXT-1 intent-context entry by its declaration.
+
+        The ``key`` is resolved per §3.1 and popped from the canonical map; a
+        missing key (or an unresolvable private lookup) is a silent no-op.
+        """
+        stored = resolve_key(key, scope, owner_id)
+        if stored is None or not self.intent_context:
+            return
+        if self.intent_context.pop(stored, None) is not None:
+            self.touch()
+
+    def clear_intent_context(self):
+        """Empty the whole OVOS-CONTEXT-1 intent-context map.
+
+        Cleared in place so the field stays an empty container (SESSION-1 §2.1
+        in-process normalization), never ``None``.
+        """
+        if self.intent_context:
+            self.intent_context.clear()
+            self.touch()
 
     # ------------------------------------------------------------------
     # Back-compat projections — legacy readers across the ecosystem still

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1,7 +1,6 @@
 import enum
 import time
-from os import environ
-from threading import Event
+from threading import Event, RLock
 from typing import Optional, List, Tuple, Union, Iterable, Dict, Any
 from uuid import uuid4
 
@@ -62,37 +61,22 @@ _CANONICAL_DICT_FIELDS = (
     "intent_context",
 )
 
-# SESSION-1 §3.4: on these list-valued override fields an empty array is
-# wire-equivalent to omission, and a producer SHOULD NOT restate a value the
-# consumer would compute as the deployment default anyway. They are dropped when
-# empty so the session does not add wire weight to every Message.
-_DEFERRABLE_LIST_FIELDS = (
-    "blacklisted_skills",
-    "blacklisted_intents",
-    "pipeline",
-)
+# Guards every mutation of a Session's ``intent_context`` map (the canonical
+# mutators, the legacy view's write-through folds, and the §5.3 sync merge).
+# Bus handlers run on reader threads, so two writers — or a writer racing the
+# sync merge's iteration — are a real schedule. A single module-level lock is
+# deliberate: contention is negligible (mutations are tiny dict ops) and a
+# per-instance lock would be replaced whenever ``update_from`` swaps a
+# session's ``__dict__``, silently splitting the mutual exclusion.
+_CONTEXT_LOCK = RLock()
 
 
-def _emit_session_defaults() -> bool:
-    """Whether serialize() should spell out deferrable fields it may omit.
-
-    Off by default: §3.4's omit rule is a SHOULD, so a lean wire shape is the
-    conformant default. Turning this on makes every Message carry the resolved
-    deployment defaults instead of deferring them to the consumer -- redundant
-    but still conformant (§3.4: "non-optimal but conformant"), and useful when
-    inspecting or replaying a bus where the reader has no access to the
-    producer's config.
-
-    ``OVOS_SESSION_EMIT_DEFAULTS`` wins when set; otherwise the
-    ``session.emit_defaults`` config key is read.
-    """
-    val = environ.get("OVOS_SESSION_EMIT_DEFAULTS")
-    if val is not None:
-        return val.strip().lower() in ("1", "true", "yes", "on")
-    try:
-        return bool(Configuration().get("session", {}).get("emit_defaults", False))
-    except Exception:
-        return False
+def _warn_legacy_view(legacy: str, spec: str, canonical: str):
+    """Log the standard deprecation for a legacy back-compat view access."""
+    log_deprecation(f"Session.{legacy} is a legacy view of the canonical "
+                    f"{spec} {canonical} field and will be removed; "
+                    f"use {canonical} directly",
+                    _NEXT_MAJOR_VERSION)
 
 
 class UtteranceState(str, enum.Enum):
@@ -121,10 +105,7 @@ class _UtteranceStatesView(dict):
 
     @staticmethod
     def _warn():
-        log_deprecation("Session.utterance_states is a legacy view of the "
-                        "canonical OVOS-CONVERSE-1 response_mode field and will "
-                        "be removed; use response_mode directly",
-                        _NEXT_MAJOR_VERSION)
+        _warn_legacy_view("utterance_states", "OVOS-CONVERSE-1", "response_mode")
 
     def _project(self) -> Dict:
         """Project the canonical response_mode holder to the legacy mapping."""
@@ -485,15 +466,24 @@ class _IntentContextView(IntentContextManager):
                 "origin": key}
 
     def _write(self, payload: Dict[str, Any]):
-        """Fold ``payload`` (CONTEXT-1 set/null-delete) into intent_context.
+        """Fold ``payload`` into ``intent_context`` (writer-side semantics).
 
-        Merged in place, like the canonical mutators: the map keeps its object
+        Applied in place, like the canonical mutators: the map keeps its object
         identity so a holder of the dict sees the write, and it stays an empty
-        container rather than becoming ``None`` when the last entry is removed.
+        container rather than becoming ``None``.
+
+        A ``None`` payload value is stored as a **tombstone** (`key -> null`),
+        not popped: OVOS-CONTEXT-1 §5.3 propagates deletions as null entries in
+        the sync payload, so a removal must stay visible in the map this
+        session serializes. Receivers apply the null-delete when they merge
+        (:meth:`SessionManager.merge_intent_context`); a tombstone is never
+        live (§2), so gating, slot fill, and the frame-stack projection all
+        treat it as absent, and the orchestrator's §4 prune reaps it.
         """
-        if self._session.intent_context is None:
-            self._session.intent_context = {}
-        SessionManager.merge_intent_context(self._session.intent_context, payload)
+        with _CONTEXT_LOCK:
+            if self._session.intent_context is None:
+                self._session.intent_context = {}
+            self._session.intent_context.update(payload)
         self._session.touch()
 
     # --- derived frame stack (read path for the inherited get_context) ---
@@ -528,17 +518,45 @@ class _IntentContextView(IntentContextManager):
 
     @frame_stack.setter
     def frame_stack(self, value):
-        """Ingest a legacy frame stack back into ``intent_context``."""
-        self._write(self._frames_to_entries(value))
+        """Replace the legacy frame stack (assignment = replacement).
+
+        Legacy ``IntentContextManager`` callers prune the stack by assigning a
+        filtered list, so assignment must carry *removal* semantics: every key
+        currently projected into the stack that the new stack no longer
+        represents is tombstoned (null-delete, §5.3), and the new stack's
+        entities are folded in. Entries the legacy stack cannot represent
+        (null flags, non-string values) are untouched — they were never part
+        of the projected stack, so a stack assignment says nothing about them.
+        """
+        payload = self._frames_to_entries(value)
+        projected = {frame.entities[0]["origin"]
+                     for frame, _ts in self.frame_stack}
+        for key in projected:
+            if key not in payload:
+                payload[key] = None
+        self._write(payload)
 
     def _frames_to_entries(self, frames) -> Dict[str, Any]:
-        """Project a legacy ``[(frame, ts), ...]`` stack to CONTEXT-1 entries."""
+        """Project a legacy ``[(frame, ts), ...]`` stack to CONTEXT-1 entries.
+
+        The legacy liveness rule is ``now - ts < timeout``, so each frame's own
+        timestamp anchors the projected ``expires_at`` (``ts + timeout``) — a
+        stale frame that legacy ``get_context`` would already have filtered out
+        is **not** resurrected with a fresh window; it is skipped.
+        """
         payload: Dict[str, Any] = {}
-        for frame, _ts in (frames or []):
+        now = time.time()
+        for frame, ts in (frames or []):
             for entity in getattr(frame, "entities", []):
                 key, entry = self._entity_to_entry(entity)
-                if key:
-                    payload[key] = entry
+                if not key:
+                    continue
+                if self.timeout and self.timeout > 0:
+                    expires_at = (ts if ts is not None else now) + self.timeout
+                    if expires_at <= now:
+                        continue  # dead under legacy semantics — stays dead
+                    entry["expires_at"] = expires_at
+                payload[key] = entry
         return payload
 
     # --- write path overrides -------------------------------------------
@@ -549,13 +567,21 @@ class _IntentContextView(IntentContextManager):
         self._write({key: entry})
 
     def remove_context(self, context_id: str):
-        self._write({context_id: None})
+        # a tombstone (null entry, §5.3) rather than a pop, so the removal
+        # propagates when this session is serialized into a sync payload; a
+        # missing key is a silent no-op, matching the canonical remover.
+        if context_id in (self._session.intent_context or {}):
+            self._write({context_id: None})
 
     def clear_context(self):
-        # cleared in place, mirroring Session.clear_intent_context: the field
-        # stays an empty container, never ``None``.
-        if self._session.intent_context:
-            self._session.intent_context.clear()
+        # every entry becomes a tombstone, in place: the map keeps its object
+        # identity, stays a dict (never ``None``), and the clear propagates as
+        # §5.3 null-deletes when the session is serialized into a sync payload.
+        with _CONTEXT_LOCK:
+            ctx = self._session.intent_context
+            if ctx:
+                for key in ctx:
+                    ctx[key] = None
         self._session.touch()
 
 
@@ -744,8 +770,13 @@ class Session(_SpecSession):
         # construction, which the SessionManager fold re-enters via
         # deserialize(); touching here would recurse under the registry lock.
         if context is not None and not self.intent_context:
-            entries = _IntentContextView(self)._frames_to_entries(
-                getattr(context, "frame_stack", []))
+            # the fold honours the legacy manager's OWN timeout and each
+            # frame's timestamp, so entries expire exactly when the legacy
+            # ``get_context`` filter would have dropped them; frames already
+            # dead under that rule are not resurrected.
+            entries = _IntentContextView(
+                self, timeout=getattr(context, "timeout", None)
+            )._frames_to_entries(getattr(context, "frame_stack", []))
             if entries:
                 self.intent_context = entries
         # persona_id is an inherited canonical field (OVOS-PERSONA-1, registered
@@ -770,6 +801,20 @@ class Session(_SpecSession):
             if getattr(self, name, None) is None:
                 setattr(self, name, {})
 
+    def _context_view(self) -> "_IntentContextView":
+        """Return the (cached) adapt-style view over ``intent_context``.
+
+        The view holds no state of its own beyond config scalars, so one
+        instance per session suffices; it is rebuilt only when the cached
+        instance is bound to a different session object (``update_from``
+        swaps ``__dict__`` wholesale, carrying the cache across objects).
+        """
+        view = self.__dict__.get("_ctx_view")
+        if view is None or view._session is not self:
+            view = _IntentContextView(self)
+            self.__dict__["_ctx_view"] = view
+        return view
+
     @property
     def context(self) -> "_IntentContextView":
         """DEPRECATED adapt-style frame-stack view of ``intent_context``.
@@ -785,7 +830,7 @@ class Session(_SpecSession):
                         "OVOS-CONTEXT-1 session.intent_context map and will be "
                         "removed; use intent_context directly",
                         _NEXT_MAJOR_VERSION)
-        return _IntentContextView(self)
+        return self._context_view()
 
     @property
     def timezone(self) -> Optional[str]:
@@ -855,7 +900,8 @@ class Session(_SpecSession):
         (``private`` -> ``<owner_id>:<key>``, ``shared`` -> the bare ``<key>``)
         and mapped to the §2 entry ``{value, expires_at?, turns_remaining?}``
         (the optional decay fields are omitted when unset, per §2). A private
-        write with no ``owner_id`` cannot resolve a key and is a no-op.
+        write cannot resolve a stored key without an ``owner_id`` and raises
+        ``ValueError`` — a silently dropped context write is a debugging trap.
 
         @param key: the caller-chosen sub-key (unprefixed).
         @param value: the entry value; ``None`` marks a valueless gate (§6).
@@ -864,44 +910,69 @@ class Session(_SpecSession):
             required for private scope.
         @param expires_at: optional §2/§4 wall-clock expiry.
         @param turns_remaining: optional §2/§4 turn-count decay budget.
+        @raise ValueError: private scope with no ``owner_id``.
         """
         stored = resolve_key(key, scope, owner_id)
         if stored is None:
-            LOG.warning(f"cannot set private intent_context '{key}' without "
-                        f"an owner_id; ignoring")
-            return
+            raise ValueError(f"cannot set private intent_context '{key}' "
+                             f"without an owner_id; pass owner_id=<skill_id> "
+                             f"or scope='shared'")
         entry: Dict[str, Any] = {"value": value}
         if expires_at is not None:
             entry["expires_at"] = expires_at
         if turns_remaining is not None:
             entry["turns_remaining"] = turns_remaining
-        if self.intent_context is None:
-            self.intent_context = {}
-        self.intent_context[stored] = entry
+        with _CONTEXT_LOCK:
+            if self.intent_context is None:
+                self.intent_context = {}
+            self.intent_context[stored] = entry
         self.touch()
 
     def remove_intent_context(self, key: str, *,
                               scope: str = "private",
                               owner_id: Optional[str] = None):
-        """Drop one OVOS-CONTEXT-1 intent-context entry by its declaration.
+        """Remove one OVOS-CONTEXT-1 intent-context entry by its declaration.
 
-        The ``key`` is resolved per §3.1 and popped from the canonical map; a
-        missing key (or an unresolvable private lookup) is a silent no-op.
+        The ``key`` is resolved per §3.1 and **tombstoned** — replaced in
+        place by a ``null`` entry, not popped. §5.3 propagates deletions as
+        null entries in the sync payload, so the removal must stay visible in
+        the map this session serializes; a popped key would be *absent* from
+        the payload, which §5.3 defines as "unchanged", and the orchestrator
+        would keep the entry alive. A tombstone is never live (§2): gating,
+        slot fill, and the legacy frame-stack view treat it as absent, the
+        receiving merge (:meth:`SessionManager.merge_intent_context`) deletes
+        the key, and the orchestrator's §4 prune reaps it locally.
+
+        A missing key (or an unresolvable private lookup) is a silent no-op.
         """
         stored = resolve_key(key, scope, owner_id)
-        if stored is None or not self.intent_context:
-            return
-        if self.intent_context.pop(stored, None) is not None:
+        touched = False
+        with _CONTEXT_LOCK:
+            ctx = self.intent_context
+            if stored is not None and ctx and stored in ctx \
+                    and ctx[stored] is not None:
+                ctx[stored] = None
+                touched = True
+        if touched:
             self.touch()
 
     def clear_intent_context(self):
-        """Empty the whole OVOS-CONTEXT-1 intent-context map.
+        """Remove every OVOS-CONTEXT-1 intent-context entry.
 
-        Cleared in place so the field stays an empty container (SESSION-1 §2.1
-        in-process normalization), never ``None``.
+        Each entry becomes a §5.3 tombstone (see
+        :meth:`remove_intent_context`), applied in place so the field keeps
+        its object identity and stays a dict (SESSION-1 §2.1 in-process
+        normalization), never ``None``.
         """
-        if self.intent_context:
-            self.intent_context.clear()
+        touched = False
+        with _CONTEXT_LOCK:
+            ctx = self.intent_context
+            if ctx:
+                for key in ctx:
+                    if ctx[key] is not None:
+                        ctx[key] = None
+                        touched = True
+        if touched:
             self.touch()
 
     # ------------------------------------------------------------------
@@ -918,19 +989,13 @@ class Session(_SpecSession):
         Reads project the canonical `active_handlers` object list to the legacy
         pair shape, head-first.
         """
-        log_deprecation("Session.active_skills is a legacy view of the canonical "
-                        "OVOS-PIPELINE-1 active_handlers field and will be "
-                        "removed; use active_handlers directly",
-                        _NEXT_MAJOR_VERSION)
+        _warn_legacy_view("active_skills", "OVOS-PIPELINE-1", "active_handlers")
         return [[h["skill_id"], h["activated_at"]] for h in self.active_handlers]
 
     @active_skills.setter
     def active_skills(self, value: Optional[List[List[Union[str, float]]]]):
         """Assigning legacy pairs rewrites the canonical `active_handlers` store."""
-        log_deprecation("Session.active_skills is a legacy view of the canonical "
-                        "OVOS-PIPELINE-1 active_handlers field and will be "
-                        "removed; use active_handlers directly",
-                        _NEXT_MAJOR_VERSION)
+        _warn_legacy_view("active_skills", "OVOS-PIPELINE-1", "active_handlers")
         self.active_handlers = self._coerce_handlers(
             self._pairs_to_handler_objects(value))
 
@@ -973,10 +1038,7 @@ class Session(_SpecSession):
         structured `response_mode` store, preserving the pre-refactor behavior
         where `utterance_states` was a plain mutable dict.
         """
-        log_deprecation("Session.utterance_states is a legacy view of the "
-                        "canonical OVOS-CONVERSE-1 response_mode field and will "
-                        "be removed; use response_mode directly",
-                        _NEXT_MAJOR_VERSION)
+        _warn_legacy_view("utterance_states", "OVOS-CONVERSE-1", "response_mode")
         if self.response_mode and self.response_mode.get("skill_id"):
             projection = {self.response_mode["skill_id"]: UtteranceState.RESPONSE.value}
         else:
@@ -986,10 +1048,7 @@ class Session(_SpecSession):
     @utterance_states.setter
     def utterance_states(self, value: Optional[Dict]):
         """Assigning legacy utterance_states rewrites the structured `response_mode`."""
-        log_deprecation("Session.utterance_states is a legacy view of the "
-                        "canonical OVOS-CONVERSE-1 response_mode field and will "
-                        "be removed; use response_mode directly",
-                        _NEXT_MAJOR_VERSION)
+        _warn_legacy_view("utterance_states", "OVOS-CONVERSE-1", "response_mode")
         self.response_mode = None
         for skill_id, state in (value or {}).items():
             if state == UtteranceState.RESPONSE.value:
@@ -1101,14 +1160,6 @@ class Session(_SpecSession):
         # or forced ``[]``.
         data = super().to_dict()
 
-        # Opt-in: spell out the deferrable fields the parent dropped, carrying
-        # the value already resolved from ovos-config. Redundant on the wire but
-        # conformant, and it lets a reader that cannot see the producer's config
-        # (a bus monitor, a replay) observe what the session actually resolved to.
-        if _emit_session_defaults():
-            for _name in _DEFERRABLE_LIST_FIELDS:
-                data[_name] = list(getattr(self, _name) or [])
-
         # Legacy back-compat wire keys, DERIVED from the canonical state (never a
         # parallel store) so old ecosystem readers parsing the raw dict keep
         # working for one deprecation cycle:
@@ -1128,7 +1179,7 @@ class Session(_SpecSession):
             "active_skills": legacy_active,
             "utterance_states": legacy_states,
             "session_id": self.session_id,
-            "context": _IntentContextView(self).serialize(),
+            "context": self._context_view().serialize(),
             "location": self.location_preferences,
             "system_unit": self.system_unit,
             "time_format": self.time_format,
@@ -1293,6 +1344,14 @@ class _BusSessionManagerMixin:
     bus = None
 
     @classmethod
+    def _broadcast_default_session(cls, message=None):
+        """Emit the legacy ``ovos.session.update_default`` default-session echo."""
+        if cls.bus:
+            message = message or Message(SpecMessage.SESSION_SYNC)
+            cls.bus.emit(message.reply("ovos.session.update_default",
+                                       {"session_data": cls.default_session.serialize()}))
+
+    @classmethod
     def sync(cls, message=None):
         """Broadcast the default session on the bus.
 
@@ -1304,10 +1363,7 @@ class _BusSessionManagerMixin:
                         "legacy; the default session propagates by value-passing "
                         "like any other session",
                         _NEXT_MAJOR_VERSION)
-        if cls.bus:
-            message = message or Message(SpecMessage.SESSION_SYNC)
-            cls.bus.emit(message.reply("ovos.session.update_default",
-                                       {"session_data": cls.default_session.serialize()}))
+        cls._broadcast_default_session(message)
 
     @classmethod
     def connect_to_bus(cls, bus):
@@ -1317,7 +1373,7 @@ class _BusSessionManagerMixin:
         cls.bus.on("recognizer_loop:audio_output_start", cls.handle_audio_output_start)
         cls.bus.on("recognizer_loop:audio_output_end", cls.handle_audio_output_end)
         cls.bus.on(SpecMessage.SESSION_SYNC, cls.handle_session_sync)
-        cls.sync()
+        cls._broadcast_default_session()
 
     @classmethod
     def prune_sessions(cls):
@@ -1366,6 +1422,8 @@ class _BusSessionManagerMixin:
             promote a session by setting its id to "default" instead.
         @return: the canonical (singleton) Session for ``sess.session_id``.
         """
+        if not sess:
+            raise ValueError("Expected Session and got None")
         if make_default:
             log_deprecation("'make_default' kwarg is deprecated and will be "
                             "removed; set session_id='default' on the session "
@@ -1375,8 +1433,6 @@ class _BusSessionManagerMixin:
             # this log is dangerous, session may contain things like passwords and access keys
             # this comment is here to avoid reintroducing it by accident
             # LOG.debug(f"replacing default session with: {sess.serialize()}") # DO NOT re-enable in production
-        if not sess:
-            raise ValueError("Expected Session and got None")
         return cls._store(sess)
 
     @classmethod
@@ -1557,28 +1613,37 @@ class _BusSessionManagerMixin:
         singleton resolves the target session and merges the snapshot's
         ``intent_context`` entry-by-entry onto it (set + null-delete, §5.3),
         keeping the managed session the authoritative owner of intent
-        context. The legacy default-session echo is then preserved for
-        callers that emit a bare ``ovos.session.sync`` to *request* the
-        current default session.
+        context. The merge mutates the working map **in place**: the map
+        object every live view holds keeps its identity, and it stays a dict
+        — never ``None`` — per the in-process SESSION-1 §2.1 normalization.
+
+        The legacy default-session echo is emitted only for a **bare**
+        request (no session carrier on the message): a spec-conformant §5.3
+        sync is not a default-session request and triggers no echo.
         """
-        if message is not None:
-            # the session rides in ``message.context.session`` — resolve it
-            # via the canonical carrier rather than ``message.data``.
+        carried = message is not None and \
+            isinstance(getattr(message, "context", None), dict) and \
+            "session" in message.context
+        if carried:
             inbound = Session.from_message(message)
-            payload = inbound.intent_context if inbound else None
-            if payload is not None:
-                # merge onto the *managed* (authoritative) session if we
-                # already track it — the singleton owns the working map.
-                # A session we have never seen is adopted from the carrier.
-                sid = inbound.session_id
-                sess = cls.sessions.get(sid, inbound)
-                merged = cls.merge_intent_context(
-                    dict(sess.intent_context or {}), payload)
-                sess.intent_context = merged or None
-                cls.update(sess)
-                LOG.debug(f"merged intent_context sync for session "
-                          f"'{sess.session_id}': {list(payload.keys())}")
-        cls.sync(message)
+            if inbound:
+                sess = cls.sessions.get(inbound.session_id)
+                if sess is None:
+                    # a session we have never seen is adopted from the carrier
+                    sess = inbound
+                payload = inbound.intent_context
+                if sess is not inbound and payload:
+                    with _CONTEXT_LOCK:
+                        if sess.intent_context is None:
+                            sess.intent_context = {}
+                        cls.merge_intent_context(sess.intent_context, payload)
+                    LOG.debug(f"merged intent_context sync for session "
+                              f"'{sess.session_id}': {list(payload.keys())}")
+                sess.touch()
+        else:
+            # legacy: a bare ``ovos.session.sync`` *requests* the current
+            # default session; echo it back.
+            cls._broadcast_default_session(message)
 
     # legacy alias — ``ovos.session.sync`` historically routed here to echo
     # the default session; it now also performs the OVOS-CONTEXT-1 §5.3 merge

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -71,14 +71,6 @@ _CANONICAL_DICT_FIELDS = (
 _CONTEXT_LOCK = RLock()
 
 
-def _warn_legacy_view(legacy: str, spec: str, canonical: str):
-    """Log the standard deprecation for a legacy back-compat view access."""
-    log_deprecation(f"Session.{legacy} is a legacy view of the canonical "
-                    f"{spec} {canonical} field and will be removed; "
-                    f"use {canonical} directly",
-                    _NEXT_MAJOR_VERSION)
-
-
 class UtteranceState(str, enum.Enum):
     INTENT = "intent"  # includes converse
     RESPONSE = "response"
@@ -103,19 +95,11 @@ class _UtteranceStatesView(dict):
         super().__init__(initial)
         self._session = session
 
-    @staticmethod
-    def _warn():
-        _warn_legacy_view("utterance_states", "OVOS-CONVERSE-1", "response_mode")
-
-    def _project(self) -> Dict:
-        """Project the canonical response_mode holder to the legacy mapping."""
-        mode = self._session.response_mode
-        if mode and mode.get("skill_id"):
-            return {mode["skill_id"]: UtteranceState.RESPONSE.value}
-        return {}
-
     def __setitem__(self, skill_id, state):
-        self._warn()
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
         state_value = getattr(state, "value", state)
         if state_value == UtteranceState.RESPONSE.value:
             self._session.enable_response_mode(skill_id)
@@ -127,16 +111,24 @@ class _UtteranceStatesView(dict):
         # project response_mode directly rather than re-reading the deprecated
         # utterance_states property, which would emit a second warning.
         super().clear()
-        super().update(self._project())
+        mode = self._session.response_mode
+        if mode and mode.get("skill_id"):
+            super().update({mode["skill_id"]: UtteranceState.RESPONSE.value})
 
     def __delitem__(self, skill_id):
-        self._warn()
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
         self._session.disable_response_mode(skill_id)
         if skill_id in self:
             super().__delitem__(skill_id)
 
     def pop(self, skill_id, *args):
-        self._warn()
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
         self._session.disable_response_mode(skill_id)
         return super().pop(skill_id, *args)
 
@@ -145,7 +137,10 @@ class _UtteranceStatesView(dict):
             self[skill_id] = state
 
     def clear(self):
-        self._warn()
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
         self._session.clear_response_mode()
         super().clear()
 
@@ -468,17 +463,10 @@ class _IntentContextView(IntentContextManager):
     def _write(self, payload: Dict[str, Any]):
         """Fold ``payload`` into ``intent_context`` (writer-side semantics).
 
-        Applied in place, like the canonical mutators: the map keeps its object
-        identity so a holder of the dict sees the write, and it stays an empty
-        container rather than becoming ``None``.
-
-        A ``None`` payload value is stored as a **tombstone** (`key -> null`),
-        not popped: OVOS-CONTEXT-1 §5.3 propagates deletions as null entries in
-        the sync payload, so a removal must stay visible in the map this
-        session serializes. Receivers apply the null-delete when they merge
-        (:meth:`SessionManager.merge_intent_context`); a tombstone is never
-        live (§2), so gating, slot fill, and the frame-stack projection all
-        treat it as absent, and the orchestrator's §4 prune reaps it.
+        Applied in place, like the canonical mutators, so the map keeps its
+        object identity and never becomes ``None``. A ``None`` payload value is
+        stored as a §5.3 tombstone, not popped (see
+        :meth:`Session.remove_intent_context`).
         """
         with _CONTEXT_LOCK:
             if self._session.intent_context is None:
@@ -529,11 +517,8 @@ class _IntentContextView(IntentContextManager):
         of the projected stack, so a stack assignment says nothing about them.
         """
         payload = self._frames_to_entries(value)
-        projected = {frame.entities[0]["origin"]
-                     for frame, _ts in self.frame_stack}
-        for key in projected:
-            if key not in payload:
-                payload[key] = None
+        for frame, _ts in self.frame_stack:
+            payload.setdefault(frame.entities[0]["origin"], None)
         self._write(payload)
 
     def _frames_to_entries(self, frames) -> Dict[str, Any]:
@@ -562,9 +547,8 @@ class _IntentContextView(IntentContextManager):
     # --- write path overrides -------------------------------------------
     def inject_context(self, entity: Dict, metadata: Dict = None):
         key, entry = self._entity_to_entry(entity)
-        if key is None:
-            return
-        self._write({key: entry})
+        if key:
+            self._write({key: entry})
 
     def remove_context(self, context_id: str):
         # a tombstone (null entry, §5.3) rather than a pop, so the removal
@@ -896,21 +880,11 @@ class Session(_SpecSession):
                            turns_remaining: Optional[int] = None):
         """Write/replace one OVOS-CONTEXT-1 §2 intent-context entry.
 
-        The caller-chosen ``key`` is resolved to its stored form per §3.1
-        (``private`` -> ``<owner_id>:<key>``, ``shared`` -> the bare ``<key>``)
-        and mapped to the §2 entry ``{value, expires_at?, turns_remaining?}``
-        (the optional decay fields are omitted when unset, per §2). A private
-        write cannot resolve a stored key without an ``owner_id`` and raises
+        ``key`` is resolved to its stored form per §3.1 (``private`` ->
+        ``<owner_id>:<key>``, ``shared`` -> the bare ``<key>``) and mapped to
+        the §2 entry ``{value, expires_at?, turns_remaining?}``, decay fields
+        omitted when unset. A private write without an ``owner_id`` raises
         ``ValueError`` — a silently dropped context write is a debugging trap.
-
-        @param key: the caller-chosen sub-key (unprefixed).
-        @param value: the entry value; ``None`` marks a valueless gate (§6).
-        @param scope: ``"private"`` (default) or ``"shared"``.
-        @param owner_id: the declaring ``skill_id`` / ``pipeline_id``;
-            required for private scope.
-        @param expires_at: optional §2/§4 wall-clock expiry.
-        @param turns_remaining: optional §2/§4 turn-count decay budget.
-        @raise ValueError: private scope with no ``owner_id``.
         """
         stored = resolve_key(key, scope, owner_id)
         if stored is None:
@@ -934,45 +908,34 @@ class Session(_SpecSession):
         """Remove one OVOS-CONTEXT-1 intent-context entry by its declaration.
 
         The ``key`` is resolved per §3.1 and **tombstoned** — replaced in
-        place by a ``null`` entry, not popped. §5.3 propagates deletions as
-        null entries in the sync payload, so the removal must stay visible in
-        the map this session serializes; a popped key would be *absent* from
-        the payload, which §5.3 defines as "unchanged", and the orchestrator
-        would keep the entry alive. A tombstone is never live (§2): gating,
-        slot fill, and the legacy frame-stack view treat it as absent, the
-        receiving merge (:meth:`SessionManager.merge_intent_context`) deletes
-        the key, and the orchestrator's §4 prune reaps it locally.
-
-        A missing key (or an unresolvable private lookup) is a silent no-op.
+        place by a ``null`` entry, not popped, so the deletion stays visible
+        in every serialized snapshot and rides the sync payload as a §5.3
+        null-delete (a popped key would read as "unchanged" and the
+        orchestrator would keep the entry alive). A tombstone is never live
+        (§2). A missing key (or an unresolvable private lookup) is a silent
+        no-op.
         """
         stored = resolve_key(key, scope, owner_id)
-        touched = False
         with _CONTEXT_LOCK:
             ctx = self.intent_context
-            if stored is not None and ctx and stored in ctx \
-                    and ctx[stored] is not None:
-                ctx[stored] = None
-                touched = True
-        if touched:
-            self.touch()
+            if stored is None or not ctx or ctx.get(stored) is None:
+                return
+            ctx[stored] = None
+        self.touch()
 
     def clear_intent_context(self):
         """Remove every OVOS-CONTEXT-1 intent-context entry.
 
         Each entry becomes a §5.3 tombstone (see
-        :meth:`remove_intent_context`), applied in place so the field keeps
-        its object identity and stays a dict (SESSION-1 §2.1 in-process
-        normalization), never ``None``.
+        :meth:`remove_intent_context`), applied in place so the map keeps its
+        object identity and stays a dict, never ``None``.
         """
-        touched = False
         with _CONTEXT_LOCK:
-            ctx = self.intent_context
-            if ctx:
-                for key in ctx:
-                    if ctx[key] is not None:
-                        ctx[key] = None
-                        touched = True
-        if touched:
+            ctx = self.intent_context or {}
+            live = [key for key, entry in ctx.items() if entry is not None]
+            for key in live:
+                ctx[key] = None
+        if live:
             self.touch()
 
     # ------------------------------------------------------------------
@@ -989,13 +952,19 @@ class Session(_SpecSession):
         Reads project the canonical `active_handlers` object list to the legacy
         pair shape, head-first.
         """
-        _warn_legacy_view("active_skills", "OVOS-PIPELINE-1", "active_handlers")
+        log_deprecation("Session.active_skills is a legacy view of the "
+                        "canonical OVOS-PIPELINE-1 active_handlers field and "
+                        "will be removed; use active_handlers directly",
+                        _NEXT_MAJOR_VERSION)
         return [[h["skill_id"], h["activated_at"]] for h in self.active_handlers]
 
     @active_skills.setter
     def active_skills(self, value: Optional[List[List[Union[str, float]]]]):
         """Assigning legacy pairs rewrites the canonical `active_handlers` store."""
-        _warn_legacy_view("active_skills", "OVOS-PIPELINE-1", "active_handlers")
+        log_deprecation("Session.active_skills is a legacy view of the "
+                        "canonical OVOS-PIPELINE-1 active_handlers field and "
+                        "will be removed; use active_handlers directly",
+                        _NEXT_MAJOR_VERSION)
         self.active_handlers = self._coerce_handlers(
             self._pairs_to_handler_objects(value))
 
@@ -1038,7 +1007,10 @@ class Session(_SpecSession):
         structured `response_mode` store, preserving the pre-refactor behavior
         where `utterance_states` was a plain mutable dict.
         """
-        _warn_legacy_view("utterance_states", "OVOS-CONVERSE-1", "response_mode")
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
         if self.response_mode and self.response_mode.get("skill_id"):
             projection = {self.response_mode["skill_id"]: UtteranceState.RESPONSE.value}
         else:
@@ -1048,7 +1020,10 @@ class Session(_SpecSession):
     @utterance_states.setter
     def utterance_states(self, value: Optional[Dict]):
         """Assigning legacy utterance_states rewrites the structured `response_mode`."""
-        _warn_legacy_view("utterance_states", "OVOS-CONVERSE-1", "response_mode")
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
         self.response_mode = None
         for skill_id, state in (value or {}).items():
             if state == UtteranceState.RESPONSE.value:
@@ -1168,16 +1143,12 @@ class Session(_SpecSession):
         #  - ``context`` mirrors intent_context as an IntentContextManager frame
         #    stack. Computed inline (not via the deprecated properties) so
         #    serializing does not emit deprecation warnings.
-        legacy_active = [[h["skill_id"], h["activated_at"]]
-                         for h in self.active_handlers]
-        if self.response_mode and self.response_mode.get("skill_id"):
-            legacy_states = {self.response_mode["skill_id"]:
-                             UtteranceState.RESPONSE.value}
-        else:
-            legacy_states = {}
+        mode = self.response_mode or {}
         data.update({
-            "active_skills": legacy_active,
-            "utterance_states": legacy_states,
+            "active_skills": [[h["skill_id"], h["activated_at"]]
+                              for h in self.active_handlers],
+            "utterance_states": ({mode["skill_id"]: UtteranceState.RESPONSE.value}
+                                 if mode.get("skill_id") else {}),
             "session_id": self.session_id,
             "context": self._context_view().serialize(),
             "location": self.location_preferences,
@@ -1627,10 +1598,8 @@ class _BusSessionManagerMixin:
         if carried:
             inbound = Session.from_message(message)
             if inbound:
-                sess = cls.sessions.get(inbound.session_id)
-                if sess is None:
-                    # a session we have never seen is adopted from the carrier
-                    sess = inbound
+                # a session we have never seen is adopted from the carrier
+                sess = cls.sessions.get(inbound.session_id, inbound)
                 payload = inbound.intent_context
                 if sess is not inbound and payload:
                     with _CONTEXT_LOCK:

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -83,7 +83,15 @@ class _UtteranceStatesView(dict):
         super().__init__(initial)
         self._session = session
 
+    @staticmethod
+    def _warn():
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
+
     def __setitem__(self, skill_id, state):
+        self._warn()
         state_value = getattr(state, "value", state)
         if state_value == UtteranceState.RESPONSE.value:
             self._session.enable_response_mode(skill_id)
@@ -96,11 +104,13 @@ class _UtteranceStatesView(dict):
         super().update(dict(self._session.utterance_states))
 
     def __delitem__(self, skill_id):
+        self._warn()
         self._session.disable_response_mode(skill_id)
         if skill_id in self:
             super().__delitem__(skill_id)
 
     def pop(self, skill_id, *args):
+        self._warn()
         self._session.disable_response_mode(skill_id)
         return super().pop(skill_id, *args)
 
@@ -109,6 +119,7 @@ class _UtteranceStatesView(dict):
             self[skill_id] = state
 
     def clear(self):
+        self._warn()
         self._session.clear_response_mode()
         super().clear()
 
@@ -357,6 +368,144 @@ class IntentContextManager:
         return self._strip_result(result)
 
 
+class _IntentContextView(IntentContextManager):
+    """Adapt-facing frame-stack VIEW projected over ``session.intent_context``.
+
+    The adapt engine drives conversational context through the legacy
+    ``IntentContextManager`` API — ``get_context`` to read tagging hints,
+    ``inject_context`` / ``update_context`` / ``remove_context`` /
+    ``clear_context`` to write. The canonical store is the flat OVOS-CONTEXT-1
+    ``session.intent_context`` map (``key -> {value, expires_at,
+    turns_remaining}``). This view keeps the exact adapt API but holds no state
+    of its own: every read projects from ``intent_context`` and every write
+    folds back into it, so the two are one store rather than a parallel pair.
+
+    Projection mapping (adapt entity <-> CONTEXT-1 entry):
+
+    - a context entity's ``data[0]`` is ``(value, entity_type)``; the
+      ``entity_type`` is the CONTEXT-1 **key** (bare == shared scope, §3) and
+      the ``value`` is the entry ``value``;
+    - a CONTEXT-1 entry projects back to the entity
+      ``{"key": value, "data": [(value, key)], "confidence": .., "origin": key}``;
+    - decay is carried as ``expires_at = now + timeout`` on write; a dead entry
+      (``expires_at`` in the past) is not projected into the frame stack and a
+      ``value: null`` flag entry has no taggable surface form so it is omitted
+      from the stack (it still gates directly via ``intent_context``, §6).
+
+    Frame timestamps are reconstructed from ``expires_at`` so the inherited
+    ``get_context`` timeout filter (``now - ts < timeout``) reproduces the
+    canonical liveness test.
+    """
+
+    def __init__(self, session: "Session", timeout: int = None,
+                 greedy: bool = None, keywords: List[str] = None,
+                 max_frames: int = None):
+        # Deliberately NOT calling super().__init__: the parent stores a
+        # ``frame_stack`` list, but here the stack is a derived property with no
+        # backing storage. Construction must stay side-effect-free (a fresh view
+        # is built on every ``session.context`` access), so only the config-read
+        # scalars are set up here.
+        config = Configuration().get('context', {})
+        self._session = session
+        self.timeout = (config.get('timeout', 2) * 60) if timeout is None else timeout
+        self.context_greedy = config.get('greedy', False) if greedy is None else greedy
+        self.context_keywords = config.get('keywords', []) if keywords is None else keywords
+        self.context_max_frames = config.get('max_frames', 3) if max_frames is None else max_frames
+
+    # --- entity <-> CONTEXT-1 entry mapping ------------------------------
+    def _entity_to_entry(self, entity: Dict) -> Tuple[Optional[str], Optional[Dict]]:
+        """Map an adapt context entity to a ``(key, CONTEXT-1 entry)`` pair."""
+        data = entity.get('data')
+        value = key = None
+        if isinstance(data, (list, tuple)) and data \
+                and isinstance(data[0], (list, tuple)) and len(data[0]) >= 2:
+            value, key = data[0][0], data[0][1]
+        elif isinstance(data, str):
+            key, value = data, entity.get('key')
+        if not key:
+            return None, None
+        entry: Dict[str, Any] = {"value": value}
+        if self.timeout and self.timeout > 0:
+            entry["expires_at"] = time.time() + self.timeout
+        return key, entry
+
+    @staticmethod
+    def _entry_to_entity(key: str, entry: Dict,
+                         confidence: float = 1.0) -> Dict:
+        """Project a CONTEXT-1 entry back to an adapt context entity."""
+        value = entry.get("value")
+        return {"key": value,
+                "data": [(value, key)],
+                "confidence": confidence,
+                "origin": key}
+
+    def _write(self, payload: Dict[str, Any]):
+        """Fold ``payload`` (CONTEXT-1 set/null-delete) into intent_context."""
+        target = dict(self._session.intent_context or {})
+        SessionManager.merge_intent_context(target, payload)
+        self._session.intent_context = target or None
+        self._session.touch()
+
+    # --- derived frame stack (read path for the inherited get_context) ---
+    @property
+    def frame_stack(self) -> List[Tuple[IntentContextManagerFrame, float]]:
+        """Project the live, taggable ``intent_context`` entries to a stack.
+
+        Newest-expiring entry first, so the inherited depth-based confidence
+        decay in ``get_context`` weights the freshest context highest.
+        """
+        now = time.time()
+        rows = []
+        for key, entry in (self._session.intent_context or {}).items():
+            if not isinstance(entry, dict):
+                continue
+            value = entry.get("value")
+            # Only a non-null STRING value is a taggable surface form
+            # (OVOS-CONTEXT-1 §7 context-supplied capture). ``null`` flags — and
+            # non-string presence markers some engines use — gate directly via
+            # ``intent_context`` (§6) and have no place in the tagging stack.
+            if not isinstance(value, str):
+                continue
+            exp = entry.get("expires_at")
+            if exp is not None and exp <= now:  # dead entry
+                continue
+            timestamp = (exp - self.timeout) if exp is not None else now
+            frame = IntentContextManagerFrame(
+                entities=[self._entry_to_entity(key, entry)])
+            rows.append((frame, timestamp, exp if exp is not None else float("inf")))
+        rows.sort(key=lambda r: r[2], reverse=True)
+        return [(frame, ts) for frame, ts, _ in rows]
+
+    @frame_stack.setter
+    def frame_stack(self, value):
+        """Ingest a legacy frame stack back into ``intent_context``."""
+        self._write(self._frames_to_entries(value))
+
+    def _frames_to_entries(self, frames) -> Dict[str, Any]:
+        """Project a legacy ``[(frame, ts), ...]`` stack to CONTEXT-1 entries."""
+        payload: Dict[str, Any] = {}
+        for frame, _ts in (frames or []):
+            for entity in getattr(frame, "entities", []):
+                key, entry = self._entity_to_entry(entity)
+                if key:
+                    payload[key] = entry
+        return payload
+
+    # --- write path overrides -------------------------------------------
+    def inject_context(self, entity: Dict, metadata: Dict = None):
+        key, entry = self._entity_to_entry(entity)
+        if key is None:
+            return
+        self._write({key: entry})
+
+    def remove_context(self, context_id: str):
+        self._write({context_id: None})
+
+    def clear_context(self):
+        self._session.intent_context = None
+        self._session.touch()
+
+
 class Session(_SpecSession):
     """OVOS-SESSION-1 carrier with the bus-client lifecycle layered on top.
 
@@ -373,12 +522,17 @@ class Session(_SpecSession):
     - **lifecycle bookkeeping**: ``touch()`` / ``touch_time`` /
       ``expiration_seconds`` / ``expired()`` and ``SessionManager``
       registration on every mutation;
-    - **bus-client-only state**: the ``IntentContextManager``, location /
-      unit / format preferences, the speaking / recording flags;
+    - **bus-client-only state**: location / unit / format preferences, the
+      speaking / recording flags;
     - **back-compat projections**: the legacy ``active_skills`` /
-      ``utterance_states`` views (and their ``activate_skill`` /
-      ``enable_response_mode`` / ``clear`` shims), plus the legacy
-      ``serialize`` / ``deserialize`` dict shape ecosystem readers expect.
+      ``utterance_states`` / ``context`` views (and their ``activate_skill`` /
+      ``enable_response_mode`` / ``clear`` shims). Each is a DERIVED view over a
+      canonical spec field — ``active_handlers`` / ``response_mode`` /
+      ``intent_context`` — never a parallel store: the ``context`` frame stack
+      (:class:`_IntentContextView`, the adapt-engine ``context_manager`` shape)
+      projects from and folds back into ``intent_context``. Access warns; the
+      legacy ``serialize`` / ``deserialize`` dict shape ecosystem readers expect
+      is emitted as derived duplicates and folded back on read.
     """
 
     def __init__(self, session_id: str = None,
@@ -423,7 +577,10 @@ class Session(_SpecSession):
             response_mode (Dict): OVOS-CONVERSE-1 §2.2 pending-response window — a single {skill_id, expires_at}
                 object, or None when no holder awaits a direct response.
             lang (str): Language tag for the session (standardized internally) — defaults to system default.
-            context (IntentContextManager): Conversational context manager for the session.
+            context (IntentContextManager): DEPRECATED legacy adapt-style frame stack.
+                Its entities fold into the canonical OVOS-CONTEXT-1 `intent_context`
+                map (only when `intent_context` is empty, so a canonical value wins).
+                Prefer passing `intent_context` directly.
             site_id (str): Identifier for the site/location associated with the session.
             pipeline (List[str]): Ordered intent processing pipeline identifiers.
             stt_prefs (Dict): Deprecated; provided value will be ignored.
@@ -524,8 +681,20 @@ class Session(_SpecSession):
         self.touch_time = int(time.time())
         self.expiration_seconds = expiration_seconds or \
                                   Configuration().get('session', {}).get("ttl", -1)
-        self.context = context or IntentContextManager()
         self.location_preferences = location_prefs or Configuration().get("location", {})
+        # Legacy back-compat: a caller (or a legacy wire payload via
+        # deserialize) may hand an ``IntentContextManager`` frame stack. It is
+        # NOT stored as a parallel object — its entities fold into the canonical
+        # ``intent_context`` map, but only when the canonical field is empty so
+        # a modern peer's ``intent_context`` always wins (never double-counted).
+        # Written directly (no touch/registry round-trip): this runs inside
+        # construction, which the SessionManager fold re-enters via
+        # deserialize(); touching here would recurse under the registry lock.
+        if context is not None and not self.intent_context:
+            entries = _IntentContextView(self)._frames_to_entries(
+                getattr(context, "frame_stack", []))
+            if entries:
+                self.intent_context = entries
         # persona_id is an inherited canonical field (OVOS-PERSONA-1, registered
         # on ovos_spec_tools.Session); it is forwarded to super().__init__ above
         # so the parent owns its validation + omit-when-empty serialization.
@@ -547,6 +716,23 @@ class Session(_SpecSession):
         for name in _CANONICAL_DICT_FIELDS:
             if getattr(self, name, None) is None:
                 setattr(self, name, {})
+
+    @property
+    def context(self) -> "_IntentContextView":
+        """DEPRECATED adapt-style frame-stack view of ``intent_context``.
+
+        Returns an :class:`IntentContextManager`-API-compatible view (the shape
+        the adapt engine consumes as ``context_manager``) projected over the
+        canonical OVOS-CONTEXT-1 ``session.intent_context`` map. It is not a
+        parallel store: reads project from ``intent_context`` and writes fold
+        back into it. Prefer reading/writing ``intent_context`` directly.
+        """
+        log_deprecation("Session.context (the IntentContextManager frame stack) "
+                        "is a legacy view of the canonical "
+                        "OVOS-CONTEXT-1 session.intent_context map and will be "
+                        "removed; use intent_context directly",
+                        _NEXT_MAJOR_VERSION)
+        return _IntentContextView(self)
 
     @property
     def timezone(self) -> Optional[str]:
@@ -611,11 +797,19 @@ class Session(_SpecSession):
         Reads project the canonical `active_handlers` object list to the legacy
         pair shape, head-first.
         """
+        log_deprecation("Session.active_skills is a legacy view of the canonical "
+                        "OVOS-PIPELINE-1 active_handlers field and will be "
+                        "removed; use active_handlers directly",
+                        _NEXT_MAJOR_VERSION)
         return [[h["skill_id"], h["activated_at"]] for h in self.active_handlers]
 
     @active_skills.setter
     def active_skills(self, value: Optional[List[List[Union[str, float]]]]):
         """Assigning legacy pairs rewrites the canonical `active_handlers` store."""
+        log_deprecation("Session.active_skills is a legacy view of the canonical "
+                        "OVOS-PIPELINE-1 active_handlers field and will be "
+                        "removed; use active_handlers directly",
+                        _NEXT_MAJOR_VERSION)
         self.active_handlers = self._coerce_handlers(
             self._pairs_to_handler_objects(value))
 
@@ -658,6 +852,10 @@ class Session(_SpecSession):
         structured `response_mode` store, preserving the pre-refactor behavior
         where `utterance_states` was a plain mutable dict.
         """
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
         if self.response_mode and self.response_mode.get("skill_id"):
             projection = {self.response_mode["skill_id"]: UtteranceState.RESPONSE.value}
         else:
@@ -667,6 +865,10 @@ class Session(_SpecSession):
     @utterance_states.setter
     def utterance_states(self, value: Optional[Dict]):
         """Assigning legacy utterance_states rewrites the structured `response_mode`."""
+        log_deprecation("Session.utterance_states is a legacy view of the "
+                        "canonical OVOS-CONVERSE-1 response_mode field and will "
+                        "be removed; use response_mode directly",
+                        _NEXT_MAJOR_VERSION)
         self.response_mode = None
         for skill_id, state in (value or {}).items():
             if state == UtteranceState.RESPONSE.value:
@@ -771,27 +973,39 @@ class Session(_SpecSession):
         Returns:
             dict: A JSON-serializable mapping of session state.
         """
-        # canonical SESSION-1 wire shape (spec fields, omit-when-empty)
+        # canonical SESSION-1 wire shape (spec fields, omit-when-empty). This
+        # already emits active_handlers / response_mode / intent_context /
+        # blacklisted_* / pipeline / persona_id following SESSION-1 §2.1
+        # omission-not-null — empty values are absent, never serialized as null
+        # or forced ``[]``.
         data = super().to_dict()
-        # legacy back-compat projections + bus-client-only state
-        # NOTE: persona_id is a canonical inherited field — the parent's
-        # to_dict() above already emits it with SESSION-1 §2.1 omit-when-empty
-        # handling, so it is intentionally NOT re-emitted here.
+
+        # Legacy back-compat wire keys, DERIVED from the canonical state (never a
+        # parallel store) so old ecosystem readers parsing the raw dict keep
+        # working for one deprecation cycle:
+        #  - ``active_skills`` mirrors active_handlers as [skill_id, ts] pairs;
+        #  - ``utterance_states`` mirrors the response_mode holder;
+        #  - ``context`` mirrors intent_context as an IntentContextManager frame
+        #    stack. Computed inline (not via the deprecated properties) so
+        #    serializing does not emit deprecation warnings.
+        legacy_active = [[h["skill_id"], h["activated_at"]]
+                         for h in self.active_handlers]
+        if self.response_mode and self.response_mode.get("skill_id"):
+            legacy_states = {self.response_mode["skill_id"]:
+                             UtteranceState.RESPONSE.value}
+        else:
+            legacy_states = {}
         data.update({
-            "active_skills": self.active_skills,
-            "utterance_states": self.utterance_states,
+            "active_skills": legacy_active,
+            "utterance_states": legacy_states,
             "session_id": self.session_id,
-            "context": self.context.serialize(),
+            "context": _IntentContextView(self).serialize(),
             "location": self.location_preferences,
             "system_unit": self.system_unit,
             "time_format": self.time_format,
             "date_format": self.date_format,
             "is_speaking": self.is_speaking,
             "is_recording": self.is_recording,
-            # always emit raw lists for legacy readers (canonical omits when empty)
-            "blacklisted_skills": self.blacklisted_skills or [],
-            "blacklisted_intents": self.blacklisted_intents or [],
-            "pipeline": self.pipeline or [],
         })
         return data
 
@@ -864,7 +1078,13 @@ class Session(_SpecSession):
         if "response_mode" in canonical_kwargs:
             states = {}
 
-        # bus-client-only state the canonical class does not carry.
+        # Legacy wire fold: a legacy producer ships a standalone ``context``
+        # frame stack instead of the canonical ``intent_context`` map. Rebuild
+        # it and hand it to the constructor, which projects its entities INTO
+        # ``intent_context`` — but only when the canonical field is absent, so a
+        # modern peer that carries both keys is never overridden (canonical
+        # wins, no double-count). ``from_dict`` above already populated
+        # ``intent_context`` in ``canonical_kwargs`` when present.
         context = IntentContextManager.deserialize(data.get("context", {}))
         location = data.get("location", {})
         system_unit = data.get("system_unit")

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -107,6 +107,13 @@ class _UtteranceStatesView(dict):
                         "be removed; use response_mode directly",
                         _NEXT_MAJOR_VERSION)
 
+    def _project(self) -> Dict:
+        """Project the canonical response_mode holder to the legacy mapping."""
+        mode = self._session.response_mode
+        if mode and mode.get("skill_id"):
+            return {mode["skill_id"]: UtteranceState.RESPONSE.value}
+        return {}
+
     def __setitem__(self, skill_id, state):
         self._warn()
         state_value = getattr(state, "value", state)
@@ -116,9 +123,11 @@ class _UtteranceStatesView(dict):
             self._session.disable_response_mode(skill_id)
         # rebuild from the canonical store so the view stays consistent with the
         # single-holder invariant rather than accumulating stale keys. Use the
-        # plain-dict ops (super()) here so we don't re-clear response_mode.
+        # plain-dict ops (super()) here so we don't re-clear response_mode, and
+        # project response_mode directly rather than re-reading the deprecated
+        # utterance_states property, which would emit a second warning.
         super().clear()
-        super().update(dict(self._session.utterance_states))
+        super().update(self._project())
 
     def __delitem__(self, skill_id):
         self._warn()

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -457,10 +457,15 @@ class _IntentContextView(IntentContextManager):
                 "origin": key}
 
     def _write(self, payload: Dict[str, Any]):
-        """Fold ``payload`` (CONTEXT-1 set/null-delete) into intent_context."""
-        target = dict(self._session.intent_context or {})
-        SessionManager.merge_intent_context(target, payload)
-        self._session.intent_context = target or None
+        """Fold ``payload`` (CONTEXT-1 set/null-delete) into intent_context.
+
+        Merged in place, like the canonical mutators: the map keeps its object
+        identity so a holder of the dict sees the write, and it stays an empty
+        container rather than becoming ``None`` when the last entry is removed.
+        """
+        if self._session.intent_context is None:
+            self._session.intent_context = {}
+        SessionManager.merge_intent_context(self._session.intent_context, payload)
         self._session.touch()
 
     # --- derived frame stack (read path for the inherited get_context) ---
@@ -519,7 +524,10 @@ class _IntentContextView(IntentContextManager):
         self._write({context_id: None})
 
     def clear_context(self):
-        self._session.intent_context = None
+        # cleared in place, mirroring Session.clear_intent_context: the field
+        # stays an empty container, never ``None``.
+        if self._session.intent_context:
+            self._session.intent_context.clear()
         self._session.touch()
 
 

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -29,9 +29,10 @@ _NEXT_MAJOR_VERSION = f"{VERSION_MAJOR + 1}.0.0"
 # ``TypeError: argument of type 'NoneType' is not iterable``. These fields are
 # therefore folded back to their canonical empty container after construction
 # so they ALWAYS deserialize to ``[]`` / ``{}``, never ``None``. Serialization
-# omits them when empty (``to_dict`` drops falsy values), except for
-# _ALWAYS_EMIT_LIST_FIELDS below, which are emitted carrying their
-# config-resolved value. Scalar fields (``site_id``, ``persona_id``, the per-channel
+# omits them when empty (``to_dict`` drops falsy values), per SESSION-1 §3.4:
+# an empty list-valued override field is wire-equivalent to omission, and a
+# producer SHOULD NOT spend wire weight restating the deployment default on
+# every Message. Scalar fields (``site_id``, ``persona_id``, the per-channel
 # language overrides) and the single-object ``response_mode`` legitimately stay
 # ``None`` and are intentionally excluded.
 _CANONICAL_LIST_FIELDS = (
@@ -58,21 +59,6 @@ _CANONICAL_LIST_FIELDS = (
 )
 _CANONICAL_DICT_FIELDS = (
     "intent_context",
-)
-
-# SESSION-1 §3.4 states omit-when-wire-equivalent-to-omission as a SHOULD, not a
-# MUST: emitting a redundant default-valued field is non-optimal but conformant,
-# and a consumer MUST tolerate it. These three are already resolved from
-# ovos-config at construction, so emit the resolved value rather than drop the
-# key — a reader then always finds a concrete list instead of re-deriving the
-# deployment default itself, and legacy readers indexing the raw dict keep
-# working. Resolving an absent value is the reader's job (see the fold above);
-# handing it a populated one is ours. Fields with no config default
-# (``active_handlers``, ``converse_handlers``, …) keep the omit-when-empty shape.
-_ALWAYS_EMIT_LIST_FIELDS = (
-    "blacklisted_skills",
-    "blacklisted_intents",
-    "pipeline",
 )
 
 
@@ -1081,12 +1067,6 @@ class Session(_SpecSession):
         # omission-not-null — empty values are absent, never serialized as null
         # or forced ``[]``.
         data = super().to_dict()
-
-        # The canonical parent drops these when empty. Re-add them carrying their
-        # config-resolved value, so every reader gets a populated list rather than
-        # an absent key it must resolve itself (SESSION-1 §3.4 permits this).
-        for _name in _ALWAYS_EMIT_LIST_FIELDS:
-            data[_name] = list(getattr(self, _name) or [])
 
         # Legacy back-compat wire keys, DERIVED from the canonical state (never a
         # parallel store) so old ecosystem readers parsing the raw dict keep

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -29,8 +29,9 @@ _NEXT_MAJOR_VERSION = f"{VERSION_MAJOR + 1}.0.0"
 # ``TypeError: argument of type 'NoneType' is not iterable``. These fields are
 # therefore folded back to their canonical empty container after construction
 # so they ALWAYS deserialize to ``[]`` / ``{}``, never ``None``. Serialization
-# still omits them when empty (``to_dict`` drops falsy values), so the wire
-# shape is unchanged. Scalar fields (``site_id``, ``persona_id``, the per-channel
+# omits them when empty (``to_dict`` drops falsy values), except for
+# _ALWAYS_EMIT_LIST_FIELDS below, which are emitted carrying their
+# config-resolved value. Scalar fields (``site_id``, ``persona_id``, the per-channel
 # language overrides) and the single-object ``response_mode`` legitimately stay
 # ``None`` and are intentionally excluded.
 _CANONICAL_LIST_FIELDS = (
@@ -57,6 +58,21 @@ _CANONICAL_LIST_FIELDS = (
 )
 _CANONICAL_DICT_FIELDS = (
     "intent_context",
+)
+
+# SESSION-1 §3.4 states omit-when-wire-equivalent-to-omission as a SHOULD, not a
+# MUST: emitting a redundant default-valued field is non-optimal but conformant,
+# and a consumer MUST tolerate it. These three are already resolved from
+# ovos-config at construction, so emit the resolved value rather than drop the
+# key — a reader then always finds a concrete list instead of re-deriving the
+# deployment default itself, and legacy readers indexing the raw dict keep
+# working. Resolving an absent value is the reader's job (see the fold above);
+# handing it a populated one is ours. Fields with no config default
+# (``active_handlers``, ``converse_handlers``, …) keep the omit-when-empty shape.
+_ALWAYS_EMIT_LIST_FIELDS = (
+    "blacklisted_skills",
+    "blacklisted_intents",
+    "pipeline",
 )
 
 
@@ -1048,6 +1064,12 @@ class Session(_SpecSession):
         # omission-not-null — empty values are absent, never serialized as null
         # or forced ``[]``.
         data = super().to_dict()
+
+        # The canonical parent drops these when empty. Re-add them carrying their
+        # config-resolved value, so every reader gets a populated list rather than
+        # an absent key it must resolve itself (SESSION-1 §3.4 permits this).
+        for _name in _ALWAYS_EMIT_LIST_FIELDS:
+            data[_name] = list(getattr(self, _name) or [])
 
         # Legacy back-compat wire keys, DERIVED from the canonical state (never a
         # parallel store) so old ecosystem readers parsing the raw dict keep

--- a/test/unittests/test_session_context_view.py
+++ b/test/unittests/test_session_context_view.py
@@ -1,0 +1,218 @@
+"""Unified-store tests for the legacy ``Session.context`` back-compat view.
+
+These assert the single-source-of-truth invariant: the legacy adapt-style
+``IntentContextManager`` frame-stack API and the canonical OVOS-CONTEXT-1
+``session.intent_context`` flat map are two views over ONE store. A write
+through either path is visible through the other and gates via CONTEXT-1.
+"""
+import time
+import unittest
+from unittest.mock import patch
+
+from ovos_spec_tools.context import gate_satisfied
+
+
+def _adapt_entity(value, entity_type, confidence=1.0):
+    """Build an entity in the shape the adapt engine feeds/reads."""
+    return {"key": value,
+            "data": [(value, entity_type)],
+            "confidence": confidence,
+            "origin": entity_type}
+
+
+class TestContextUnifiedStore(unittest.TestCase):
+    def setUp(self):
+        from ovos_bus_client.session import Session
+        self.session = Session("ctx-view-test")
+        self.session.intent_context = None
+
+    # (a) legacy write -> canonical read + CONTEXT-1 gating
+    def test_legacy_inject_visible_in_intent_context_and_gates(self):
+        self.session.context.inject_context(_adapt_entity("Bob", "person"))
+
+        # visible in the canonical flat map as a CONTEXT-1 entry
+        self.assertIn("person", self.session.intent_context)
+        entry = self.session.intent_context["person"]
+        self.assertEqual(entry["value"], "Bob")
+
+        # gates via CONTEXT-1 (shared scope, bare key)
+        self.assertTrue(gate_satisfied(self.session.intent_context,
+                                       requires=[{"key": "person",
+                                                  "scope": "shared"}],
+                                       excludes=None, owner_id="some.skill"))
+
+    # (b) canonical write -> legacy adapt get_context read
+    def test_canonical_write_visible_through_legacy_get_context(self):
+        self.session.intent_context = {
+            "person": {"value": "Bob", "turns_remaining": 3}}
+        ctx = self.session.context.get_context()
+        # adapt reads (value, entity_type) out of data[0]
+        pairs = [e["data"][0] for e in ctx]
+        self.assertIn(("Bob", "person"), pairs)
+
+    def test_legacy_remove_context_deletes_canonical_entry(self):
+        self.session.intent_context = {"person": {"value": "Bob"}}
+        self.session.context.remove_context("person")
+        self.assertNotIn("person", self.session.intent_context or {})
+
+    def test_legacy_clear_context_empties_canonical_store(self):
+        self.session.intent_context = {"person": {"value": "Bob"},
+                                       "room": {"value": "kitchen"}}
+        self.session.context.clear_context()
+        self.assertFalse(self.session.intent_context)
+
+    def test_update_context_greedy_writes_canonical(self):
+        # greedy mode injects every scanned entity
+        view = self.session.context
+        view.context_greedy = True
+        view.update_context([_adapt_entity("kitchen", "room")])
+        self.assertEqual(self.session.intent_context["room"]["value"], "kitchen")
+
+    def test_dead_entry_not_projected_to_frame_stack(self):
+        self.session.intent_context = {
+            "person": {"value": "Bob", "expires_at": time.time() - 10}}
+        ctx = self.session.context.get_context()
+        self.assertEqual(ctx, [])
+
+
+class TestContextWarnOnAccess(unittest.TestCase):
+    def setUp(self):
+        from ovos_bus_client.session import Session
+        self.session = Session("ctx-warn-test")
+
+    def test_context_getter_warns(self):
+        with patch("ovos_bus_client.session.log_deprecation") as dep:
+            _ = self.session.context
+        self.assertTrue(dep.called)
+
+    def test_active_skills_getter_warns(self):
+        with patch("ovos_bus_client.session.log_deprecation") as dep:
+            _ = self.session.active_skills
+        self.assertTrue(dep.called)
+
+    def test_active_skills_setter_warns(self):
+        with patch("ovos_bus_client.session.log_deprecation") as dep:
+            self.session.active_skills = [["s", time.time()]]
+        self.assertTrue(dep.called)
+
+    def test_utterance_states_getter_warns(self):
+        with patch("ovos_bus_client.session.log_deprecation") as dep:
+            _ = self.session.utterance_states
+        self.assertTrue(dep.called)
+
+    def test_utterance_states_mutation_warns(self):
+        from ovos_bus_client.session import UtteranceState
+        with patch("ovos_bus_client.session.log_deprecation") as dep:
+            view = self.session.utterance_states
+            view["some.skill"] = UtteranceState.RESPONSE.value
+        self.assertTrue(dep.called)
+
+
+class TestSerializeOmissionNotNull(unittest.TestCase):
+    def test_serialize_context_derived_from_intent_context(self):
+        from ovos_bus_client.session import Session
+        session = Session("ctx-ser-test")
+        session.intent_context = {"person": {"value": "Bob"}}
+        data = session.serialize()
+        # the legacy ``context`` wire key is DERIVED from intent_context, not a
+        # separate disjoint store: the migrated entry surfaces in its frame_stack
+        frames = data["context"]["frame_stack"]
+        entity_types = [f[0]["entities"][0]["data"][0][1] for f in frames]
+        self.assertIn("person", entity_types)
+
+    def test_serialize_omits_empty_blacklists_and_pipeline(self):
+        from ovos_bus_client.session import Session
+        session = Session("ctx-omit-test")
+        session.blacklisted_skills = []
+        session.blacklisted_intents = []
+        session.pipeline = []
+        data = session.serialize()
+        # SESSION-1 §2.1 omission-not-null: empty lists are absent, never []
+        self.assertNotIn("blacklisted_skills", data)
+        self.assertNotIn("blacklisted_intents", data)
+        self.assertNotIn("pipeline", data)
+
+
+class TestLegacyWireRoundTrip(unittest.TestCase):
+    def test_legacy_dict_folds_into_canonical(self):
+        """A legacy producer's Session dict deserializes into canonical fields."""
+        from ovos_bus_client.session import Session
+        now = time.time()
+        legacy = {
+            "session_id": "legacy-1",
+            "lang": "en-us",
+            "active_skills": [["legacy.skill", now]],
+            "utterance_states": {"legacy.skill": "response"},
+            "context": {
+                "timeout": 120,
+                "frame_stack": [
+                    ({"entities": [_adapt_entity("Bob", "person")],
+                      "metadata": {}}, now)
+                ],
+            },
+        }
+        sess = Session.deserialize(legacy)
+        # active_skills -> active_handlers
+        self.assertTrue(any(h["skill_id"] == "legacy.skill"
+                            for h in sess.active_handlers))
+        # utterance_states -> response_mode
+        self.assertEqual(sess.response_mode.get("skill_id"), "legacy.skill")
+        # legacy context frame_stack -> intent_context, gates via CONTEXT-1
+        self.assertEqual(sess.intent_context["person"]["value"], "Bob")
+        self.assertTrue(gate_satisfied(sess.intent_context,
+                                       requires=[{"key": "person",
+                                                  "scope": "shared"}],
+                                       excludes=None, owner_id="x"))
+
+    def test_modern_dict_canonical_intact_and_stable(self):
+        from ovos_bus_client.session import Session
+        modern = {
+            "session_id": "modern-1",
+            "lang": "en-us",
+            "active_handlers": [{"skill_id": "modern.skill",
+                                 "activated_at": time.time()}],
+            "intent_context": {"person": {"value": "Bob",
+                                          "turns_remaining": 2}},
+        }
+        sess = Session.deserialize(modern)
+        self.assertTrue(any(h["skill_id"] == "modern.skill"
+                            for h in sess.active_handlers))
+        self.assertEqual(sess.intent_context["person"]["value"], "Bob")
+        # re-serialize -> deserialize stable
+        again = Session.deserialize(sess.serialize())
+        self.assertEqual(again.intent_context["person"]["value"], "Bob")
+
+    def test_mixed_dict_canonical_wins(self):
+        from ovos_bus_client.session import Session
+        now = time.time()
+        mixed = {
+            "session_id": "mixed-1",
+            "active_handlers": [{"skill_id": "canon.skill",
+                                 "activated_at": now}],
+            "active_skills": [["legacy.skill", now]],
+            "intent_context": {"room": {"value": "kitchen"}},
+            "context": {"timeout": 120,
+                        "frame_stack": [({"entities": [_adapt_entity("Bob",
+                                                                     "person")],
+                                          "metadata": {}}, now)]},
+        }
+        sess = Session.deserialize(mixed)
+        skills = [h["skill_id"] for h in sess.active_handlers]
+        self.assertIn("canon.skill", skills)
+        self.assertNotIn("legacy.skill", skills)
+        # canonical intent_context wins; legacy context frame_stack ignored
+        self.assertIn("room", sess.intent_context)
+        self.assertNotIn("person", sess.intent_context)
+
+    def test_serialize_deserialize_idempotent(self):
+        from ovos_bus_client.session import Session
+        session = Session("idem-1")
+        session.intent_context = {"person": {"value": "Bob",
+                                             "expires_at": time.time() + 999}}
+        a = session.serialize()
+        b = Session.deserialize(a).serialize()
+        self.assertEqual(a["intent_context"], b["intent_context"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_session_context_view.py
+++ b/test/unittests/test_session_context_view.py
@@ -104,8 +104,13 @@ class TestContextWarnOnAccess(unittest.TestCase):
         from ovos_bus_client.session import UtteranceState
         with patch("ovos_bus_client.session.log_deprecation") as dep:
             view = self.session.utterance_states
+            # the attribute access above warns on its own; drop those calls so
+            # this asserts the mutation path warns, not the accessor
+            dep.reset_mock()
             view["some.skill"] = UtteranceState.RESPONSE.value
-        self.assertTrue(dep.called)
+        # exactly once: the internal rebuild projects response_mode directly
+        # instead of re-reading the deprecated property
+        self.assertEqual(dep.call_count, 1)
 
 
 class TestSerializeOmissionNotNull(unittest.TestCase):

--- a/test/unittests/test_session_context_view.py
+++ b/test/unittests/test_session_context_view.py
@@ -50,16 +50,66 @@ class TestContextUnifiedStore(unittest.TestCase):
         pairs = [e["data"][0] for e in ctx]
         self.assertIn(("Bob", "person"), pairs)
 
-    def test_legacy_remove_context_deletes_canonical_entry(self):
+    def test_legacy_remove_context_tombstones_canonical_entry(self):
         self.session.intent_context = {"person": {"value": "Bob"}}
         self.session.context.remove_context("person")
-        self.assertNotIn("person", self.session.intent_context or {})
+        # removed = tombstoned (null entry, CONTEXT-1 §5.3), so the deletion
+        # propagates in the sync payload; a tombstone is never live
+        self.assertIsNone(self.session.intent_context["person"])
+        self.assertFalse(gate_satisfied(self.session.intent_context,
+                                        requires=[{"key": "person",
+                                                   "scope": "shared"}],
+                                        excludes=None, owner_id="x"))
+        self.assertEqual(self.session.context.get_context(), [])
 
-    def test_legacy_clear_context_empties_canonical_store(self):
+    def test_legacy_remove_missing_key_is_noop(self):
+        self.session.intent_context = {"person": {"value": "Bob"}}
+        self.session.context.remove_context("nope")
+        self.assertNotIn("nope", self.session.intent_context)
+
+    def test_legacy_clear_context_tombstones_canonical_store(self):
         self.session.intent_context = {"person": {"value": "Bob"},
                                        "room": {"value": "kitchen"}}
         self.session.context.clear_context()
-        self.assertFalse(self.session.intent_context)
+        # every entry becomes a §5.3 tombstone: dead for gating/projection,
+        # but the deletion is carried in the serialized map
+        self.assertEqual(self.session.intent_context,
+                         {"person": None, "room": None})
+        self.assertEqual(self.session.context.frame_stack, [])
+
+    def test_frame_stack_assignment_replaces(self):
+        # legacy callers prune the stack by assigning a filtered list, so
+        # assignment must carry removal semantics for the projected keys
+        view = self.session.context
+        view.inject_context(_adapt_entity("Bob", "person"))
+        view.inject_context(_adapt_entity("kitchen", "room"))
+        kept = [(frame, ts) for frame, ts in view.frame_stack
+                if frame.entities[0]["data"][0][1] == "room"]
+        view.frame_stack = kept
+        self.assertIsNone(self.session.intent_context["person"])  # tombstoned
+        self.assertEqual(self.session.intent_context["room"]["value"],
+                         "kitchen")
+
+    def test_frame_stack_assignment_leaves_unprojectable_entries(self):
+        # entries the legacy stack cannot represent (null flags, non-string
+        # values) are invisible to the view; assignment says nothing about them
+        view = self.session.context
+        view.inject_context(_adapt_entity("Bob", "person"))
+        self.session.intent_context["skill.a:flag"] = {"value": None}
+        view.frame_stack = []
+        self.assertIsNone(self.session.intent_context["person"])
+        self.assertEqual(self.session.intent_context["skill.a:flag"],
+                         {"value": None})
+
+    def test_non_string_value_not_projected_to_frame_stack(self):
+        # only a non-null STRING value is a taggable surface form (§7); flags
+        # and numeric presence markers gate via intent_context only (§6)
+        self.session.intent_context = {"count": {"value": 3},
+                                       "flag": {"value": None},
+                                       "person": {"value": "Bob"}}
+        keys = [frame.entities[0]["origin"]
+                for frame, _ in self.session.context.frame_stack]
+        self.assertEqual(keys, ["person"])
 
     def test_update_context_greedy_writes_canonical(self):
         # greedy mode injects every scanned entity
@@ -222,7 +272,7 @@ class TestLegacyWireRoundTrip(unittest.TestCase):
     def test_legacy_write_preserves_intent_context_identity(self):
         from ovos_bus_client.session import Session
         session = Session("identity-1")
-        session.set_intent_context("person", "Bob")
+        session.set_intent_context("person", "Bob", scope="shared")
         held = session.intent_context
         # adapt entity shape: data[0] is (value, key)
         session.context.inject_context({"key": "pet",
@@ -230,22 +280,56 @@ class TestLegacyWireRoundTrip(unittest.TestCase):
         self.assertIs(session.intent_context, held)
         self.assertIn("pet", held)
 
-    def test_legacy_clear_context_leaves_empty_dict_not_none(self):
+    def test_legacy_clear_context_keeps_dict_and_identity(self):
         from ovos_bus_client.session import Session
         session = Session("clear-1")
-        session.set_intent_context("person", "Bob")
+        session.set_intent_context("person", "Bob", scope="shared")
+        held = session.intent_context
         session.context.clear_context()
-        self.assertEqual(session.intent_context, {})
-        # membership on the cleared map must not raise
-        self.assertNotIn("person", session.intent_context)
+        # cleared in place: same object, still a dict, entry tombstoned
+        self.assertIs(session.intent_context, held)
+        self.assertEqual(session.intent_context, {"person": None})
+        self.assertEqual(session.context.frame_stack, [])
 
-    def test_legacy_remove_last_entry_leaves_empty_dict_not_none(self):
+    def test_legacy_remove_keeps_dict_and_identity(self):
         from ovos_bus_client.session import Session
         session = Session("remove-1")
-        session.set_intent_context("person", "Bob")
+        session.set_intent_context("person", "Bob", scope="shared")
+        held = session.intent_context
         session.context.remove_context("person")
-        self.assertEqual(session.intent_context, {})
-        self.assertNotIn("person", session.intent_context)
+        self.assertIs(session.intent_context, held)
+        self.assertEqual(session.intent_context, {"person": None})
+
+    def test_stale_legacy_frame_stays_dead_across_deserialize(self):
+        """A frame older than the legacy timeout is not resurrected."""
+        from ovos_bus_client.session import Session
+        now = time.time()
+        legacy = {
+            "session_id": "stale-1",
+            "context": {"timeout": 120,
+                        "frame_stack": [
+                            ({"entities": [_adapt_entity("Bob", "person")],
+                              "metadata": {}}, now - 10_000),
+                            ({"entities": [_adapt_entity("kitchen", "room")],
+                              "metadata": {}}, now),
+                        ]},
+        }
+        sess = Session.deserialize(legacy)
+        self.assertNotIn("person", sess.intent_context)
+        # the live frame folds with its own timestamp anchoring the expiry
+        entry = sess.intent_context["room"]
+        self.assertEqual(entry["value"], "kitchen")
+        self.assertAlmostEqual(entry["expires_at"], now + 120, delta=5)
+
+    def test_update_from_fold_keeps_intent_context_a_dict(self):
+        """Folding a snapshot onto the singleton never leaves None behind."""
+        from ovos_bus_client.session import Session
+        live = Session("fold-1")
+        live.set_intent_context("person", "Bob", scope="shared")
+        snapshot = Session.deserialize({"session_id": "fold-1"})
+        live.update_from(snapshot)
+        self.assertIsInstance(live.intent_context, dict)
+        self.assertNotIn("x", live.intent_context)  # membership never raises
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_session_context_view.py
+++ b/test/unittests/test_session_context_view.py
@@ -120,17 +120,19 @@ class TestSerializeOmissionNotNull(unittest.TestCase):
         entity_types = [f[0]["entities"][0]["data"][0][1] for f in frames]
         self.assertIn("person", entity_types)
 
-    def test_serialize_omits_empty_blacklists_and_pipeline(self):
+    def test_serialize_emits_empty_blacklists_and_pipeline(self):
         from ovos_bus_client.session import Session
         session = Session("ctx-omit-test")
         session.blacklisted_skills = []
         session.blacklisted_intents = []
         session.pipeline = []
         data = session.serialize()
-        # SESSION-1 §2.1 omission-not-null: empty lists are absent, never []
-        self.assertNotIn("blacklisted_skills", data)
-        self.assertNotIn("blacklisted_intents", data)
-        self.assertNotIn("pipeline", data)
+        # SESSION-1 §3.4 makes omit-when-empty a SHOULD, not a MUST. These fields
+        # are emitted carrying their config-resolved value so readers always find
+        # a concrete list; with no configured default that value is [].
+        self.assertEqual(data["blacklisted_skills"], [])
+        self.assertEqual(data["blacklisted_intents"], [])
+        self.assertEqual(data["pipeline"], [])
 
 
 class TestLegacyWireRoundTrip(unittest.TestCase):

--- a/test/unittests/test_session_context_view.py
+++ b/test/unittests/test_session_context_view.py
@@ -125,19 +125,18 @@ class TestSerializeOmissionNotNull(unittest.TestCase):
         entity_types = [f[0]["entities"][0]["data"][0][1] for f in frames]
         self.assertIn("person", entity_types)
 
-    def test_serialize_emits_empty_blacklists_and_pipeline(self):
+    def test_serialize_omits_empty_blacklists_and_pipeline(self):
         from ovos_bus_client.session import Session
         session = Session("ctx-omit-test")
         session.blacklisted_skills = []
         session.blacklisted_intents = []
         session.pipeline = []
         data = session.serialize()
-        # SESSION-1 §3.4 makes omit-when-empty a SHOULD, not a MUST. These fields
-        # are emitted carrying their config-resolved value so readers always find
-        # a concrete list; with no configured default that value is [].
-        self.assertEqual(data["blacklisted_skills"], [])
-        self.assertEqual(data["blacklisted_intents"], [])
-        self.assertEqual(data["pipeline"], [])
+        # SESSION-1 §3.4: an empty list-valued override field is wire-equivalent
+        # to omission, and a producer SHOULD NOT restate the deployment default.
+        self.assertNotIn("blacklisted_skills", data)
+        self.assertNotIn("blacklisted_intents", data)
+        self.assertNotIn("pipeline", data)
 
 
 class TestLegacyWireRoundTrip(unittest.TestCase):

--- a/test/unittests/test_session_context_view.py
+++ b/test/unittests/test_session_context_view.py
@@ -215,6 +215,34 @@ class TestLegacyWireRoundTrip(unittest.TestCase):
         b = Session.deserialize(a).serialize()
         self.assertEqual(a["intent_context"], b["intent_context"])
 
+    def test_legacy_write_preserves_intent_context_identity(self):
+        from ovos_bus_client.session import Session
+        session = Session("identity-1")
+        session.set_intent_context("person", "Bob")
+        held = session.intent_context
+        # adapt entity shape: data[0] is (value, key)
+        session.context.inject_context({"key": "pet",
+                                        "data": [["cat", "pet"]]})
+        self.assertIs(session.intent_context, held)
+        self.assertIn("pet", held)
+
+    def test_legacy_clear_context_leaves_empty_dict_not_none(self):
+        from ovos_bus_client.session import Session
+        session = Session("clear-1")
+        session.set_intent_context("person", "Bob")
+        session.context.clear_context()
+        self.assertEqual(session.intent_context, {})
+        # membership on the cleared map must not raise
+        self.assertNotIn("person", session.intent_context)
+
+    def test_legacy_remove_last_entry_leaves_empty_dict_not_none(self):
+        from ovos_bus_client.session import Session
+        session = Session("remove-1")
+        session.set_intent_context("person", "Bob")
+        session.context.remove_context("person")
+        self.assertEqual(session.intent_context, {})
+        self.assertNotIn("person", session.intent_context)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_session_empty_containers.py
+++ b/test/unittests/test_session_empty_containers.py
@@ -1,11 +1,14 @@
-"""Canonical collection fields must always be iterable containers.
+"""Canonical collection fields must always be iterable containers in process.
 
 The canonical parent stores an empty list/dict field as ``None`` (SESSION-1
 §2.1 omit-when-empty). bus-client folds those back to ``[]`` / ``{}`` so a
 ``session.blacklisted_intents``-style membership test never raises
-``TypeError: argument of type 'NoneType' is not iterable``, honouring the
-bidirectional-wire contract: tolerate ``None`` inbound, always present a
-container outbound.
+``TypeError: argument of type 'NoneType' is not iterable``.
+
+This is an in-process guarantee about the *attribute*, not about the wire. On
+the wire an empty list-valued override field is omitted, because SESSION-1 §3.4
+makes ``[]`` wire-equivalent to omission — both resolve to the deployment
+default at the consumer.
 """
 import unittest
 
@@ -36,13 +39,14 @@ class TestEmptyContainerNormalization(unittest.TestCase):
         for name in _CANONICAL_DICT_FIELDS:
             self.assertIsInstance(getattr(sess, name), dict, name)
 
-    def test_serialize_emits_empty_list_for_blacklisted_intents(self):
+    def test_serialize_omits_empty_blacklisted_intents(self):
+        # SESSION-1 §3.4: [] is wire-equivalent to omission, so it is dropped
+        # rather than restated as the deployment default on every Message.
         data = Session(blacklisted_intents=[]).serialize()
-        self.assertEqual(data["blacklisted_intents"], [])
+        self.assertNotIn("blacklisted_intents", data)
 
     def test_deserialize_restores_empty_list_not_none(self):
         data = Session().serialize()
-        self.assertEqual(data["blacklisted_intents"], [])
         sess = Session.deserialize(data)
         self.assertEqual(sess.blacklisted_intents, [])
         self.assertNotIn("x", sess.blacklisted_intents)

--- a/test/unittests/test_session_empty_containers.py
+++ b/test/unittests/test_session_empty_containers.py
@@ -11,9 +11,12 @@ makes ``[]`` wire-equivalent to omission — both resolve to the deployment
 default at the consumer.
 """
 import unittest
+from unittest.mock import patch
 
+import ovos_bus_client.session as session_module
 from ovos_bus_client.session import (Session, _CANONICAL_LIST_FIELDS,
-                                      _CANONICAL_DICT_FIELDS)
+                                      _CANONICAL_DICT_FIELDS,
+                                      _DEFERRABLE_LIST_FIELDS)
 
 
 class TestEmptyContainerNormalization(unittest.TestCase):
@@ -79,6 +82,67 @@ class TestEmptyContainerNormalization(unittest.TestCase):
         for name in _CANONICAL_LIST_FIELDS:
             self.assertIsInstance(getattr(sess, name), list, name)
             self.assertNotIn("x", getattr(sess, name))
+
+
+class TestEmitSessionDefaultsOptIn(unittest.TestCase):
+    """Lean wire by default; opt in to spell out the deferrable fields."""
+
+    @staticmethod
+    def _empty_session():
+        sess = Session("emit-defaults")
+        for name in _DEFERRABLE_LIST_FIELDS:
+            setattr(sess, name, [])
+        return sess
+
+    def test_default_is_lean(self):
+        with patch.dict("os.environ", {}, clear=False):
+            data = self._empty_session().serialize()
+        for name in _DEFERRABLE_LIST_FIELDS:
+            self.assertNotIn(name, data)
+
+    def test_env_var_opts_in(self):
+        with patch.dict("os.environ", {"OVOS_SESSION_EMIT_DEFAULTS": "true"}):
+            data = self._empty_session().serialize()
+        for name in _DEFERRABLE_LIST_FIELDS:
+            self.assertEqual(data[name], [], name)
+
+    def test_env_var_off_value_stays_lean(self):
+        with patch.dict("os.environ", {"OVOS_SESSION_EMIT_DEFAULTS": "false"}):
+            data = self._empty_session().serialize()
+        for name in _DEFERRABLE_LIST_FIELDS:
+            self.assertNotIn(name, data)
+
+    def test_config_key_opts_in(self):
+        with patch.dict("os.environ", {}, clear=True), \
+                patch.object(session_module, "Configuration",
+                             lambda: {"session": {"emit_defaults": True}}):
+            data = self._empty_session().serialize()
+        for name in _DEFERRABLE_LIST_FIELDS:
+            self.assertEqual(data[name], [], name)
+
+    def test_env_var_overrides_config(self):
+        with patch.dict("os.environ", {"OVOS_SESSION_EMIT_DEFAULTS": "0"}), \
+                patch.object(session_module, "Configuration",
+                             lambda: {"session": {"emit_defaults": True}}):
+            data = self._empty_session().serialize()
+        for name in _DEFERRABLE_LIST_FIELDS:
+            self.assertNotIn(name, data)
+
+    def test_both_modes_deserialize_identically(self):
+        lean = self._empty_session().serialize()
+        with patch.dict("os.environ", {"OVOS_SESSION_EMIT_DEFAULTS": "1"}):
+            verbose = self._empty_session().serialize()
+        self.assertNotEqual(lean.keys(), verbose.keys())
+        for name in _DEFERRABLE_LIST_FIELDS:
+            self.assertEqual(getattr(Session.deserialize(lean), name),
+                             getattr(Session.deserialize(verbose), name), name)
+
+    def test_populated_values_emit_regardless(self):
+        sess = Session("diverging")
+        sess.blacklisted_intents = ["a.skill:some.intent"]
+        with patch.dict("os.environ", {}, clear=False):
+            data = sess.serialize()
+        self.assertEqual(data["blacklisted_intents"], ["a.skill:some.intent"])
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_session_empty_containers.py
+++ b/test/unittests/test_session_empty_containers.py
@@ -11,12 +11,9 @@ makes ``[]`` wire-equivalent to omission — both resolve to the deployment
 default at the consumer.
 """
 import unittest
-from unittest.mock import patch
 
-import ovos_bus_client.session as session_module
 from ovos_bus_client.session import (Session, _CANONICAL_LIST_FIELDS,
-                                      _CANONICAL_DICT_FIELDS,
-                                      _DEFERRABLE_LIST_FIELDS)
+                                      _CANONICAL_DICT_FIELDS)
 
 
 class TestEmptyContainerNormalization(unittest.TestCase):
@@ -84,64 +81,11 @@ class TestEmptyContainerNormalization(unittest.TestCase):
             self.assertNotIn("x", getattr(sess, name))
 
 
-class TestEmitSessionDefaultsOptIn(unittest.TestCase):
-    """Lean wire by default; opt in to spell out the deferrable fields."""
-
-    @staticmethod
-    def _empty_session():
-        sess = Session("emit-defaults")
-        for name in _DEFERRABLE_LIST_FIELDS:
-            setattr(sess, name, [])
-        return sess
-
-    def test_default_is_lean(self):
-        with patch.dict("os.environ", {}, clear=False):
-            data = self._empty_session().serialize()
-        for name in _DEFERRABLE_LIST_FIELDS:
-            self.assertNotIn(name, data)
-
-    def test_env_var_opts_in(self):
-        with patch.dict("os.environ", {"OVOS_SESSION_EMIT_DEFAULTS": "true"}):
-            data = self._empty_session().serialize()
-        for name in _DEFERRABLE_LIST_FIELDS:
-            self.assertEqual(data[name], [], name)
-
-    def test_env_var_off_value_stays_lean(self):
-        with patch.dict("os.environ", {"OVOS_SESSION_EMIT_DEFAULTS": "false"}):
-            data = self._empty_session().serialize()
-        for name in _DEFERRABLE_LIST_FIELDS:
-            self.assertNotIn(name, data)
-
-    def test_config_key_opts_in(self):
-        with patch.dict("os.environ", {}, clear=True), \
-                patch.object(session_module, "Configuration",
-                             lambda: {"session": {"emit_defaults": True}}):
-            data = self._empty_session().serialize()
-        for name in _DEFERRABLE_LIST_FIELDS:
-            self.assertEqual(data[name], [], name)
-
-    def test_env_var_overrides_config(self):
-        with patch.dict("os.environ", {"OVOS_SESSION_EMIT_DEFAULTS": "0"}), \
-                patch.object(session_module, "Configuration",
-                             lambda: {"session": {"emit_defaults": True}}):
-            data = self._empty_session().serialize()
-        for name in _DEFERRABLE_LIST_FIELDS:
-            self.assertNotIn(name, data)
-
-    def test_both_modes_deserialize_identically(self):
-        lean = self._empty_session().serialize()
-        with patch.dict("os.environ", {"OVOS_SESSION_EMIT_DEFAULTS": "1"}):
-            verbose = self._empty_session().serialize()
-        self.assertNotEqual(lean.keys(), verbose.keys())
-        for name in _DEFERRABLE_LIST_FIELDS:
-            self.assertEqual(getattr(Session.deserialize(lean), name),
-                             getattr(Session.deserialize(verbose), name), name)
-
-    def test_populated_values_emit_regardless(self):
+class TestSerializeLean(unittest.TestCase):
+    def test_populated_override_values_emit(self):
         sess = Session("diverging")
         sess.blacklisted_intents = ["a.skill:some.intent"]
-        with patch.dict("os.environ", {}, clear=False):
-            data = sess.serialize()
+        data = sess.serialize()
         self.assertEqual(data["blacklisted_intents"], ["a.skill:some.intent"])
 
 

--- a/test/unittests/test_session_extra.py
+++ b/test/unittests/test_session_extra.py
@@ -208,9 +208,7 @@ class TestSessionSerialization(TestCase):
         _reset_session_manager()
 
     def test_serialize_includes_all_keys(self):
-        s = Session("sid", lang="pt-pt", site_id="kitchen", persona_id="p1",
-                    blacklisted_skills=["bad.skill"],
-                    blacklisted_intents=["bad:intent"])
+        s = Session("sid", lang="pt-pt", site_id="kitchen", persona_id="p1")
         d = s.serialize()
         for key in ["active_skills", "utterance_states", "session_id",
                     "persona_id", "lang", "context", "site_id", "pipeline",
@@ -221,17 +219,6 @@ class TestSessionSerialization(TestCase):
         self.assertEqual(d["session_id"], "sid")
         self.assertEqual(d["persona_id"], "p1")
         self.assertEqual(d["site_id"], "kitchen")
-
-    def test_serialize_omits_empty_blacklists(self):
-        # SESSION-1 §2.1 omission-not-null: empty blacklists are absent from the
-        # wire, never forced to ``[]``.
-        s = Session("sid")
-        # set post-construction to bypass the config-default fallback
-        s.blacklisted_skills = []
-        s.blacklisted_intents = []
-        d = s.serialize()
-        self.assertNotIn("blacklisted_skills", d)
-        self.assertNotIn("blacklisted_intents", d)
 
     def test_deserialize_roundtrip(self):
         s = Session("sid", lang="en-us", site_id="lab")

--- a/test/unittests/test_session_extra.py
+++ b/test/unittests/test_session_extra.py
@@ -208,7 +208,9 @@ class TestSessionSerialization(TestCase):
         _reset_session_manager()
 
     def test_serialize_includes_all_keys(self):
-        s = Session("sid", lang="pt-pt", site_id="kitchen", persona_id="p1")
+        s = Session("sid", lang="pt-pt", site_id="kitchen", persona_id="p1",
+                    blacklisted_skills=["bad.skill"],
+                    blacklisted_intents=["bad:intent"])
         d = s.serialize()
         for key in ["active_skills", "utterance_states", "session_id",
                     "persona_id", "lang", "context", "site_id", "pipeline",
@@ -219,6 +221,17 @@ class TestSessionSerialization(TestCase):
         self.assertEqual(d["session_id"], "sid")
         self.assertEqual(d["persona_id"], "p1")
         self.assertEqual(d["site_id"], "kitchen")
+
+    def test_serialize_omits_empty_blacklists(self):
+        # SESSION-1 §2.1 omission-not-null: empty blacklists are absent from the
+        # wire, never forced to ``[]``.
+        s = Session("sid")
+        # set post-construction to bypass the config-default fallback
+        s.blacklisted_skills = []
+        s.blacklisted_intents = []
+        d = s.serialize()
+        self.assertNotIn("blacklisted_skills", d)
+        self.assertNotIn("blacklisted_intents", d)
 
     def test_deserialize_roundtrip(self):
         s = Session("sid", lang="en-us", site_id="lab")

--- a/test/unittests/test_session_extra.py
+++ b/test/unittests/test_session_extra.py
@@ -208,7 +208,9 @@ class TestSessionSerialization(TestCase):
         _reset_session_manager()
 
     def test_serialize_includes_all_keys(self):
-        s = Session("sid", lang="pt-pt", site_id="kitchen", persona_id="p1")
+        s = Session("sid", lang="pt-pt", site_id="kitchen", persona_id="p1",
+                    blacklisted_skills=["bad.skill"],
+                    blacklisted_intents=["bad:intent"])
         d = s.serialize()
         for key in ["active_skills", "utterance_states", "session_id",
                     "persona_id", "lang", "context", "site_id", "pipeline",
@@ -219,6 +221,17 @@ class TestSessionSerialization(TestCase):
         self.assertEqual(d["session_id"], "sid")
         self.assertEqual(d["persona_id"], "p1")
         self.assertEqual(d["site_id"], "kitchen")
+
+    def test_serialize_omits_empty_blacklists(self):
+        # SESSION-1 §3.4: an empty list-valued override field is wire-equivalent
+        # to omission, so it is absent from the wire, never forced to ``[]``.
+        s = Session("sid")
+        # set post-construction to bypass the config-default fallback
+        s.blacklisted_skills = []
+        s.blacklisted_intents = []
+        d = s.serialize()
+        self.assertNotIn("blacklisted_skills", d)
+        self.assertNotIn("blacklisted_intents", d)
 
     def test_deserialize_roundtrip(self):
         s = Session("sid", lang="en-us", site_id="lab")

--- a/test/unittests/test_session_intent_context_mutators.py
+++ b/test/unittests/test_session_intent_context_mutators.py
@@ -1,0 +1,126 @@
+"""Tests for the canonical OVOS-CONTEXT-1 intent-context mutators.
+
+``Session.set_intent_context`` / ``remove_intent_context`` /
+``clear_intent_context`` are the ONE canonical write path into the flat §2
+``intent_context`` map. They resolve keys per §3.1 (private vs shared), mutate
+the map in place (preserving Session + map identity), and every write is
+reflected both in the canonical map and in the derived legacy ``context``
+frame-stack view.
+"""
+import unittest
+
+from ovos_spec_tools.context import gate_satisfied, resolve_key
+
+
+class TestIntentContextMutators(unittest.TestCase):
+    def setUp(self):
+        from ovos_bus_client.session import Session
+        self.session = Session("ctx-mutator-test")
+
+    # --- set: private vs shared scope resolution (§3.1) ------------------
+    def test_set_private_resolves_owner_prefixed_key(self):
+        self.session.set_intent_context("topic", "weather",
+                                        scope="private", owner_id="skill.a")
+        self.assertIn("skill.a:topic", self.session.intent_context)
+        self.assertEqual(self.session.intent_context["skill.a:topic"]["value"],
+                         "weather")
+        # a shared gate on the same name is NOT satisfied by the private entry
+        self.assertFalse(gate_satisfied(
+            self.session.intent_context,
+            requires=[{"key": "topic", "scope": "shared"}],
+            excludes=None, owner_id="skill.a"))
+        # the private gate IS satisfied
+        self.assertTrue(gate_satisfied(
+            self.session.intent_context,
+            requires=[{"key": "topic", "scope": "private"}],
+            excludes=None, owner_id="skill.a"))
+
+    def test_set_shared_resolves_bare_key(self):
+        self.session.set_intent_context("person", "Bob", scope="shared")
+        self.assertIn("person", self.session.intent_context)
+        self.assertEqual(self.session.intent_context["person"]["value"], "Bob")
+
+    def test_set_private_without_owner_is_noop(self):
+        self.session.set_intent_context("topic", "x", scope="private",
+                                        owner_id=None)
+        self.assertFalse(self.session.intent_context)
+
+    def test_set_records_optional_decay_fields_only_when_given(self):
+        self.session.set_intent_context("a", 1, scope="shared")
+        self.assertEqual(set(self.session.intent_context["a"]), {"value"})
+        self.session.set_intent_context("b", 2, scope="shared",
+                                        expires_at=123.0, turns_remaining=3)
+        self.assertEqual(self.session.intent_context["b"],
+                         {"value": 2, "expires_at": 123.0,
+                          "turns_remaining": 3})
+
+    def test_set_replaces_existing_entry(self):
+        self.session.set_intent_context("a", 1, scope="shared")
+        self.session.set_intent_context("a", 2, scope="shared")
+        self.assertEqual(self.session.intent_context["a"], {"value": 2})
+
+    # --- remove ----------------------------------------------------------
+    def test_remove_pops_resolved_key(self):
+        self.session.set_intent_context("topic", "x", owner_id="skill.a")
+        self.session.remove_intent_context("topic", owner_id="skill.a")
+        self.assertNotIn("skill.a:topic", self.session.intent_context)
+
+    def test_remove_wrong_scope_leaves_entry(self):
+        self.session.set_intent_context("topic", "x", owner_id="skill.a")
+        # a shared removal must not touch the private entry
+        self.session.remove_intent_context("topic", scope="shared")
+        self.assertIn("skill.a:topic", self.session.intent_context)
+
+    def test_remove_missing_key_is_noop(self):
+        self.session.remove_intent_context("nope", scope="shared")
+        self.assertFalse(self.session.intent_context)
+
+    # --- clear -----------------------------------------------------------
+    def test_clear_empties_map_in_place(self):
+        self.session.set_intent_context("a", 1, scope="shared")
+        self.session.set_intent_context("b", 2, scope="shared")
+        before = self.session.intent_context
+        self.session.clear_intent_context()
+        self.assertEqual(self.session.intent_context, {})
+        # cleared IN PLACE — same object, never None (SESSION-1 §2.1)
+        self.assertIs(self.session.intent_context, before)
+
+    # --- identity / mutate-in-place --------------------------------------
+    def test_mutators_preserve_map_object_identity(self):
+        # once the map exists, every further mutation is in place: the same
+        # dict object (and Session) is kept, never replaced.
+        self.session.set_intent_context("a", 1, scope="shared")
+        original_map = self.session.intent_context
+        self.session.set_intent_context("b", 2, scope="shared")
+        self.session.remove_intent_context("b", scope="shared")
+        self.session.clear_intent_context()
+        self.assertIs(self.session.intent_context, original_map)
+
+    def test_set_touches_session(self):
+        from unittest.mock import patch
+        with patch.object(type(self.session), "touch") as touch:
+            self.session.set_intent_context("a", 1, scope="shared")
+        touch.assert_called_once()
+
+    # --- derived legacy view reflects canonical writes -------------------
+    def test_shared_set_visible_in_legacy_context_view(self):
+        self.session.set_intent_context("person", "Bob", scope="shared")
+        # the adapt-style frame stack projects taggable shared string entries
+        frames = self.session.context.frame_stack
+        found = any(ent.get("origin") == "person"
+                    for frame, _ in frames for ent in frame.entities)
+        self.assertTrue(found)
+
+    def test_roundtrip_set_remove_clear_reflected_both_ways(self):
+        self.session.set_intent_context("person", "Bob", scope="shared")
+        self.assertEqual(resolve_key("person", "shared", None), "person")
+        self.assertIn("person", self.session.intent_context)
+        self.session.remove_intent_context("person", scope="shared")
+        self.assertNotIn("person", self.session.intent_context)
+        self.session.set_intent_context("x", 1, scope="shared")
+        self.session.clear_intent_context()
+        self.assertEqual(self.session.context.frame_stack, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_session_intent_context_mutators.py
+++ b/test/unittests/test_session_intent_context_mutators.py
@@ -3,7 +3,8 @@
 ``Session.set_intent_context`` / ``remove_intent_context`` /
 ``clear_intent_context`` are the ONE canonical write path into the flat §2
 ``intent_context`` map. They resolve keys per §3.1 (private vs shared), mutate
-the map in place (preserving Session + map identity), and every write is
+the map in place (preserving Session + map identity), record removals as §5.3
+null tombstones so deletions propagate in sync payloads, and every write is
 reflected both in the canonical map and in the derived legacy ``context``
 frame-stack view.
 """
@@ -40,9 +41,12 @@ class TestIntentContextMutators(unittest.TestCase):
         self.assertIn("person", self.session.intent_context)
         self.assertEqual(self.session.intent_context["person"]["value"], "Bob")
 
-    def test_set_private_without_owner_is_noop(self):
-        self.session.set_intent_context("topic", "x", scope="private",
-                                        owner_id=None)
+    def test_set_private_without_owner_raises(self):
+        # a private write cannot resolve a stored key without an owner; a
+        # silently dropped context write would be a debugging trap
+        with self.assertRaises(ValueError):
+            self.session.set_intent_context("topic", "x", scope="private",
+                                            owner_id=None)
         self.assertFalse(self.session.intent_context)
 
     def test_set_records_optional_decay_fields_only_when_given(self):
@@ -60,30 +64,56 @@ class TestIntentContextMutators(unittest.TestCase):
         self.assertEqual(self.session.intent_context["a"], {"value": 2})
 
     # --- remove ----------------------------------------------------------
-    def test_remove_pops_resolved_key(self):
+    def test_remove_tombstones_resolved_key(self):
+        # removal writes a §5.3 null tombstone rather than popping, so the
+        # deletion stays visible in the map this session serializes and the
+        # receiving merge deletes the key; a tombstone is never live
         self.session.set_intent_context("topic", "x", owner_id="skill.a")
         self.session.remove_intent_context("topic", owner_id="skill.a")
-        self.assertNotIn("skill.a:topic", self.session.intent_context)
+        self.assertIsNone(self.session.intent_context["skill.a:topic"])
+        self.assertFalse(gate_satisfied(
+            self.session.intent_context,
+            requires=[{"key": "topic", "scope": "private"}],
+            excludes=None, owner_id="skill.a"))
 
     def test_remove_wrong_scope_leaves_entry(self):
         self.session.set_intent_context("topic", "x", owner_id="skill.a")
         # a shared removal must not touch the private entry
         self.session.remove_intent_context("topic", scope="shared")
-        self.assertIn("skill.a:topic", self.session.intent_context)
+        self.assertEqual(self.session.intent_context["skill.a:topic"],
+                         {"value": "x"})
 
     def test_remove_missing_key_is_noop(self):
         self.session.remove_intent_context("nope", scope="shared")
         self.assertFalse(self.session.intent_context)
 
+    def test_remove_propagates_over_sync_payload(self):
+        """remove + serialize + §5.3 merge deletes the entry at the receiver."""
+        from ovos_bus_client.session import SessionManager
+        self.session.set_intent_context("person", "Bob", scope="shared")
+        self.session.remove_intent_context("person", scope="shared")
+        payload = self.session.serialize().get("intent_context")
+        # the deletion rides the payload as a null entry (§5.3), never absent
+        self.assertEqual(payload, {"person": None})
+        receiver = {"person": {"value": "Bob"}, "room": {"value": "kitchen"}}
+        SessionManager.merge_intent_context(receiver, payload)
+        self.assertEqual(receiver, {"room": {"value": "kitchen"}})
+
     # --- clear -----------------------------------------------------------
-    def test_clear_empties_map_in_place(self):
+    def test_clear_tombstones_map_in_place(self):
         self.session.set_intent_context("a", 1, scope="shared")
         self.session.set_intent_context("b", 2, scope="shared")
         before = self.session.intent_context
         self.session.clear_intent_context()
-        self.assertEqual(self.session.intent_context, {})
-        # cleared IN PLACE — same object, never None (SESSION-1 §2.1)
+        # every entry tombstoned IN PLACE — same object, never None
+        self.assertEqual(self.session.intent_context, {"a": None, "b": None})
         self.assertIs(self.session.intent_context, before)
+        # nothing live remains for gating or the legacy projection
+        self.assertFalse(gate_satisfied(
+            self.session.intent_context,
+            requires=[{"key": "a", "scope": "shared"}],
+            excludes=None, owner_id="x"))
+        self.assertEqual(self.session.context.frame_stack, [])
 
     # --- identity / mutate-in-place --------------------------------------
     def test_mutators_preserve_map_object_identity(self):
@@ -114,9 +144,11 @@ class TestIntentContextMutators(unittest.TestCase):
     def test_roundtrip_set_remove_clear_reflected_both_ways(self):
         self.session.set_intent_context("person", "Bob", scope="shared")
         self.assertEqual(resolve_key("person", "shared", None), "person")
-        self.assertIn("person", self.session.intent_context)
+        self.assertEqual(self.session.intent_context["person"],
+                         {"value": "Bob"})
         self.session.remove_intent_context("person", scope="shared")
-        self.assertNotIn("person", self.session.intent_context)
+        self.assertIsNone(self.session.intent_context["person"])
+        self.assertEqual(self.session.context.frame_stack, [])
         self.session.set_intent_context("x", 1, scope="shared")
         self.session.clear_intent_context()
         self.assertEqual(self.session.context.frame_stack, [])

--- a/test/unittests/test_session_sync_handler.py
+++ b/test/unittests/test_session_sync_handler.py
@@ -1,0 +1,117 @@
+"""Tests for the OVOS-CONTEXT-1 §5.3 ``ovos.session.sync`` handler.
+
+The handler merges the inbound snapshot's ``intent_context`` entry-by-entry
+onto the managed (singleton) session: present entry objects set or replace,
+``null`` entries delete, absent keys are unchanged. The merge mutates the
+working map **in place** — the tracked session's map keeps its object
+identity and stays a dict, never ``None`` — and the legacy default-session
+echo fires only for a bare request that carries no session snapshot.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+
+
+def _sync_message(session_dict):
+    return Message("ovos.session.sync", context={"session": session_dict})
+
+
+class TestHandleSessionSync(unittest.TestCase):
+    def setUp(self):
+        self._sessions = dict(SessionManager.sessions)
+        self._bus = SessionManager.bus
+        SessionManager.bus = None
+
+    def tearDown(self):
+        SessionManager.sessions.clear()
+        SessionManager.sessions.update(self._sessions)
+        SessionManager.bus = self._bus
+
+    def _track(self, session_id, intent_context=None):
+        sess = Session(session_id)
+        if intent_context is not None:
+            sess.intent_context.update(intent_context)
+        SessionManager.sessions[session_id] = sess
+        return sess
+
+    def test_set_and_replace_entries(self):
+        sess = self._track("sync-1", {"person": {"value": "Bob"}})
+        SessionManager.handle_session_sync(_sync_message(
+            {"session_id": "sync-1",
+             "intent_context": {"person": {"value": "Alice"},
+                                "room": {"value": "kitchen"}}}))
+        self.assertEqual(sess.intent_context,
+                         {"person": {"value": "Alice"},
+                          "room": {"value": "kitchen"}})
+
+    def test_null_entry_deletes(self):
+        sess = self._track("sync-2", {"person": {"value": "Bob"},
+                                      "room": {"value": "kitchen"}})
+        SessionManager.handle_session_sync(_sync_message(
+            {"session_id": "sync-2", "intent_context": {"person": None}}))
+        self.assertEqual(sess.intent_context, {"room": {"value": "kitchen"}})
+
+    def test_absent_keys_unchanged(self):
+        sess = self._track("sync-3", {"person": {"value": "Bob"}})
+        SessionManager.handle_session_sync(_sync_message(
+            {"session_id": "sync-3",
+             "intent_context": {"room": {"value": "kitchen"}}}))
+        self.assertEqual(sess.intent_context["person"], {"value": "Bob"})
+
+    def test_empty_sync_leaves_map_a_dict_and_identity(self):
+        sess = self._track("sync-4")
+        held = sess.intent_context
+        SessionManager.handle_session_sync(_sync_message(
+            {"session_id": "sync-4"}))
+        # never rebound, never None: membership on the live map must not raise
+        self.assertIs(sess.intent_context, held)
+        self.assertNotIn("x", sess.intent_context)
+
+    def test_merge_preserves_map_identity(self):
+        sess = self._track("sync-5", {"person": {"value": "Bob"}})
+        held = sess.intent_context
+        SessionManager.handle_session_sync(_sync_message(
+            {"session_id": "sync-5",
+             "intent_context": {"room": {"value": "kitchen"}}}))
+        self.assertIs(sess.intent_context, held)
+        self.assertIn("room", held)
+
+    def test_untracked_session_adopted(self):
+        SessionManager.handle_session_sync(_sync_message(
+            {"session_id": "sync-new",
+             "intent_context": {"person": {"value": "Bob"}}}))
+        sess = SessionManager.sessions.get("sync-new")
+        self.assertIsNotNone(sess)
+        self.assertEqual(sess.intent_context["person"], {"value": "Bob"})
+
+    def test_removal_propagates_end_to_end(self):
+        """skill-side remove + sync deletes the entry on the managed session."""
+        managed = self._track("sync-6", {"person": {"value": "Bob"}})
+        # the skill's local copy, as received on its dispatch Message
+        local = Session.deserialize(managed.serialize())
+        local.remove_intent_context("person", scope="shared")
+        SessionManager.handle_session_sync(_sync_message(local.serialize()))
+        self.assertNotIn("person", managed.intent_context)
+
+    def test_no_echo_for_spec_sync(self):
+        """A session-carrying §5.3 sync is not a default-session request."""
+        SessionManager.bus = MagicMock()
+        self._track("sync-7")
+        SessionManager.handle_session_sync(_sync_message(
+            {"session_id": "sync-7",
+             "intent_context": {"person": {"value": "Bob"}}}))
+        SessionManager.bus.emit.assert_not_called()
+
+    def test_bare_request_echoes_default_session(self):
+        SessionManager.bus = MagicMock()
+        SessionManager.get_default_session()
+        SessionManager.handle_session_sync(Message("ovos.session.sync"))
+        SessionManager.bus.emit.assert_called_once()
+        emitted = SessionManager.bus.emit.call_args[0][0]
+        self.assertEqual(emitted.msg_type, "ovos.session.update_default")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`Session.context` was an `IntentContextManager` frame stack stored as a **parallel object**, disjoint from the canonical OVOS-CONTEXT-1 `session.intent_context` flat map. Legacy `inject_context`/`update_context`/`remove_context` wrote only the frame stack; writes/reads of `intent_context` touched only the flat map — the two never intersected. Adapt drove context through `sess.context` while gating read `intent_context`, so a value set through one path was invisible to the other.

## Change

Every back-compat structure becomes a **derived view over the one canonical store**:

- **`Session.context` → derived view** (`_IntentContextView`, an `IntentContextManager`-API-compatible object — the shape adapt consumes as `context_manager`). Its frame stack projects from live `intent_context` entries; its mutators fold back into `intent_context` via `SessionManager.merge_intent_context`. Mapping: a context entity's `data[0] == (value, entity_type)` ↔ CONTEXT-1 `key`/`value`; decay carried as `expires_at`; only non-null **string** values are taggable surface forms (§7), null/flag entries gate directly (§6). Getter warns.
- **Warn-on-access** added to `active_skills` getter/setter, `utterance_states` getter, and the `_UtteranceStatesView` mutators (all already canonical-derived over `active_handlers` / `response_mode`).
- **`serialize()`** derives the legacy `context`/`active_skills`/`utterance_states` wire keys from canonical state (inline, no warnings) and stops forcing `blacklisted_*`/`pipeline` to `[]` — omission-not-null (SESSION-1 §2.1).
- **`deserialize()`** folds a legacy standalone `context` frame stack, `active_skills`, and `utterance_states` into `intent_context` / `active_handlers` / `response_mode`, **only when the canonical field is absent** (a modern peer's fields win, no double-count). Never raises on old-format payloads.

Both legacy and canonical paths converge on `intent_context`; deprecated APIs still work, backed by canonical data.

## Tests

New `test/unittests/test_session_context_view.py`: unified-store convergence (legacy write → canonical read + CONTEXT-1 gating, and vice-versa), warn-on-access, serialize omission-not-null, and legacy/modern/mixed/idempotent wire round-trips. Updated `test_session_extra.py` for the omission-not-null serialize contract.

## Verification

- Full `test/unittests/` suite: **672 passed** (random + fixed order).
- Cross-checked adapt (`ovos-adapt-pipeline-plugin@dev`) against this branch: **40 context/gating/integration/intent tests pass** — adapt still matches unchanged. The 4 `test_ovoscope_e2e.py::TestDetach`/`TestRegisteredIntentMatch` failures reproduce against the released bus-client too (pre-existing/environmental, unrelated).

## Canonical intent-context mutators

Beyond the read/derive view, this PR adds the **canonical write path** onto `Session` (mutate-in-place, singleton + map identity preserved):

- `set_intent_context(key, value=None, *, scope="private", owner_id=None, expires_at=None, turns_remaining=None)` — writes the §2 entry `{value, expires_at?, turns_remaining?}` at the §3.1 resolved stored key (private `<owner_id>:<key>`, shared bare `<key>`); unset decay fields are omitted.
- `remove_intent_context(key, *, scope="private", owner_id=None)` — pops the resolved key.
- `clear_intent_context()` — empties the map in place (leaves `{}`, never `None`, per SESSION-1 §2.1).

The legacy `Session.context` frame stack (`_IntentContextView`) is a derived view over this same map, so these setters and the legacy adapt API are one store. New `test/unittests/test_session_intent_context_mutators.py` covers round-trip set/remove/clear reflected in both `intent_context` and the derived legacy view, private-vs-shared scope resolution, and in-place identity. Full suite: **685 passed**.

## Dependency chain

`#256` (this) → `ovos-core#804` → `#459` → `#458`. `#804` floor-pins the alpha that carries these helpers and stays red until `#256` publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how empty, omitted, and `null` override fields are handled during session serialization.
  * Documented the legacy session context behavior and how it maps to the newer session state.

* **Bug Fixes**
  * Improved session context handling so legacy and current views stay in sync.
  * Ensured session data serializes consistently with concrete list values where expected.
  * Refined context updates, removals, and clearing to behave more predictably.

* **Tests**
  * Added coverage for session context compatibility, serialization, and mutation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->