### PR TITLE
fix: snapshot namespace counterparts before dispatch

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -533,24 +533,36 @@ class MessageBusClient:
         # to the suffixed spelling is only ever served from this frame, RULE
         # 2 does not translate canonical -> suffixed) -- only the firehose
         # double-count is what this gate closes.
+        # namespace migration bridge: also dispatch the counterpart topic(s) to
+        # LOCAL listeners so a handler on either namespace receives the event
+        # (consumers dedupe via the on() mirror-guard). This is a listener-delivery
+        # convenience, not a second logical bus message: the counterpart is NOT put
+        # back on the wire and does NOT re-fire the 'message' firehose, so one
+        # logical emit yields exactly one captured message. The mirrored payload is
+        # reshaped into the counterpart topic's shape (identity for payload-compatible
+        # renames, a per-topic transform for shape-changing ones).
+        #
+        # Every counterpart is built BEFORE ``parsed_message`` is dispatched. The
+        # default ExecutorEventEmitter runs handlers concurrently and handlers may
+        # mutate Message data/context, so deep-copying the original context inside
+        # ``Message.forward`` after dispatch can race a handler and raise
+        # ``RuntimeError: dictionary changed size during iteration``, which
+        # websocket-client then treats as a transport failure.
+        counterparts = []
+        if not is_namespace_twin:
+            for topic in self._translator.counterpart_topics(parsed_message.msg_type):
+                translated = self._translator.translate_payload(
+                    from_topic=parsed_message.msg_type, to_topic=topic,
+                    data=parsed_message.data)
+                counterparts.append((topic, parsed_message.forward(topic, translated)))
+
         try:
             if not is_namespace_twin and not is_intent_twin:
                 self.emitter.emit('message', message)
             if not is_namespace_twin:
                 self.emitter.emit(parsed_message.msg_type, parsed_message)
-                # namespace migration bridge: also dispatch the counterpart topic(s) to
-                # LOCAL listeners so a handler on either namespace receives the event
-                # (consumers dedupe via the on() mirror-guard). This is a listener-delivery
-                # convenience, not a second logical bus message: the counterpart is NOT put
-                # back on the wire and does NOT re-fire the 'message' firehose, so one
-                # logical emit yields exactly one captured message. The mirrored payload is
-                # reshaped into the counterpart topic's shape (identity for payload-compatible
-                # renames, a per-topic transform for shape-changing ones).
-                for topic in self._translator.counterpart_topics(parsed_message.msg_type):
-                    translated = self._translator.translate_payload(
-                        from_topic=parsed_message.msg_type, to_topic=topic,
-                        data=parsed_message.data)
-                    self.emitter.emit(topic, parsed_message.forward(topic, translated))
+                for topic, counterpart in counterparts:
+                    self.emitter.emit(topic, counterpart)
             # else: a marked namespace twin is a REAL second wire frame that only
             # exists to reach an old pre-spec-tools client with no translator of
             # its own. A modern receiver already got both spellings delivered

--- a/test/unittests/test_namespace_migration.py
+++ b/test/unittests/test_namespace_migration.py
@@ -145,6 +145,31 @@ class TestReceiveSideBridge(unittest.TestCase):
         c.on_message(Message("ovos.utterance.speak", {"utterance": "hi"}).serialize())
         c.client.send.assert_not_called()
 
+    def test_counterpart_snapshots_context_before_handler_dispatch(self):
+        """Async handlers cannot race counterpart context construction."""
+        c = _recv_client()
+        counterpart_seen = []
+
+        def mutate_original(message):
+            message.context["request_id"] = "handler-mutated"
+
+        c.emitter.on("speak", mutate_original)
+        c.emitter.on(
+            "ovos.utterance.speak",
+            lambda message: counterpart_seen.append(message),
+        )
+        c.on_message(Message(
+            "speak",
+            {"utterance": "hi"},
+            {"request_id": "wire-value"},
+        ).serialize())
+
+        self.assertEqual(len(counterpart_seen), 1)
+        self.assertEqual(
+            counterpart_seen[0].context["request_id"],
+            "wire-value",
+        )
+
 
 class TestReceiveSidePayloadTranslation(unittest.TestCase):
     """The locally-dispatched counterpart carries the counterpart topic's PAYLOAD


### PR DESCRIPTION
## What changed

- construct receive-side namespace counterpart messages before dispatching the original parsed message to handlers
- retain one wire frame and one `message` firehose event
- add a regression test proving handler mutation cannot alter counterpart context
- remove one unused exception binding in the touched client module so its Ruff check remains clean

## Root cause

`MessageBusClient` uses `ExecutorEventEmitter` by default. The receive path emitted the parsed message before calling `Message.forward()` for namespace counterparts. An asynchronous handler could mutate the original context while `forward()` deep-copied it, raising `RuntimeError: dictionary changed size during iteration`. `websocket-client` then treated that application race as a transport error and reconnected, losing in-flight replies.

Building the counterparts first gives all topics the same wire-time snapshot and removes the cross-thread copy race without changing public routing semantics.

## Validation

- `python -m pytest -q`: 735 passed, 85 subtests passed
- `python -m pytest -q test/unittests/test_namespace_migration.py`: 23 passed
- `ruff check ovos_bus_client/client/client.py test/unittests/test_namespace_migration.py`: passed

Repository-wide Ruff still reports pre-existing findings outside the two changed files; no lint or CI configuration was changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message compatibility between canonical and legacy namespaces.
  * Ensured translated counterpart messages are prepared before handlers run, preserving consistent message context.
  * Canonical messages now emit their legacy counterparts, while legacy messages continue to emit only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->