### PR TITLE
fix: discard malformed frames instead of tearing down the connection

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -22,6 +22,7 @@ from ovos_bus_client.client.collector import MessageCollector
 from ovos_bus_client.client.waiter import MessageWaiter
 from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf, load_gui_message_bus_config
 from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
+                                     MalformedMessage,
                                      encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import SessionManager, Session
 from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
@@ -259,7 +260,16 @@ class MessageBusClient:
             message = args[0]
         else:
             message = args[1]
-        parsed_message = Message.deserialize(_maybe_decrypt(message))
+        try:
+            parsed_message = Message.deserialize(_maybe_decrypt(message))
+        except MalformedMessage as e:
+            # A malformed frame is a per-message fault, not a transport fault:
+            # discard it and keep the connection. Letting it propagate would
+            # reach on_error, which tears the socket down and reconnects — so a
+            # single bad message (e.g. a non-conformant server greeting) would
+            # otherwise trigger an endless reconnect loop.
+            LOG.warning("discarding malformed bus message: %s", e)
+            return
         sess = Session.from_message(parsed_message)
         if sess.session_id != "default": # 'default' can only be updated by core
             SessionManager.update(sess)
@@ -601,5 +611,11 @@ class GUIWebsocketClient(MessageBusClient):
 
         self.emitter.emit('message', message)
 
-        parsed_message = GUIMessage.deserialize(_maybe_decrypt(message))
+        try:
+            parsed_message = GUIMessage.deserialize(_maybe_decrypt(message))
+        except MalformedMessage as e:
+            # Discard a malformed frame instead of letting it tear down the
+            # GUI websocket via on_error (see the core on_message handler).
+            LOG.warning("discarding malformed GUI message: %s", e)
+            return
         self.emitter.emit(parsed_message.msg_type, parsed_message)

--- a/test/unittests/test_client.py
+++ b/test/unittests/test_client.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import call, Mock, patch
+from unittest.mock import ANY, call, Mock, patch
 
 try:
     from pyee import ExecutorEventEmitter
@@ -57,6 +57,25 @@ class TestMessageBusClient(unittest.TestCase):
     def test_on_message(self):
         # TODO
         pass
+
+    def test_on_message_discards_malformed(self):
+        """A malformed frame (e.g. the non-conformant '{"msg_type": ...}'
+        greeting from the pure-Rust bus) must be discarded, not raised —
+        letting it propagate reaches on_error and tears the socket down."""
+        mock_emitter = Mock()
+        mc = MessageBusClient(emitter=mock_emitter)
+        greeting = ('{"msg_type": "connected", "data": {}, '
+                    '"context": {"session": {"session_id": "default"}}}')
+        # must not raise
+        mc.on_message(greeting)
+        # parse failed before any dispatch: no topic was emitted
+        mock_emitter.emit.assert_not_called()
+
+    def test_on_message_dispatches_valid(self):
+        mock_emitter = Mock()
+        mc = MessageBusClient(emitter=mock_emitter)
+        mc.on_message(Message("ovos.test").serialize())
+        mock_emitter.emit.assert_any_call("ovos.test", ANY)
 
     def test_emit(self):
         # TODO
@@ -141,6 +160,17 @@ class TestGuiWebsocketClient(unittest.TestCase):
     def test_on_message(self):
         # TODO
         pass
+
+    def test_on_message_discards_malformed(self):
+        """GUI websocket must also discard a malformed frame rather than
+        letting it tear down the connection via on_error."""
+        mock_emitter = Mock()
+        gc = GUIWebsocketClient(emitter=mock_emitter)
+        gc.on_message('{"not_a_valid": "gui frame"}')  # missing 'type'
+        # the 'message' firehose fires first, but no parsed topic is dispatched
+        # and no exception escapes
+        for c in mock_emitter.emit.call_args_list:
+            self.assertEqual(c.args[0], "message")
 
 
 class TestMessageWaiter:


### PR DESCRIPTION
## Problem

`on_message` (both the core `MessageBusClient` and `GUIWebsocketClient`) called `Message.deserialize` / `GUIMessage.deserialize` **without a guard**. When deserialize raises `MalformedMessage`, websocket-client routes the exception to `on_error`, which — since it isn't a connection closed/refused/reset error — treats it as a fatal transport fault: it **closes the socket and reconnects** with exponential backoff.

Result: a single malformed frame drives an endless teardown/reconnect loop. Reported downstream at OpenVoiceOS/ovos-dinkum-listener#240, triggered by the non-conformant `{"msg_type": "connected", ...}` greeting from the external pure-Rust bus (OscillateLabsLLC/ovos-rust-messagebus, upstream issue #33).

## Fix

Catch `MalformedMessage` at parse time in both `on_message` handlers, log a warning, and **discard the frame**. A malformed message is a per-message fault, not a transport fault — it must not affect the connection.

The reference deserializer stays strict (OVOS-MSG-1 §2/§7 — rejecting non-conformant input is correct). Resilience against bad frames belongs at the transport edge, which is this client. This covers *all* malformed input (truncated JSON, wrong types, unknown keys), not just the one greeting.

## Tests

- `test_on_message_discards_malformed` (core) — the `msg_type` greeting is discarded, no exception, no topic dispatched.
- `test_on_message_dispatches_valid` (core) — a valid message still dispatches its topic.
- `test_on_message_discards_malformed` (GUI) — malformed GUI frame discarded, connection untouched.
- Full client suite: 68 passed.

## Related

- Supersedes the narrower spec-tools fold (ovos-spec-tools#83, closed) — the spec reference impl stays strict; the client absorbs bad frames.
- Root cause filed/patched upstream: OscillateLabsLLC/ovos-rust-messagebus#33.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed WebSocket messages are now safely discarded instead of causing errors or connection interruptions.
  * Valid messages continue to be routed and processed normally.
  * Improved handling of malformed GUI WebSocket messages to preserve active connections.
* **Configuration**
  * Added support for configurable WebSocket encryption and unencrypted connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->