### PR TITLE
fix: always deserialize canonical Session list/dict fields to empty containers

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -20,6 +20,44 @@ from ovos_bus_client.version import VERSION_MAJOR
 # version.py so the warning text can never drift out of date.
 _NEXT_MAJOR_VERSION = f"{VERSION_MAJOR + 1}.0.0"
 
+# Bidirectional-wire back-compat: the canonical parent applies SESSION-1 §2.1
+# omit-when-empty semantics and stores an *empty* collection field as ``None``.
+# On the wire that is equivalent to omission, but in-process it breaks the
+# public contract that these fields are always iterable containers — consumers
+# do ``intent in session.blacklisted_intents`` and a ``None`` raises
+# ``TypeError: argument of type 'NoneType' is not iterable``. These fields are
+# therefore folded back to their canonical empty container after construction
+# so they ALWAYS deserialize to ``[]`` / ``{}``, never ``None``. Serialization
+# still omits them when empty (``to_dict`` drops falsy values), so the wire
+# shape is unchanged. Scalar fields (``site_id``, ``persona_id``, the per-channel
+# language overrides) and the single-object ``response_mode`` legitimately stay
+# ``None`` and are intentionally excluded.
+_CANONICAL_LIST_FIELDS = (
+    "secondary_langs",
+    "pipeline",
+    "blacklisted_skills",
+    "blacklisted_intents",
+    "blacklisted_pipelines",
+    "audio_transformers",
+    "utterance_transformers",
+    "metadata_transformers",
+    "intent_transformers",
+    "dialog_transformers",
+    "tts_transformers",
+    "blacklisted_audio_transformers",
+    "blacklisted_utterance_transformers",
+    "blacklisted_metadata_transformers",
+    "blacklisted_intent_transformers",
+    "blacklisted_dialog_transformers",
+    "blacklisted_tts_transformers",
+    "fallback_handlers",
+    "active_handlers",
+    "converse_handlers",
+)
+_CANONICAL_DICT_FIELDS = (
+    "intent_context",
+)
+
 
 class UtteranceState(str, enum.Enum):
     INTENT = "intent"  # includes converse
@@ -491,6 +529,24 @@ class Session(_SpecSession):
         # persona_id is an inherited canonical field (OVOS-PERSONA-1, registered
         # on ovos_spec_tools.Session); it is forwarded to super().__init__ above
         # so the parent owns its validation + omit-when-empty serialization.
+
+        self._normalize_empty_containers()
+
+    def _normalize_empty_containers(self):
+        """Fold ``None`` canonical collection fields back to empty containers.
+
+        The parent stores an empty list/dict field as ``None`` (SESSION-1 §2.1
+        omit-when-empty). Re-materialize the empty container so the field stays
+        iterable in-process, honouring the bidirectional-wire contract: a legacy
+        or explicitly-null wire value folds to ``[]`` / ``{}`` rather than
+        leaking a ``None`` that breaks ``x in session.<field>``.
+        """
+        for name in _CANONICAL_LIST_FIELDS:
+            if getattr(self, name, None) is None:
+                setattr(self, name, [])
+        for name in _CANONICAL_DICT_FIELDS:
+            if getattr(self, name, None) is None:
+                setattr(self, name, {})
 
     @property
     def timezone(self) -> Optional[str]:

--- a/test/unittests/test_session_config_defaults.py
+++ b/test/unittests/test_session_config_defaults.py
@@ -1,0 +1,73 @@
+"""Config-backed fields resolve to the deployment default, not an empty list.
+
+OVOS-SESSION-1 §2.1: an omitted or ``null`` field means "let the orchestrator
+decide" — the consumer substitutes its own deployment default at the point of
+consumption. For config-backed fields (``pipeline``, ``lang``) that default is
+the deployment-configured value, NOT an empty container.
+
+``Session.deserialize`` routes every field through ``Session.__init__``, whose
+``x or Configuration().get(...)`` resolution runs BEFORE
+``_normalize_empty_containers`` folds still-``None`` fields to ``[]`` / ``{}``.
+So a wire dict that omits (or nulls) ``pipeline`` reconstructs with the
+configured pipeline, while genuinely-empty-default fields
+(``blacklisted_intents``, the ``*_transformers`` override lists) fold to ``[]``.
+These tests pin that ordering so a future change to the normalization step
+cannot silently blank a config-backed default.
+"""
+import unittest
+from unittest.mock import patch
+
+import ovos_bus_client.session as session_module
+from ovos_bus_client.session import Session
+
+_CUSTOM_PIPELINE = ["adapt_high", "fallback_low"]
+_CONFIG = {
+    "lang": "en-us",
+    "intents": {"pipeline": list(_CUSTOM_PIPELINE)},
+}
+
+
+class TestConfigBackedDefaultsOnDeserialize(unittest.TestCase):
+    def _deserialize(self, data):
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG):
+            return Session.deserialize(data)
+
+    def test_omitted_pipeline_resolves_to_configured_pipeline(self):
+        sess = self._deserialize({"session_id": "abc"})
+        self.assertEqual(sess.pipeline, _CUSTOM_PIPELINE)
+
+    def test_null_pipeline_resolves_to_configured_pipeline(self):
+        # SESSION-1 §2.1: explicit null MUST be treated exactly as omitted.
+        sess = self._deserialize({"session_id": "abc", "pipeline": None})
+        self.assertEqual(sess.pipeline, _CUSTOM_PIPELINE)
+
+    def test_empty_pipeline_resolves_to_configured_pipeline(self):
+        # §3.4: an empty array on an override field is wire-equivalent to
+        # omission, so it too resolves to the deployment default.
+        sess = self._deserialize({"session_id": "abc", "pipeline": []})
+        self.assertEqual(sess.pipeline, _CUSTOM_PIPELINE)
+
+    def test_explicit_pipeline_is_preserved(self):
+        sess = self._deserialize({"session_id": "abc",
+                                  "pipeline": ["stop_high"]})
+        self.assertEqual(sess.pipeline, ["stop_high"])
+
+    def test_omitted_blacklisted_intents_folds_to_empty_list(self):
+        # empty deployment default: no config-backed value to substitute.
+        sess = self._deserialize({"session_id": "abc"})
+        self.assertEqual(sess.blacklisted_intents, [])
+
+    def test_omitted_transformer_lists_fold_to_empty_list(self):
+        # the six active *_transformers are override lists whose empty value
+        # defers to the deployment-configured chain at the consuming
+        # transformer service (§3.4 case 3); the Session carries [] for them.
+        sess = self._deserialize({"session_id": "abc"})
+        for name in ("audio_transformers", "utterance_transformers",
+                     "metadata_transformers", "intent_transformers",
+                     "dialog_transformers", "tts_transformers"):
+            self.assertEqual(getattr(sess, name), [], name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_session_empty_containers.py
+++ b/test/unittests/test_session_empty_containers.py
@@ -1,0 +1,81 @@
+"""Canonical collection fields must always be iterable containers.
+
+The canonical parent stores an empty list/dict field as ``None`` (SESSION-1
+§2.1 omit-when-empty). bus-client folds those back to ``[]`` / ``{}`` so a
+``session.blacklisted_intents``-style membership test never raises
+``TypeError: argument of type 'NoneType' is not iterable``, honouring the
+bidirectional-wire contract: tolerate ``None`` inbound, always present a
+container outbound.
+"""
+import unittest
+
+from ovos_bus_client.session import (Session, _CANONICAL_LIST_FIELDS,
+                                      _CANONICAL_DICT_FIELDS)
+
+
+class TestEmptyContainerNormalization(unittest.TestCase):
+    def test_constructor_none_becomes_empty_list(self):
+        sess = Session(blacklisted_intents=None)
+        self.assertEqual(sess.blacklisted_intents, [])
+        self.assertNotIn("anything", sess.blacklisted_intents)
+
+    def test_constructor_empty_list_stays_empty_list(self):
+        sess = Session(blacklisted_intents=[])
+        self.assertEqual(sess.blacklisted_intents, [])
+
+    def test_default_session_has_iterable_list_fields(self):
+        sess = Session()
+        for name in _CANONICAL_LIST_FIELDS:
+            value = getattr(sess, name)
+            self.assertIsInstance(value, list, name)
+            # membership on a default field must never raise
+            self.assertNotIn("x", value)
+
+    def test_default_session_has_dict_fields(self):
+        sess = Session()
+        for name in _CANONICAL_DICT_FIELDS:
+            self.assertIsInstance(getattr(sess, name), dict, name)
+
+    def test_serialize_emits_empty_list_for_blacklisted_intents(self):
+        data = Session(blacklisted_intents=[]).serialize()
+        self.assertEqual(data["blacklisted_intents"], [])
+
+    def test_deserialize_restores_empty_list_not_none(self):
+        data = Session().serialize()
+        self.assertEqual(data["blacklisted_intents"], [])
+        sess = Session.deserialize(data)
+        self.assertEqual(sess.blacklisted_intents, [])
+        self.assertNotIn("x", sess.blacklisted_intents)
+
+    def test_deserialize_null_wire_value_folds_to_empty_list(self):
+        data = Session().serialize()
+        data["blacklisted_intents"] = None
+        sess = Session.deserialize(data)
+        self.assertEqual(sess.blacklisted_intents, [])
+        self.assertNotIn("x", sess.blacklisted_intents)
+
+    def test_deserialize_missing_key_folds_to_empty_list(self):
+        data = Session().serialize()
+        data.pop("blacklisted_intents", None)
+        sess = Session.deserialize(data)
+        self.assertEqual(sess.blacklisted_intents, [])
+
+    def test_roundtrip_is_idempotent(self):
+        first = Session.deserialize(Session().serialize())
+        second = Session.deserialize(first.serialize())
+        self.assertEqual(first.blacklisted_intents, [])
+        self.assertEqual(second.blacklisted_intents, [])
+        self.assertNotIn("x", second.blacklisted_intents)
+
+    def test_sibling_list_fields_roundtrip_to_list(self):
+        data = Session().serialize()
+        for name in _CANONICAL_LIST_FIELDS:
+            data[name] = None
+        sess = Session.deserialize(data)
+        for name in _CANONICAL_LIST_FIELDS:
+            self.assertIsInstance(getattr(sess, name), list, name)
+            self.assertNotIn("x", getattr(sess, name))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_session_spec_fields.py
+++ b/test/unittests/test_session_spec_fields.py
@@ -346,9 +346,11 @@ class TestInheritedCanonicalScalarFields(TestCase):
         self.assertEqual(back.fallback_handlers, ["skill.a", "skill.b"])
 
     def test_fallback_handlers_omitted_when_empty(self):
-        # §3.4 empty-list ≡ omission; parent to_dict() drops it
+        # §3.4 empty-list ≡ omission on the wire: parent to_dict() drops it.
+        # In-process the field stays an iterable empty container (never None),
+        # so membership tests on it cannot raise TypeError.
         s = Session("sid")
-        self.assertIsNone(s.fallback_handlers)
+        self.assertEqual(s.fallback_handlers, [])
         self.assertNotIn("fallback_handlers", SpecSession.to_dict(s))
 
     def test_fallback_handlers_is_inherited_not_overridden(self):


### PR DESCRIPTION
## Problem

`Session.blacklisted_intents` round-tripped asymmetrically: `serialize()`/`as_dict` emitted `[]` for empty, but `deserialize()` restored it as **None**. The canonical parent (`ovos_spec_tools.Session`) stores empty collection fields as `None` under SESSION-1 §2.1 omit-when-empty semantics, and the bus-client subclass never folded them back. Downstream consumers doing `intent in sess.blacklisted_intents` crashed with `TypeError: argument of type 'NoneType' is not iterable` (breaking padacioso and others).

## Fix

`Session._normalize_empty_containers()` runs at the end of `__init__` (so it covers the `deserialize()` path, which constructs via the ctor) and folds every canonical **list** field to `[]` and **dict** field (`intent_context`) to `{}` when the parent left them `None`. The public type is unchanged — the contract is "always a list/dict", not `Optional`.

- Tolerate `None`/`null`/absent inbound → present the canonical empty container outbound (bidirectional-wire back-compat).
- `serialize()`/`to_dict()` still omit empty fields (falsy values are dropped), so the wire shape is unchanged.
- Scalar fields (`site_id`, `persona_id`, per-channel language overrides) and the single-object `response_mode` legitimately stay `None` and are excluded.

Audited siblings all covered: `active_skills`/`utterance_states` (legacy aliases, already `[]`/`{}`), `active_handlers`, `converse_handlers`, `secondary_langs`, `pipeline`, the six `*_transformers` + six `blacklisted_*_transformers` lists, `blacklisted_pipelines`, `blacklisted_skills`, `fallback_handlers`, and `intent_context`.

## Tests

New `test_session_empty_containers.py`: `Session(blacklisted_intents=None)`, a wire dict with `blacklisted_intents: null`, and a missing key all deserialize to `[]`; `x in sess.blacklisted_intents` never raises; serialize→deserialize is idempotent; every sibling list field folds `None`→`list`. Updated `test_fallback_handlers_omitted_when_empty` to the corrected contract (empty container in-process, still omitted on the wire). Full suite: 664 passed.

This is the ROOT fix; the padacioso defensive guard is a separate sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)