### PR TITLE
fix: Clear bus connected state on close/error

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -340,7 +340,7 @@ class MessageBusClient:
                         'has been closed')
             if raise_errors:
                 raise
-        except Exception as e:
+        except Exception:
             LOG.exception(f"failed to emit message {message.msg_type} with len {len(msg)}")
             if raise_errors:
                 raise

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -4,7 +4,7 @@ import time
 from ovos_utils import json_dumps
 
 from os import getpid
-from threading import Event, RLock, Thread
+from threading import Event, Thread
 from typing import Union, Callable, Any, List, Optional
 from uuid import uuid4
 
@@ -141,7 +141,6 @@ class MessageBusClient:
         self.retry = 5
         self.connected_event = Event()
         self.started_running = False
-        self._send_lock = RLock()
         self.wrapped_funcs = {}
         # namespace translation on emit (orthogonal, both ON by default during
         # the migration window so every migrated event travels on BOTH the
@@ -289,12 +288,6 @@ class MessageBusClient:
         SessionManager.update(sess)
         LOG.debug("synced default_session")
 
-    def _ensure_session(self, message: Message) -> None:
-        if "session" not in message.context:
-            sess = SessionManager.sessions.get(self.session_id) or \
-                   Session(self.session_id)
-            message.context["session"] = sess.serialize()
-
     def emit(self, message: Message):
         """
         Send a message onto the message bus.
@@ -305,7 +298,10 @@ class MessageBusClient:
         Args:
             message (Message): Message to send
         """
-        self._ensure_session(message)
+        if "session" not in message.context:
+            sess = SessionManager.sessions.get(self.session_id) or \
+                   Session(self.session_id)
+            message.context["session"] = sess.serialize()
 
         # a single logical emit puts exactly ONE message on the wire. The
         # namespace counterpart is bridged to listeners on the RECEIVE side
@@ -314,12 +310,7 @@ class MessageBusClient:
         # and double in the capture firehose.
         self._send(message)
 
-    def emit_checked(self, message: Message):
-        """Emit a message and raise websocket send failures to the caller."""
-        self._ensure_session(message)
-        self._send(message, raise_errors=True)
-
-    def _send(self, message: Message, raise_errors: bool = False):
+    def _send(self, message: Message):
         """Serialize and send a single message over the websocket."""
         if not self.connected_event.wait(10):
             if not self.started_running:
@@ -333,21 +324,12 @@ class MessageBusClient:
             msg = json_dumps(message.__dict__)
         msg = _maybe_encrypt(msg)
         try:
-            lock = getattr(self, "_send_lock", None)
-            if lock is None:
-                self.client.send(msg)
-            else:
-                with lock:
-                    self.client.send(msg)
+            self.client.send(msg)
         except WebSocketConnectionClosedException:
             LOG.warning(f'Could not send {message.msg_type} message because connection '
                         'has been closed')
-            if raise_errors:
-                raise
-        except Exception:
+        except Exception as e:
             LOG.exception(f"failed to emit message {message.msg_type} with len {len(msg)}")
-            if raise_errors:
-                raise
 
     def collect_responses(self, message: Message,
                           min_timeout: Union[int, float] = 0.2,
@@ -592,7 +574,14 @@ class GUIWebsocketClient(MessageBusClient):
                                  'before emitting messages')
             self.connected_event.wait()
 
-        self._send(message)
+        try:
+            if hasattr(message, 'serialize'):
+                self.client.send(_maybe_encrypt(message.serialize()))
+            else:
+                self.client.send(_maybe_encrypt(json_dumps(message.__dict__)))
+        except WebSocketConnectionClosedException:
+            LOG.warning('Could not send %s message because connection '
+                        'has been closed', message.msg_type)
 
     def on_open(self, *args):
         super().on_open(*args)

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -333,8 +333,12 @@ class MessageBusClient:
             msg = json_dumps(message.__dict__)
         msg = _maybe_encrypt(msg)
         try:
-            with self._send_lock:
+            lock = getattr(self, "_send_lock", None)
+            if lock is None:
                 self.client.send(msg)
+            else:
+                with lock:
+                    self.client.send(msg)
         except WebSocketConnectionClosedException:
             LOG.warning(f'Could not send {message.msg_type} message because connection '
                         'has been closed')

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -4,7 +4,7 @@ import time
 from ovos_utils import json_dumps
 
 from os import getpid
-from threading import Event, Thread
+from threading import Event, RLock, Thread
 from typing import Union, Callable, Any, List, Optional
 from uuid import uuid4
 
@@ -141,6 +141,7 @@ class MessageBusClient:
         self.retry = 5
         self.connected_event = Event()
         self.started_running = False
+        self._send_lock = RLock()
         self.wrapped_funcs = {}
         # namespace translation on emit (orthogonal, both ON by default during
         # the migration window so every migrated event travels on BOTH the
@@ -197,6 +198,7 @@ class MessageBusClient:
         Handle the "close" event from the websocket.
         A Basic message with the name "close" is forwarded to the emitter.
         """
+        self.connected_event.clear()
         self.emitter.emit("close")
 
     def on_error(self, *args):
@@ -217,6 +219,7 @@ class MessageBusClient:
             LOG.debug("ignoring non-exception websocket error callback: %r",
                       error)
             return
+        self.connected_event.clear()
         if isinstance(error, WebSocketConnectionClosedException):
             LOG.warning('Could not send message because connection has closed')
         elif isinstance(error, ConnectionRefusedError):
@@ -286,6 +289,12 @@ class MessageBusClient:
         SessionManager.update(sess)
         LOG.debug("synced default_session")
 
+    def _ensure_session(self, message: Message) -> None:
+        if "session" not in message.context:
+            sess = SessionManager.sessions.get(self.session_id) or \
+                   Session(self.session_id)
+            message.context["session"] = sess.serialize()
+
     def emit(self, message: Message):
         """
         Send a message onto the message bus.
@@ -296,10 +305,7 @@ class MessageBusClient:
         Args:
             message (Message): Message to send
         """
-        if "session" not in message.context:
-            sess = SessionManager.sessions.get(self.session_id) or \
-                   Session(self.session_id)
-            message.context["session"] = sess.serialize()
+        self._ensure_session(message)
 
         # a single logical emit puts exactly ONE message on the wire. The
         # namespace counterpart is bridged to listeners on the RECEIVE side
@@ -308,7 +314,12 @@ class MessageBusClient:
         # and double in the capture firehose.
         self._send(message)
 
-    def _send(self, message: Message):
+    def emit_checked(self, message: Message):
+        """Emit a message and raise websocket send failures to the caller."""
+        self._ensure_session(message)
+        self._send(message, raise_errors=True)
+
+    def _send(self, message: Message, raise_errors: bool = False):
         """Serialize and send a single message over the websocket."""
         if not self.connected_event.wait(10):
             if not self.started_running:
@@ -322,12 +333,17 @@ class MessageBusClient:
             msg = json_dumps(message.__dict__)
         msg = _maybe_encrypt(msg)
         try:
-            self.client.send(msg)
+            with self._send_lock:
+                self.client.send(msg)
         except WebSocketConnectionClosedException:
             LOG.warning(f'Could not send {message.msg_type} message because connection '
                         'has been closed')
+            if raise_errors:
+                raise
         except Exception as e:
             LOG.exception(f"failed to emit message {message.msg_type} with len {len(msg)}")
+            if raise_errors:
+                raise
 
     def collect_responses(self, message: Message,
                           min_timeout: Union[int, float] = 0.2,
@@ -572,14 +588,7 @@ class GUIWebsocketClient(MessageBusClient):
                                  'before emitting messages')
             self.connected_event.wait()
 
-        try:
-            if hasattr(message, 'serialize'):
-                self.client.send(_maybe_encrypt(message.serialize()))
-            else:
-                self.client.send(_maybe_encrypt(json_dumps(message.__dict__)))
-        except WebSocketConnectionClosedException:
-            LOG.warning('Could not send %s message because connection '
-                        'has been closed', message.msg_type)
+        self._send(message)
 
     def on_open(self, *args):
         super().on_open(*args)

--- a/test/unittests/test_client_extra.py
+++ b/test/unittests/test_client_extra.py
@@ -3,7 +3,7 @@ handler/emit/wait helpers and GUIWebsocketClient construction."""
 import json
 import unittest
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock
 
 from websocket import WebSocketConnectionClosedException
 
@@ -50,7 +50,9 @@ class TestHandlerRegistration(TestCase):
         self.assertEqual(len(called), 1)
 
     def test_remove_normal_handler(self):
-        cb = lambda m: None
+        def cb(_message):
+            return None
+
         self.client.on("evt", cb)
         self.client.remove("evt", cb)
         # second remove should not raise
@@ -104,6 +106,49 @@ class TestEmit(TestCase):
 
         with self.assertRaises(WebSocketConnectionClosedException):
             self.client.emit_checked(Message("test.message"))
+
+    def test_concurrent_emit_serializes_websocket_sends(self):
+        from threading import Event, Lock, Thread
+        import time
+
+        start = Event()
+        state_lock = Lock()
+        active_sends = 0
+        max_active_sends = 0
+        sent_types = []
+        errors = []
+
+        def fake_send(raw):
+            nonlocal active_sends, max_active_sends
+            with state_lock:
+                active_sends += 1
+                max_active_sends = max(max_active_sends, active_sends)
+                sent_types.append(json.loads(raw)["type"])
+            time.sleep(0.05)
+            with state_lock:
+                active_sends -= 1
+
+        def emit(name):
+            start.wait(timeout=1)
+            try:
+                self.client.emit(Message(name))
+            except Exception as exc:
+                errors.append(exc)
+
+        self.client.client.send.side_effect = fake_send
+        threads = [
+            Thread(target=emit, args=(f"test.message.{idx}",), daemon=True)
+            for idx in range(2)
+        ]
+        for thread in threads:
+            thread.start()
+        start.set()
+        for thread in threads:
+            thread.join(timeout=1)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(max_active_sends, 1)
+        self.assertCountEqual(sent_types, ["test.message.0", "test.message.1"])
 
 
 class TestWaitForMessage(TestCase):

--- a/test/unittests/test_client_extra.py
+++ b/test/unittests/test_client_extra.py
@@ -259,9 +259,11 @@ class TestLifecycle(TestCase):
     def test_on_close_emits_close_event(self):
         client = MessageBusClient()
         seen = []
+        client.connected_event.set()
         client.emitter.on("close", lambda *_: seen.append(True))
         client.on_close()
         self.assertEqual(seen, [True])
+        self.assertFalse(client.connected_event.is_set())
 
 
 class TestGUIWebsocketClient(TestCase):

--- a/test/unittests/test_client_extra.py
+++ b/test/unittests/test_client_extra.py
@@ -3,9 +3,7 @@ handler/emit/wait helpers and GUIWebsocketClient construction."""
 import json
 import unittest
 from unittest import TestCase
-from unittest.mock import MagicMock
-
-from websocket import WebSocketConnectionClosedException
+from unittest.mock import MagicMock, Mock, patch
 
 from ovos_bus_client.client.client import (GUIWebsocketClient,
                                            MessageBusClient)
@@ -50,9 +48,7 @@ class TestHandlerRegistration(TestCase):
         self.assertEqual(len(called), 1)
 
     def test_remove_normal_handler(self):
-        def cb(_message):
-            return None
-
+        cb = lambda m: None
         self.client.on("evt", cb)
         self.client.remove("evt", cb)
         # second remove should not raise
@@ -83,72 +79,6 @@ class TestEmit(TestCase):
         decoded = json.loads(payload)
         self.assertEqual(decoded["type"], "test.message")
         self.assertEqual(decoded["data"]["utterance"], "hi")
-
-    def test_emit_uses_send_lock(self):
-        class _Lock:
-            entered = False
-
-            def __enter__(self):
-                self.entered = True
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        lock = _Lock()
-        self.client._send_lock = lock
-
-        self.client.emit(Message("test.message"))
-
-        self.assertTrue(lock.entered)
-
-    def test_emit_checked_raises_send_failures(self):
-        self.client.client.send.side_effect = WebSocketConnectionClosedException()
-
-        with self.assertRaises(WebSocketConnectionClosedException):
-            self.client.emit_checked(Message("test.message"))
-
-    def test_concurrent_emit_serializes_websocket_sends(self):
-        from threading import Event, Lock, Thread
-        import time
-
-        start = Event()
-        state_lock = Lock()
-        active_sends = 0
-        max_active_sends = 0
-        sent_types = []
-        errors = []
-
-        def fake_send(raw):
-            nonlocal active_sends, max_active_sends
-            with state_lock:
-                active_sends += 1
-                max_active_sends = max(max_active_sends, active_sends)
-                sent_types.append(json.loads(raw)["type"])
-            time.sleep(0.05)
-            with state_lock:
-                active_sends -= 1
-
-        def emit(name):
-            start.wait(timeout=1)
-            try:
-                self.client.emit(Message(name))
-            except Exception as exc:
-                errors.append(exc)
-
-        self.client.client.send.side_effect = fake_send
-        threads = [
-            Thread(target=emit, args=(f"test.message.{idx}",), daemon=True)
-            for idx in range(2)
-        ]
-        for thread in threads:
-            thread.start()
-        start.set()
-        for thread in threads:
-            thread.join(timeout=1)
-
-        self.assertEqual(errors, [])
-        self.assertEqual(max_active_sends, 1)
-        self.assertCountEqual(sent_types, ["test.message.0", "test.message.1"])
 
 
 class TestWaitForMessage(TestCase):

--- a/test/unittests/test_client_extra.py
+++ b/test/unittests/test_client_extra.py
@@ -5,6 +5,8 @@ import unittest
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
+from websocket import WebSocketConnectionClosedException
+
 from ovos_bus_client.client.client import (GUIWebsocketClient,
                                            MessageBusClient)
 from ovos_bus_client.message import GUIMessage, Message
@@ -79,6 +81,29 @@ class TestEmit(TestCase):
         decoded = json.loads(payload)
         self.assertEqual(decoded["type"], "test.message")
         self.assertEqual(decoded["data"]["utterance"], "hi")
+
+    def test_emit_uses_send_lock(self):
+        class _Lock:
+            entered = False
+
+            def __enter__(self):
+                self.entered = True
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        lock = _Lock()
+        self.client._send_lock = lock
+
+        self.client.emit(Message("test.message"))
+
+        self.assertTrue(lock.entered)
+
+    def test_emit_checked_raises_send_failures(self):
+        self.client.client.send.side_effect = WebSocketConnectionClosedException()
+
+        with self.assertRaises(WebSocketConnectionClosedException):
+            self.client.emit_checked(Message("test.message"))
 
 
 class TestWaitForMessage(TestCase):

--- a/test/unittests/test_client_more.py
+++ b/test/unittests/test_client_more.py
@@ -1,5 +1,6 @@
 """More client.py coverage — on_error variants, on_default_session_update,
 two-arg dispatchers, GUIWebsocketClient on_open / on_message."""
+import json
 import unittest
 from unittest import TestCase
 from unittest.mock import MagicMock, patch

--- a/test/unittests/test_client_more.py
+++ b/test/unittests/test_client_more.py
@@ -29,6 +29,7 @@ class TestOnError(TestCase):
         bus.create_client = MagicMock(return_value=MagicMock())
         bus.run_forever = MagicMock(side_effect=WebSocketException())
         bus.on_error(WebSocketConnectionClosedException())
+        self.assertFalse(bus.connected_event.is_set())
 
     @patch("ovos_bus_client.client.client.time.sleep", MagicMock())
     def test_connection_refused(self):

--- a/test/unittests/test_client_more.py
+++ b/test/unittests/test_client_more.py
@@ -1,6 +1,5 @@
 """More client.py coverage — on_error variants, on_default_session_update,
 two-arg dispatchers, GUIWebsocketClient on_open / on_message."""
-import json
 import unittest
 from unittest import TestCase
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
Clears connected_event when the websocket closes or reports a real connection error, so callers do not keep treating a dead socket as connected.

Reduced after review: no extra send lock, no emit_checked API, no unrelated refactor.

Tested:
- PYTHONPATH=. pytest test/unittests/test_client_extra.py test/unittests/test_client_more.py -q