### PR TITLE
fix: survive a malformed session on an inbound message

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -24,7 +24,7 @@ from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf, 
 from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      MalformedMessage,
                                      encrypt_as_dict, decrypt_from_dict)
-from ovos_bus_client.session import SessionManager, Session
+from ovos_bus_client.session import SessionManager, Session, MalformedSession
 from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
 
 # --- Layer-2 encryption at the transport edge (deprecated) -----------------
@@ -270,7 +270,15 @@ class MessageBusClient:
             # otherwise trigger an endless reconnect loop.
             LOG.warning("discarding malformed bus message: %s", e)
             return
-        sess = Session.from_message(parsed_message)
+        try:
+            sess = Session.from_message(parsed_message)
+        except MalformedSession as e:
+            # A non-object session carrier is a per-message producer fault, not a
+            # transport fault (SESSION-1 §2.5): drop this one message and keep the
+            # connection. Letting it propagate would reach on_error and reconnect,
+            # so a single bad producer could hold the client in a reconnect loop.
+            LOG.warning("discarding bus message with malformed session: %s", e)
+            return
         if sess.session_id != "default": # 'default' can only be updated by core
             SessionManager.update(sess)
         self.emitter.emit('message', message)

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -13,6 +13,7 @@ from ovos_spec_tools.session import (Session as _SpecSession,
                                      SessionManager as _SpecSessionManager,
                                      DEFAULT_CONVERSE_HANDLERS_CAP,
                                      DEFAULT_SESSION_ID,
+                                     MalformedSession,
                                      SESSION1_REGISTERED_FIELDS)
 from ovos_bus_client.message import dig_for_message, Message
 from ovos_bus_client.version import VERSION_MAJOR
@@ -1268,31 +1269,38 @@ class Session(_SpecSession):
     @staticmethod
     def from_message(message: Message = None):
         """
-        Get a Session for the given message. If no session in message context,
-        SessionManager.default_session is returned.
-        If SessionManager.default_session is None, a default session is created
+        Get a Session for the given message.
+
+        An absent session (no ``session`` key, or an explicit ``null``) resolves
+        to the default session (SESSION-1 §2.1). A present-but-malformed session
+        carrier — anything that is not a JSON object — is a producer error: it is
+        rejected with :class:`MalformedSession` rather than silently defaulted, so
+        the consumer never processes a message under a fabricated session
+        identity (SESSION-1 §2.5). Callers on the inbound path drop the offending
+        message on this error instead of tearing down the connection.
+
         @param message: Message to get session for
         @return: Session object
+        @raises MalformedSession: the message carries a non-object session
         """
         message = message or dig_for_message()
-        if message and "session" in message.context:
-            lang = message.context.get("lang") or \
-                   message.data.get("lang")
-            sess = message.context["session"]
-            if lang and "lang" not in sess:
-                sess["lang"] = lang
-            sess = Session.deserialize(sess)
+        session = message.context.get("session") if message else None
+        if session is not None:
+            lang = message.context.get("lang") or message.data.get("lang")
+            # deserialize rejects a non-dict carrier with MalformedSession; only
+            # fold the context lang onto a well-formed (dict) carrier first.
+            if isinstance(session, dict) and lang and "lang" not in session:
+                session["lang"] = lang
+            return Session.deserialize(session)
+        if message:
+            LOG.warning(f"No session context in message:{message.msg_type}")
+            LOG.debug(f"Update ovos-bus-client or add `session` to "
+                      f"`message.context` where emitted. "
+                      f"context={message.context}")
         else:
-            if message:
-                LOG.warning(f"No session context in message:{message.msg_type}")
-                LOG.debug(f"Update ovos-bus-client or add `session` to "
-                          f"`message.context` where emitted. "
-                          f"context={message.context}")
-            else:
-                LOG.warning(f"No message found, using default session")
-            # no session on the message -> the default session
-            sess = SessionManager.get_default_session()
-        return sess
+            LOG.warning(f"No message found, using default session")
+        # no session on the message -> the default session
+        return SessionManager.get_default_session()
 
 
 class _BusSessionManagerMixin:

--- a/test/unittests/test_client.py
+++ b/test/unittests/test_client.py
@@ -71,6 +71,21 @@ class TestMessageBusClient(unittest.TestCase):
         # parse failed before any dispatch: no topic was emitted
         mock_emitter.emit.assert_not_called()
 
+    def test_on_message_discards_malformed_session(self):
+        """A well-formed frame carrying a non-object session (SESSION-1 §2.5)
+        must be dropped like a malformed frame — never raised. The raise would
+        reach on_error on the handler thread and tear the socket into a
+        reconnect loop, so one bad producer could hold the client offline."""
+        mock_emitter = Mock()
+        mc = MessageBusClient(emitter=mock_emitter)
+        bad = ('{"type": "ovos.test", "data": {}, '
+               '"context": {"session": "oops"}}')
+        # must not raise
+        mc.on_message(bad)
+        # rejected before dispatch: the topic was never emitted
+        for call in mock_emitter.emit.call_args_list:
+            self.assertNotEqual(call.args and call.args[0], "ovos.test")
+
     def test_on_message_dispatches_valid(self):
         mock_emitter = Mock()
         mc = MessageBusClient(emitter=mock_emitter)

--- a/test/unittests/test_session.py
+++ b/test/unittests/test_session.py
@@ -194,8 +194,46 @@ class TestSession(unittest.TestCase):
         self.assertIsInstance(serialized['context'], dict)
 
     def test_from_message(self):
-        # TODO
-        pass
+        from ovos_bus_client.session import (Session, SessionManager,
+                                             MalformedSession)
+        from ovos_bus_client.message import Message
+
+        # a well-formed session deserializes identically to a direct call
+        well_formed = Session("sid-wf", lang="pt-PT")
+        msg = Message("test", context={"session": well_formed.serialize()})
+        got = Session.from_message(msg)
+        self.assertIsInstance(got, Session)
+        self.assertEqual(got.session_id, "sid-wf")
+        self.assertEqual(got.lang, "pt-PT")
+
+        # SESSION-1 §2.5: a present-but-malformed (non-object) session carrier is
+        # a producer error — rejected with MalformedSession, never silently
+        # defaulted. The inbound handler catches this to drop the one message; it
+        # is a ValueError, so it never escapes as an unhandled TypeError that
+        # would tear the connection down.
+        for bad in ("oops", 42, ["a", "b"]):
+            msg = Message("test", context={"session": bad})
+            with self.assertRaises(MalformedSession):
+                Session.from_message(msg)
+
+        # an explicit null carrier is absence, not malformation (§2.1) -> default
+        msg = Message("test", context={"session": None})
+        got = Session.from_message(msg)
+        self.assertIsInstance(got, Session)
+        self.assertEqual(got.session_id,
+                         SessionManager.get_default_session().session_id)
+
+        # a dict missing every field is well-formed (all fields omissible):
+        # it deserializes without raising, the consumer filling its own
+        # deployment defaults (§2.1)
+        msg = Message("test", context={"session": {}})
+        got = Session.from_message(msg)
+        self.assertIsInstance(got, Session)
+        self.assertTrue(got.session_id)
+
+        # no session key at all -> default session
+        got = Session.from_message(Message("test", context={}))
+        self.assertIsInstance(got, Session)
 
 
 class TestSessionManager(unittest.TestCase):


### PR DESCRIPTION
## Problem

A non-object `session` in `message.context` (a string, number, array, ...) made `Session.from_message` raise: `sess["lang"] = lang` fails with `TypeError: 'str' object does not support item assignment`, and a non-dict passed to `Session.deserialize` raises `MalformedSession`.

That call runs on the inbound websocket handler thread (`client.on_message`), **outside** the client's malformed-frame guard. The raise propagates to `on_error`, which tears the socket down and reconnects. So any component emitting a malformed session — protocol drift, a buggy plugin, a misbehaving remote/HiveMind client — can knock a receiving client offline into an endless 5s reconnect loop.

## Fix

Per **OVOS-SESSION-1 §2.5** (a malformed session *carrier* is a per-message producer fault, not a transport fault): `from_message` now rejects a non-object carrier with a clean `MalformedSession` (never a raw `TypeError`), and `on_message` drops that one message with a WARNING — the same per-message-fault handling the malformed-frame guard already applies one line up. The connection survives and keeps serving other messages.

A malformed carrier is **not** silently defaulted: fabricating a session identity for a broken carrier would route the message into the wrong session, which is worse than dropping it. An absent or explicit-`null` session still resolves to the default session, and a well-formed session deserializes identically.

Companion spec change adding SESSION-1 §2.5: OpenVoiceOS/architecture (linked separately).

## Live evidence

Real messagebus + real client, malformed session injected on the raw wire, then a well-formed message:

- **before:** `TypeError` at `session.py:551` on the handler thread → `Message Bus Client will reconnect in 5.0 seconds`; neither message processed.
- **after:** one WARNING (`discarding bus message with malformed session: session must be a JSON object`); client stays connected (0 reconnect events); the following well-formed message is still processed.

## Tests

- `test_from_message`: a string / int / list carrier each raises `MalformedSession`; an explicit `null` and an absent key resolve to the default session; `{}` and a well-formed session deserialize identically.
- `test_on_message_discards_malformed_session`: `on_message` on a frame with `session: "oops"` does not raise and never dispatches the topic.

Fail-before/pass-after proven.