### PR TITLE
fix: seed blacklisted_pipelines deployment default from config

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -620,6 +620,7 @@ class Session(_SpecSession):
                  is_recording: bool = False,
                  blacklisted_intents: Optional[List[str]] = None,
                  blacklisted_skills: Optional[List[str]] = None,
+                 blacklisted_pipelines: Optional[List[str]] = None,
                  persona_id: Optional[str] = None,
                  fallback_handlers: Optional[List[str]] = None,
                  **canonical_kwargs):
@@ -657,13 +658,14 @@ class Session(_SpecSession):
             is_recording (bool): Initial recording state flag.
             blacklisted_intents (Optional[List[str]]): Intents to ignore for this session.
             blacklisted_skills (Optional[List[str]]): Skills to ignore for this session.
+            blacklisted_pipelines (Optional[List[str]]): Pipeline stages to ignore for this session.
             persona_id (Optional[str]): Optional persona identifier associated with this session.
             fallback_handlers (Optional[List[str]]): OVOS-FALLBACK-1 §4 registered session field —
                 ordered skill-id strings. Inherited canonical field; forwarded to the parent.
             **canonical_kwargs: Every remaining canonical ``ovos_spec_tools.Session``
                 SESSION-1 field — ``secondary_langs``, ``output_lang``, ``stt_lang``,
                 ``request_lang``, ``detected_lang``, ``intent_context``,
-                ``blacklisted_pipelines``, the six ``*_transformers`` lists, the six
+                the six ``*_transformers`` lists, the six
                 ``blacklisted_*_transformers`` lists, and ``extras`` — is accepted here
                 and forwarded verbatim to the parent so the full registered field set
                 round-trips. Unknown keys raise (the parent ``__init__`` rejects them),
@@ -680,6 +682,8 @@ class Session(_SpecSession):
                               Configuration().get("skills", {}).get("blacklisted_skills", []))
         blacklisted_intents = (blacklisted_intents or
                                Configuration().get("intents", {}).get("blacklisted_intents", []))
+        blacklisted_pipelines = (blacklisted_pipelines or
+                                 Configuration().get("intents", {}).get("blacklisted_pipelines", []))
         lang = standardize_lang(lang or get_default_lang())
         # OVOS-BRIDGE-1 §3.3: site_id is the opaque group identifier. A deployer
         # MAY configure one (the bridge's own determination, step 1), but an
@@ -729,6 +733,7 @@ class Session(_SpecSession):
                          pipeline=pipeline,
                          blacklisted_skills=blacklisted_skills,
                          blacklisted_intents=blacklisted_intents,
+                         blacklisted_pipelines=blacklisted_pipelines,
                          active_handlers=active_handlers,
                          converse_handlers=converse_handlers,
                          response_mode=response_mode,

--- a/test/unittests/test_session_config_defaults.py
+++ b/test/unittests/test_session_config_defaults.py
@@ -21,9 +21,11 @@ import ovos_bus_client.session as session_module
 from ovos_bus_client.session import Session
 
 _CUSTOM_PIPELINE = ["adapt_high", "fallback_low"]
+_CUSTOM_BLACKLISTED_PIPELINES = ["adapt_low"]
 _CONFIG = {
     "lang": "en-us",
-    "intents": {"pipeline": list(_CUSTOM_PIPELINE)},
+    "intents": {"pipeline": list(_CUSTOM_PIPELINE),
+                "blacklisted_pipelines": list(_CUSTOM_BLACKLISTED_PIPELINES)},
 }
 
 
@@ -57,6 +59,23 @@ class TestConfigBackedDefaultsOnDeserialize(unittest.TestCase):
         # empty deployment default: no config-backed value to substitute.
         sess = self._deserialize({"session_id": "abc"})
         self.assertEqual(sess.blacklisted_intents, [])
+
+    def test_omitted_blacklisted_pipelines_resolves_to_configured_default(self):
+        # OVOS-SESSION-1 §2.1 / OVOS-PIPELINE-1 §5.2: deployment default for
+        # blacklisted_pipelines is seeded from config, same as
+        # blacklisted_skills / blacklisted_intents, NOT hardcoded to [].
+        sess = self._deserialize({"session_id": "abc"})
+        self.assertEqual(sess.blacklisted_pipelines, _CUSTOM_BLACKLISTED_PIPELINES)
+
+    def test_explicit_blacklisted_pipelines_kwarg_wins_over_config(self):
+        with patch.object(session_module, "Configuration", return_value=_CONFIG):
+            sess = Session(blacklisted_pipelines=["stop_high"])
+        self.assertEqual(sess.blacklisted_pipelines, ["stop_high"])
+
+    def test_blacklisted_pipelines_defaults_to_empty_list_absent_config(self):
+        with patch.object(session_module, "Configuration", return_value={}):
+            sess = Session()
+        self.assertEqual(sess.blacklisted_pipelines, [])
 
     def test_omitted_transformer_lists_fold_to_empty_list(self):
         # the six active *_transformers are override lists whose empty value


### PR DESCRIPTION
## Summary

`Session.__init__` already seeds two deployment-default fields from
`ovos-config` when the caller omits them:

- `blacklisted_skills` ← `skills.blacklisted_skills`
- `blacklisted_intents` ← `intents.blacklisted_intents`

`blacklisted_pipelines` was missing this treatment and always resolved
to `[]`, regardless of deployment config. Per **OVOS-SESSION-1 §2.1**,
a consumer that sees an omitted session field MUST substitute its own
deployment default at the point of consumption — an empty list is not
a valid substitute for a configured value. **OVOS-PIPELINE-1 §5.2**
defines the runtime semantics of `blacklisted_pipelines` (which
pipeline stages a session ignores).

This PR adds the same seeding pattern used for `blacklisted_skills` /
`blacklisted_intents`: `blacklisted_pipelines` now defaults to
`intents.blacklisted_pipelines` from config, and an explicit kwarg
still wins. This is the same config key that ovos-core PR #832 uses
for its load-time counterpart, so the two stay in sync.

## Changes

- `ovos_bus_client/session.py`: `blacklisted_pipelines` becomes an
  explicit constructor kwarg, seeded from
  `Configuration().get("intents", {}).get("blacklisted_pipelines", [])`
  when omitted, and forwarded explicitly to the canonical parent
  (mirrors the `blacklisted_skills` / `blacklisted_intents` blocks).
- `test/unittests/test_session_config_defaults.py`: adds coverage for
  config-seeded, explicit-kwarg-wins, and absent-config-defaults-to-[]
  cases, matching the existing `pipeline` / `blacklisted_intents`
  tests in this file.

## Test plan

- [x] New tests fail before the fix (confirmed via `git stash`), pass after.
- [x] `pytest test/unittests/test_session_config_defaults.py` — 9 passed
- [x] `pytest test/unittests/test_session_*.py` — 162 passed
- [x] Full unit suite: `pytest test/unittests/` — 732 passed

## Model usage

Implemented by Claude (sonnet), orchestrated by Claude Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring pipelines that should be excluded from session processing.
  * Session settings now use the deployment default when no explicit pipeline exclusions are provided.

* **Bug Fixes**
  * Added fallback handling when pipeline exclusion settings are absent.
  * Explicit session configuration now correctly takes precedence over deployment defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->