### PR TITLE
Serialize websocket sends

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -338,7 +338,7 @@ class MessageBusClient:
                         'has been closed')
             if raise_errors:
                 raise
-        except Exception as e:
+        except Exception:
             LOG.exception(f"failed to emit message {message.msg_type} with len {len(msg)}")
             if raise_errors:
                 raise

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -4,7 +4,7 @@ import time
 from ovos_utils import json_dumps
 
 from os import getpid
-from threading import Event, Thread
+from threading import Event, RLock, Thread
 from typing import Union, Callable, Any, List, Optional
 from uuid import uuid4
 
@@ -141,6 +141,7 @@ class MessageBusClient:
         self.retry = 5
         self.connected_event = Event()
         self.started_running = False
+        self._send_lock = RLock()
         self.wrapped_funcs = {}
         # namespace translation on emit (orthogonal, both ON by default during
         # the migration window so every migrated event travels on BOTH the
@@ -286,6 +287,12 @@ class MessageBusClient:
         SessionManager.update(sess)
         LOG.debug("synced default_session")
 
+    def _ensure_session(self, message: Message) -> None:
+        if "session" not in message.context:
+            sess = SessionManager.sessions.get(self.session_id) or \
+                   Session(self.session_id)
+            message.context["session"] = sess.serialize()
+
     def emit(self, message: Message):
         """
         Send a message onto the message bus.
@@ -296,10 +303,7 @@ class MessageBusClient:
         Args:
             message (Message): Message to send
         """
-        if "session" not in message.context:
-            sess = SessionManager.sessions.get(self.session_id) or \
-                   Session(self.session_id)
-            message.context["session"] = sess.serialize()
+        self._ensure_session(message)
 
         # a single logical emit puts exactly ONE message on the wire. The
         # namespace counterpart is bridged to listeners on the RECEIVE side
@@ -308,7 +312,12 @@ class MessageBusClient:
         # and double in the capture firehose.
         self._send(message)
 
-    def _send(self, message: Message):
+    def emit_checked(self, message: Message):
+        """Emit a message and raise websocket send failures to the caller."""
+        self._ensure_session(message)
+        self._send(message, raise_errors=True)
+
+    def _send(self, message: Message, raise_errors: bool = False):
         """Serialize and send a single message over the websocket."""
         if not self.connected_event.wait(10):
             if not self.started_running:
@@ -322,12 +331,17 @@ class MessageBusClient:
             msg = json_dumps(message.__dict__)
         msg = _maybe_encrypt(msg)
         try:
-            self.client.send(msg)
+            with self._send_lock:
+                self.client.send(msg)
         except WebSocketConnectionClosedException:
             LOG.warning(f'Could not send {message.msg_type} message because connection '
                         'has been closed')
+            if raise_errors:
+                raise
         except Exception as e:
             LOG.exception(f"failed to emit message {message.msg_type} with len {len(msg)}")
+            if raise_errors:
+                raise
 
     def collect_responses(self, message: Message,
                           min_timeout: Union[int, float] = 0.2,
@@ -572,14 +586,7 @@ class GUIWebsocketClient(MessageBusClient):
                                  'before emitting messages')
             self.connected_event.wait()
 
-        try:
-            if hasattr(message, 'serialize'):
-                self.client.send(_maybe_encrypt(message.serialize()))
-            else:
-                self.client.send(_maybe_encrypt(json_dumps(message.__dict__)))
-        except WebSocketConnectionClosedException:
-            LOG.warning('Could not send %s message because connection '
-                        'has been closed', message.msg_type)
+        self._send(message)
 
     def on_open(self, *args):
         super().on_open(*args)

--- a/test/unittests/test_client_extra.py
+++ b/test/unittests/test_client_extra.py
@@ -3,7 +3,7 @@ handler/emit/wait helpers and GUIWebsocketClient construction."""
 import json
 import unittest
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock
 
 from websocket import WebSocketConnectionClosedException
 
@@ -50,7 +50,9 @@ class TestHandlerRegistration(TestCase):
         self.assertEqual(len(called), 1)
 
     def test_remove_normal_handler(self):
-        cb = lambda m: None
+        def cb(message):
+            return None
+
         self.client.on("evt", cb)
         self.client.remove("evt", cb)
         # second remove should not raise

--- a/test/unittests/test_client_extra.py
+++ b/test/unittests/test_client_extra.py
@@ -5,6 +5,8 @@ import unittest
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
+from websocket import WebSocketConnectionClosedException
+
 from ovos_bus_client.client.client import (GUIWebsocketClient,
                                            MessageBusClient)
 from ovos_bus_client.message import GUIMessage, Message
@@ -79,6 +81,29 @@ class TestEmit(TestCase):
         decoded = json.loads(payload)
         self.assertEqual(decoded["type"], "test.message")
         self.assertEqual(decoded["data"]["utterance"], "hi")
+
+    def test_emit_uses_send_lock(self):
+        class _Lock:
+            entered = False
+
+            def __enter__(self):
+                self.entered = True
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        lock = _Lock()
+        self.client._send_lock = lock
+
+        self.client.emit(Message("test.message"))
+
+        self.assertTrue(lock.entered)
+
+    def test_emit_checked_raises_send_failures(self):
+        self.client.client.send.side_effect = WebSocketConnectionClosedException()
+
+        with self.assertRaises(WebSocketConnectionClosedException):
+            self.client.emit_checked(Message("test.message"))
 
 
 class TestWaitForMessage(TestCase):


### PR DESCRIPTION
## What
- serialize websocket writes with a per-client send lock
- add `emit_checked()` for callers that need send failures to raise
- reuse the same send path for GUI websocket emits

## Why
High-concurrency callers can write to the same websocket from multiple threads. The default `emit()` path stays compatible, while callers that need delivery accounting can opt into checked failures.

## Test
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/unittests/test_client_extra.py -q`
