### PR TITLE
fix: bridge namespace counterpart on receive, not as a second wire message

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -263,6 +263,19 @@ class MessageBusClient:
             SessionManager.update(sess)
         self.emitter.emit('message', message)
         self.emitter.emit(parsed_message.msg_type, parsed_message)
+        # namespace migration bridge: also dispatch the counterpart topic(s) to
+        # LOCAL listeners so a handler on either namespace receives the event
+        # (consumers dedupe via the on() mirror-guard). This is a listener-delivery
+        # convenience, not a second logical bus message: the counterpart is NOT put
+        # back on the wire and does NOT re-fire the 'message' firehose, so one
+        # logical emit yields exactly one captured message. The mirrored payload is
+        # reshaped into the counterpart topic's shape (identity for payload-compatible
+        # renames, a per-topic transform for shape-changing ones).
+        for topic in self._translator.counterpart_topics(parsed_message.msg_type):
+            translated = self._translator.translate_payload(
+                from_topic=parsed_message.msg_type, to_topic=topic,
+                data=parsed_message.data)
+            self.emitter.emit(topic, parsed_message.forward(topic, translated))
 
     def on_default_session_update(self, message):
         new_session = message.data["session_data"]
@@ -288,16 +301,12 @@ class MessageBusClient:
                    Session(self.session_id)
             message.context["session"] = sess.serialize()
 
+        # a single logical emit puts exactly ONE message on the wire. The
+        # namespace counterpart is bridged to listeners on the RECEIVE side
+        # (see on_message) in every process, so both namespaces are delivered
+        # without a second wire copy that the broadcast server would echo back
+        # and double in the capture firehose.
         self._send(message)
-
-        # also put the namespace counterpart(s) on the wire (per the flags); the
-        # mirrored payload is reshaped into the counterpart topic's shape (identity
-        # for payload-compatible renames, a per-topic transform for shape-changing
-        # ones) so a consumer on the counterpart topic receives it in *its* shape.
-        for topic in self._translator.counterpart_topics(message.msg_type):
-            translated = self._translator.translate_payload(
-                from_topic=message.msg_type, to_topic=topic, data=message.data)
-            self._send(message.forward(topic, translated))
 
     def _send(self, message: Message):
         """Serialize and send a single message over the websocket."""

--- a/test/unittests/test_namespace_migration.py
+++ b/test/unittests/test_namespace_migration.py
@@ -12,14 +12,16 @@ import unittest
 from threading import Event
 from unittest.mock import MagicMock, patch
 
+from pyee import EventEmitter
+
 from ovos_bus_client.client.client import MessageBusClient, _bus_flag
 from ovos_bus_client.message import Message
 from ovos_spec_tools import NamespaceTranslator
 
 
-def _client(modernize=True, emit_legacy=True):
+def _client(modernize=True, emit_legacy=True, emitter=None):
     c = MessageBusClient.__new__(MessageBusClient)
-    c.emitter = MagicMock()
+    c.emitter = emitter if emitter is not None else MagicMock()
     c.client = MagicMock()
     c._translator = NamespaceTranslator(modernize=modernize, emit_legacy=emit_legacy)
     c._handler_guards = {}
@@ -30,6 +32,13 @@ def _client(modernize=True, emit_legacy=True):
     c.started_running = True
     c.session_id = "default"
     return c
+
+
+def _recv_client(modernize=True, emit_legacy=True):
+    """A client wired to a real synchronous emitter so on_message dispatch
+    (the receive-side namespace bridge) can be observed deterministically."""
+    return _client(modernize=modernize, emit_legacy=emit_legacy,
+                   emitter=EventEmitter())
 
 
 def _sent_types(c):
@@ -60,19 +69,23 @@ class TestDefaultsOn(unittest.TestCase):
             self.assertFalse(_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy", default=True))
 
 
-class TestEmitTranslation(unittest.TestCase):
-    def test_legacy_emit_adds_spec(self):
+class TestEmitSendsOnce(unittest.TestCase):
+    """A single logical emit puts exactly ONE message on the wire regardless of
+    the migration flags. The counterpart is bridged on the receive side, never as
+    a second wire copy (which the broadcast server would echo back and double in
+    the capture firehose)."""
+
+    def test_legacy_emit_sends_once(self):
         c = _client()
         c.emit(Message("speak", {"utterance": "hi"}))
-        self.assertEqual(_sent_types(c), ["speak", "ovos.utterance.speak"])
+        self.assertEqual(_sent_types(c), ["speak"])
 
-    def test_spec_emit_adds_legacy(self):
+    def test_spec_emit_sends_once(self):
         c = _client()
         c.emit(Message("ovos.utterance.handle", {"utterances": ["hi"]}))
-        self.assertEqual(_sent_types(c),
-                         ["ovos.utterance.handle", "recognizer_loop:utterance"])
+        self.assertEqual(_sent_types(c), ["ovos.utterance.handle"])
 
-    def test_unmapped_never_translated(self):
+    def test_unmapped_sends_once(self):
         c = _client()
         c.emit(Message("some.topic", {"x": 1}))
         self.assertEqual(_sent_types(c), ["some.topic"])
@@ -83,46 +96,88 @@ class TestEmitTranslation(unittest.TestCase):
         self.assertEqual(_sent_types(c), ["speak"])
 
 
-class TestEmitPayloadTranslation(unittest.TestCase):
-    """The mirrored emission carries the counterpart topic's PAYLOAD shape,
-    not a verbatim copy of the producer's payload (translate_payload bridge)."""
+class TestReceiveSideBridge(unittest.TestCase):
+    """on_message dispatches the received topic AND its namespace counterpart to
+    LOCAL listeners, firing the 'message' capture firehose exactly once."""
+
+    def _firehose(self, c):
+        seen = []
+        c.emitter.on("message", lambda m: seen.append(m))
+        return seen
+
+    def test_one_wire_message_one_firehose_entry(self):
+        c = _recv_client()
+        firehose = self._firehose(c)
+        c.on_message(Message("ovos.utterance.speak", {"utterance": "hi"}).serialize())
+        self.assertEqual(len(firehose), 1)
+
+    def test_spec_wire_reaches_legacy_listener(self):
+        c = _recv_client()
+        legacy_seen = []
+        c.on("speak", lambda m: legacy_seen.append(m))
+        c.on_message(Message("ovos.utterance.speak", {"utterance": "hi"}).serialize())
+        self.assertEqual(len(legacy_seen), 1)
+        self.assertEqual(legacy_seen[0].msg_type, "speak")
+        self.assertEqual(legacy_seen[0].data["utterance"], "hi")
+
+    def test_legacy_wire_reaches_spec_listener(self):
+        c = _recv_client()
+        spec_seen = []
+        c.on("ovos.utterance.handle", lambda m: spec_seen.append(m))
+        c.on_message(Message("recognizer_loop:utterance",
+                             {"utterances": ["hi"]}).serialize())
+        self.assertEqual(len(spec_seen), 1)
+        self.assertEqual(spec_seen[0].data["utterances"], ["hi"])
+
+    def test_counterpart_not_re_sent_on_wire(self):
+        # bridging the counterpart to local listeners must not put it back on
+        # the wire (that would re-broadcast and double the firehose everywhere)
+        c = _recv_client()
+        c.on_message(Message("ovos.utterance.speak", {"utterance": "hi"}).serialize())
+        c.client.send.assert_not_called()
+
+
+class TestReceiveSidePayloadTranslation(unittest.TestCase):
+    """The locally-dispatched counterpart carries the counterpart topic's PAYLOAD
+    shape, not a verbatim copy (translate_payload bridge)."""
+
+    def _capture(self, c, topic):
+        seen = []
+        c.on(topic, lambda m: seen.append(m))
+        return seen
 
     def test_shape_changing_legacy_to_spec_reshapes_payload(self):
-        c = _client()
+        c = _recv_client()
+        spec_seen = self._capture(c, "ovos.intent.deregister")
         # legacy detach_intent payload shape: {"intent_name": "<skill_id>:<name>"}
-        c.emit(Message("detach_intent", {"intent_name": "skill.foo:HelloIntent"}))
-        sent = _sent(c)
-        # original on the legacy topic is verbatim
-        self.assertEqual(sent[0], ("detach_intent",
-                                   {"intent_name": "skill.foo:HelloIntent"}))
-        # mirror on the spec topic is RESHAPED into the spec shape
-        # ({"skill_id", "intent_name"}), NOT the verbatim legacy munged form
-        spec_topic, spec_data = sent[1]
-        self.assertEqual(spec_topic, "ovos.intent.deregister")
-        self.assertEqual(spec_data, {"skill_id": "skill.foo",
-                                     "intent_name": "HelloIntent"})
-        self.assertNotIn("handler", spec_data)  # not verbatim
+        c.on_message(Message("detach_intent",
+                             {"intent_name": "skill.foo:HelloIntent"}).serialize())
+        self.assertEqual(len(spec_seen), 1)
+        self.assertEqual(spec_seen[0].msg_type, "ovos.intent.deregister")
+        # reshaped into the spec shape ({"skill_id", "intent_name"})
+        self.assertEqual(spec_seen[0].data,
+                         {"skill_id": "skill.foo", "intent_name": "HelloIntent"})
 
     def test_shape_changing_spec_to_legacy_reshapes_payload(self):
-        c = _client()
-        # spec deregister payload shape: {"skill_id", "intent_name"}
-        c.emit(Message("ovos.intent.deregister",
-                       {"skill_id": "skill.foo", "intent_name": "HelloIntent"}))
-        sent = _sent(c)
-        self.assertEqual(sent[0][0], "ovos.intent.deregister")
-        legacy_topic, legacy_data = sent[1]
-        self.assertEqual(legacy_topic, "detach_intent")
+        c = _recv_client()
+        legacy_seen = self._capture(c, "detach_intent")
+        c.on_message(Message("ovos.intent.deregister",
+                             {"skill_id": "skill.foo",
+                              "intent_name": "HelloIntent"}).serialize())
+        self.assertEqual(len(legacy_seen), 1)
+        self.assertEqual(legacy_seen[0].msg_type, "detach_intent")
         # reshaped to the legacy munged form -> "<skill_id>:<intent_name>"
-        self.assertEqual(legacy_data, {"intent_name": "skill.foo:HelloIntent"})
+        self.assertEqual(legacy_seen[0].data,
+                         {"intent_name": "skill.foo:HelloIntent"})
 
     def test_payload_compatible_rename_stays_equivalent(self):
-        c = _client()
+        c = _recv_client()
+        spec_seen = self._capture(c, "ovos.utterance.speak")
         data = {"utterance": "hi", "lang": "en-us"}
-        c.emit(Message("speak", dict(data)))
-        sent = _sent(c)
-        self.assertEqual(sent[0], ("speak", data))
-        # payload-compatible rename: mirror carries equivalent (identity) data
-        self.assertEqual(sent[1], ("ovos.utterance.speak", data))
+        c.on_message(Message("speak", dict(data)).serialize())
+        self.assertEqual(len(spec_seen), 1)
+        # payload-compatible rename: counterpart carries equivalent (identity) data
+        self.assertEqual(spec_seen[0].data, data)
 
 
 class TestHandlerDedup(unittest.TestCase):


### PR DESCRIPTION
## Problem

Sequence-based ovoscope e2e saw **every** bus message doubled ("got 10, expected 5").

## True source

`MessageBusClient.emit` dual-sent every migrated event as **two separate wire messages** (the canonical topic + its namespace counterpart, via `_send`). The messagebus server (`ovos-messagebus` `event_handler.py`) broadcasts every received wire message back to **all** clients including the sender, so each client's `on_message` fired the `'message'` capture firehose **twice** per logical emit.

`FakeBus` never had the bug: it fires the firehose once and dispatches the counterpart to local listeners only. The real client was inconsistent with it.

Reproduced end-to-end against a live `ovos-messagebus`:
- before: firehose captured `['ovos.utterance.speak', 'speak']` for one emit
- after: firehose captures `['ovos.utterance.speak']`; a legacy `speak` listener and an `ovos.utterance.speak` listener each still fire once

## Fix

- `emit` puts **exactly one** message on the wire (drop the counterpart `_send`).
- `on_message` dispatches the namespace counterpart to **local** listeners (with payload reshaping + the existing `on()` mirror-guard dedup). It is a listener-delivery convenience, not a second logical bus message, so it never re-fires the `'message'` firehose.

Every process bridges on receive, so a listener on either namespace still receives the event exactly once, legacy back-compat is preserved, and the capture firehose logs each logical emit exactly once. No capture-side filtering anywhere.

## Tests (TDD)

New `TestReceiveSideBridge` / `TestReceiveSidePayloadTranslation`: one wire message -> one firehose entry, both namespaces delivered once, counterpart never re-sent on the wire, payload reshaping preserved. `TestEmitSendsOnce` pins the single-wire-message contract. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)