### PR TITLE
fix: bus CLIs hang forever when the messagebus is unreachable

### DIFF
--- a/ovos_bus_client/scripts.py
+++ b/ovos_bus_client/scripts.py
@@ -6,8 +6,50 @@ from ovos_config import Configuration
 import sys
 import time
 
+#: Seconds to wait for the messagebus before giving up. These are one-shot
+#: command line tools, so a device with no bus running has to fail fast and
+#: say why, instead of blocking forever on a blank terminal.
+CONNECT_TIMEOUT = 10
+
+
+def _help_requested():
+    return any(arg in ("-h", "--help") for arg in sys.argv[1:])
+
+
+def _print_help(description, usage):
+    print(f"{description}\n\nUSAGE: {usage}")
+    raise SystemExit(0)
+
+
+def _connect(usage):
+    """Return a connected MessageBusClient, or exit with a message.
+
+    `usage` is echoed on failure, so the user learns what the command does as
+    well as why it did not run.
+    """
+    client = MessageBusClient()
+    client.run_in_thread()
+    if not client.connected_event.is_set():
+        client.connected_event.wait(CONNECT_TIMEOUT)
+    if not client.connected_event.is_set():
+        cfg = Configuration().get("websocket", {})
+        host = cfg.get("host", "0.0.0.0")
+        port = cfg.get("port", 8181)
+        print(f"ERROR: could not reach the messagebus at ws://{host}:{port} "
+              f"after {CONNECT_TIMEOUT} seconds.\n"
+              f"Is it running? Check with: "
+              f"systemctl --user status ovos-messagebus.service\n\n"
+              f"USAGE: {usage}", file=sys.stderr)
+        client.close()
+        raise SystemExit(1)
+    return client
+
 
 def ovos_speak():
+    usage = "ovos-speak {utterance} [lang]"
+    if _help_requested():
+        _print_help("Speak an utterance out loud, via the OVOS TTS service.",
+                    usage)
     args_count = len(sys.argv)
     if args_count == 2:
         utt = sys.argv[1]
@@ -16,18 +58,19 @@ def ovos_speak():
         utt = sys.argv[1]
         lang = sys.argv[2]
     else:
-        print("USAGE: ovos-speak {utterance} [lang]")
+        print(f"USAGE: {usage}")
         raise SystemExit(2)
-    client = MessageBusClient()
-    client.run_in_thread()
-    if not client.connected_event.is_set():
-        client.connected_event.wait()
+    client = _connect(usage)
     client.emit(Message("speak", {"utterance": utt, "lang": lang}))
     time.sleep(0.5)  # avoids crash in c++ bus server
     client.close()
 
 
 def ovos_say_to():
+    usage = "ovos-say-to {utterance} [lang]"
+    if _help_requested():
+        _print_help("Inject an utterance as if the user had spoken it, "
+                    "skipping the microphone and STT.", usage)
     args_count = len(sys.argv)
     if args_count == 2:
         utt = sys.argv[1]
@@ -36,41 +79,40 @@ def ovos_say_to():
         utt = sys.argv[1]
         lang = sys.argv[2]
     else:
-        print("USAGE: ovos-say-to {utterance} [lang]")
+        print(f"USAGE: {usage}")
         raise SystemExit(2)
-    client = MessageBusClient()
-    client.run_in_thread()
-    if not client.connected_event.is_set():
-        client.connected_event.wait()
+    client = _connect(usage)
     client.emit(Message("recognizer_loop:utterance", {"utterances": [utt], "lang": lang}))
     time.sleep(0.5)  # avoids crash in c++ bus server
     client.close()
 
 
 def ovos_listen():
-    client = MessageBusClient()
-    client.run_in_thread()
-    if not client.connected_event.is_set():
-        client.connected_event.wait()
+    usage = "ovos-listen"
+    if _help_requested():
+        _print_help("Trigger the listener, as if the wake word had been "
+                    "spoken.", usage)
+    client = _connect(usage)
     client.emit(Message("mycroft.mic.listen"))
     time.sleep(0.5)  # avoids crash in c++ bus server
     client.close()
 
 
 def simple_cli():
+    usage = "ovos-simple-cli [lang]"
+    if _help_requested():
+        _print_help("Talk to the assistant from the terminal. Type ':exit' "
+                    "to quit.", usage)
     args_count = len(sys.argv)
     if args_count == 1:
         lang = Configuration().get("lang", "en-us")
     elif args_count == 2:
         lang = sys.argv[1]
     else:
-        print("USAGE: ovos-simple-cli [lang]")
+        print(f"USAGE: {usage}")
         return
 
-    client = MessageBusClient()
-    client.run_in_thread()
-    if not client.connected_event.is_set():
-        client.connected_event.wait()
+    client = _connect(usage)
     lang = lang or Configuration().get("lang", "en-us")
 
     from ovos_bus_client.session import SessionManager, Session

--- a/test/unittests/test_scripts.py
+++ b/test/unittests/test_scripts.py
@@ -1,15 +1,106 @@
+"""The console scripts must not hang when the messagebus is unreachable.
+
+These are one-shot troubleshooting commands. `ovos-listen` in particular is
+the first thing the technical manual tells a user to run when the assistant
+stops responding, so blocking forever on a blank terminal is the worst
+available failure mode: it looks exactly like a command that is working.
+"""
+import sys
 import unittest
+from unittest import mock
+
+from ovos_bus_client import scripts
+
+SCRIPTS = [
+    ("ovos-listen", scripts.ovos_listen, ["ovos-listen"]),
+    ("ovos-speak", scripts.ovos_speak, ["ovos-speak", "hello"]),
+    ("ovos-say-to", scripts.ovos_say_to, ["ovos-say-to", "hello"]),
+    ("ovos-simple-cli", scripts.simple_cli, ["ovos-simple-cli"]),
+]
+
+
+class _NeverConnects:
+    """A client whose connected_event is never set."""
+
+    def __init__(self, *args, **kwargs):
+        self.connected_event = mock.Mock()
+        self.connected_event.is_set.return_value = False
+        self.closed = False
+
+    def run_in_thread(self):
+        pass
+
+    def close(self):
+        self.closed = True
 
 
 class TestScripts(unittest.TestCase):
-    def test_ovos_speak(self):
-        from ovos_bus_client.scripts import ovos_speak
-        # TODO
+    def test_scripts_exit_when_bus_unreachable(self):
+        for name, func, argv in SCRIPTS:
+            with self.subTest(script=name):
+                client = _NeverConnects()
+                with mock.patch.object(scripts, "MessageBusClient",
+                                       return_value=client), \
+                        mock.patch.object(sys, "argv", argv):
+                    with self.assertRaises(SystemExit) as ctx:
+                        func()
+                self.assertEqual(ctx.exception.code, 1)
+                # the wait has to be bounded, not open ended
+                client.connected_event.wait.assert_called_once_with(
+                    scripts.CONNECT_TIMEOUT)
+                self.assertTrue(client.closed,
+                                "client must be closed before exiting")
 
-    def test_ovos_say_to(self):
-        from ovos_bus_client.scripts import ovos_say_to
-        # TODO
+    def test_connect_timeout_is_bounded(self):
+        self.assertIsInstance(scripts.CONNECT_TIMEOUT, (int, float))
+        self.assertGreater(scripts.CONNECT_TIMEOUT, 0)
 
-    def test_ovos_listen(self):
-        from ovos_bus_client.scripts import ovos_listen
-        # TODO
+    def test_help_never_touches_the_bus(self):
+        # `ovos-speak --help` used to treat "--help" as the utterance, so on a
+        # device with a reachable bus it said "--help" out loud.
+        for name, func, _ in SCRIPTS:
+            for flag in ("-h", "--help"):
+                with self.subTest(script=name, flag=flag):
+                    with mock.patch.object(scripts, "MessageBusClient") as bus, \
+                            mock.patch.object(sys, "argv", [name, flag]):
+                        with self.assertRaises(SystemExit) as ctx:
+                            func()
+                    self.assertEqual(ctx.exception.code, 0)
+                    bus.assert_not_called()
+
+    def test_scripts_emit_expected_message(self):
+        expected = {
+            "ovos-listen": "mycroft.mic.listen",
+            "ovos-speak": "speak",
+            "ovos-say-to": "recognizer_loop:utterance",
+        }
+        for name, func, argv in SCRIPTS:
+            if name not in expected:
+                continue
+            with self.subTest(script=name):
+                client = mock.Mock()
+                client.connected_event.is_set.return_value = True
+                with mock.patch.object(scripts, "MessageBusClient",
+                                       return_value=client), \
+                        mock.patch.object(sys, "argv", argv), \
+                        mock.patch.object(scripts.time, "sleep"):
+                    func()
+                client.emit.assert_called_once()
+                message = client.emit.call_args[0][0]
+                self.assertEqual(message.msg_type, expected[name])
+                client.close.assert_called_once()
+
+    def test_bad_usage_exits_two(self):
+        for name, func, _ in [s for s in SCRIPTS if s[0] != "ovos-listen"]:
+            with self.subTest(script=name):
+                argv = [name, "too", "many", "args"]
+                with mock.patch.object(scripts, "MessageBusClient") as bus, \
+                        mock.patch.object(sys, "argv", argv):
+                    if name == "ovos-simple-cli":
+                        # returns rather than raising, by long-standing habit
+                        func()
+                    else:
+                        with self.assertRaises(SystemExit) as ctx:
+                            func()
+                        self.assertEqual(ctx.exception.code, 2)
+                    bus.assert_not_called()


### PR DESCRIPTION
## The bug

`ovos-listen`, `ovos-speak`, `ovos-say-to` and `ovos-simple-cli` all do:

```python
if not client.connected_event.is_set():
    client.connected_event.wait()   # no timeout
```

With no messagebus running, that blocks **forever** and prints nothing. The
terminal just sits there, which is indistinguishable from a command that is
working normally.

This matters most for `ovos-listen`, because the technical manual gives it as
the *first* step when the assistant stops responding. The user runs the
diagnostic, and the diagnostic hangs.

Reproduced on `dev`, with no bus running:

```bash
$ timeout 12 ovos-listen ; echo "exit=$?"
exit=124        # still going, no output at all
```

## Second bug, same file

These scripts read the first positional argument as the utterance, so the
conventional help flag is taken as content:

- `ovos-speak --help` makes the device **say "--help" out loud**
- `ovos-say-to --help` injects it as a user utterance

`docs/cli-tools.md` in the technical manual tells readers "run any of them with
`--help`", which is how this surfaced.

## The fix

- Wait at most `CONNECT_TIMEOUT` (10s), then print the bus address that was
  tried, how to check the service, and the usage line, and exit `1`.
- Handle `-h`/`--help` before any bus connection is attempted.

After:

```bash
$ ovos-listen
ERROR: could not reach the messagebus at ws://127.0.0.1:8181 after 10 seconds.
Is it running? Check with: systemctl --user status ovos-messagebus.service

USAGE: ovos-listen
$ echo $?
1
```

## Tests

`test/unittests/test_scripts.py` was three empty stubs with `# TODO` bodies. It
now covers, for all four scripts:

- exit 1 rather than blocking, with the wait asserted to be bounded
- `-h`/`--help` exits 0 and never constructs a `MessageBusClient`
- the message type each script emits
- the usage exit code

Three of these fail on `dev` and pass here. Full suite: 734 passed.

## How this surfaced

Found while auditing the ovos-technical-manual troubleshooting pages against
the real CLIs: the manual documents an error message for the unreachable-bus
case that the code never prints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-h`/`--help` options and usage guidance to command-line utilities.
  * Added clearer connection failure messages, including the configured endpoint and troubleshooting guidance.
  * Added bounded connection handling to prevent commands from waiting indefinitely.

* **Bug Fixes**
  * Commands now cleanly close connections and return appropriate exit statuses for failures and invalid arguments.
  * Help and invalid-usage requests no longer attempt to connect to the message bus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->