### PR TITLE
feat: trace correlated speech emission

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -213,3 +213,13 @@ worked example of a subclass that overrides `emit`, `on_open`, and
 If you find yourself reaching for deeper hooks, ask whether a transport plugin
 is what you actually want — that is what `hivemind-ovos-agent-plugin` and the
 GUI client are doing structurally.
+
+## Request-correlated performance tracing
+
+Set `OVOS_PERFORMANCE_TRACE=true` to emit structured `performance_trace`
+records for client-visible speech at the shared message-bus emission boundary.
+Each record contains a bounded explicit request ID, a wall-clock nanosecond
+timestamp, and the fixed stage name `skill_reply_emit`. Request IDs are written
+only to diagnostic logs and must never be used as Prometheus labels. Tracing is
+disabled by default; when disabled, ordinary bus emissions do not inspect the
+message for an ID.

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -24,6 +24,7 @@ from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf, 
 from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      MalformedMessage,
                                      encrypt_as_dict, decrypt_from_dict)
+from ovos_bus_client.performance import trace_skill_reply_emission
 from ovos_bus_client.session import SessionManager, Session, MalformedSession
 from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
 
@@ -326,6 +327,7 @@ class MessageBusClient:
         # (see on_message) in every process, so both namespaces are delivered
         # without a second wire copy that the broadcast server would echo back
         # and double in the capture firehose.
+        trace_skill_reply_emission(message)
         self._send(message)
 
     def _send(self, message: Message):

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -348,7 +348,7 @@ class MessageBusClient:
         except WebSocketConnectionClosedException:
             LOG.warning(f'Could not send {message.msg_type} message because connection '
                         'has been closed')
-        except Exception as e:
+        except Exception:
             LOG.exception(f"failed to emit message {message.msg_type} with len {len(msg)}")
 
     def collect_responses(self, message: Message,

--- a/ovos_bus_client/performance.py
+++ b/ovos_bus_client/performance.py
@@ -1,0 +1,100 @@
+"""Opt-in request-correlated performance trace events.
+
+Request identifiers are deliberately emitted to structured logs rather than
+Prometheus labels. This keeps metrics fixed-cardinality while diagnostic tools
+can join timestamps across processes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections import deque
+from typing import Any
+
+from ovos_utils.log import LOG
+
+_LOG = LOG.create_logger("ovos.performance.trace")
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_DIRECT_ID_KEYS = ("query_id", "request_id", "qa_query_id")
+_NESTED_KEYS = ("context", "data", "metadata", "payload")
+_SPEECH_REPLY_TYPES = {"speak", "ovos.utterance.speak"}
+_MAX_REQUEST_ID_LENGTH = 256
+_MAX_SEARCH_NODES = 24
+
+
+def performance_trace_enabled() -> bool:
+    """Return whether request-correlated OVOS tracing is enabled."""
+    return os.environ.get(
+        "OVOS_PERFORMANCE_TRACE", ""
+    ).strip().lower() in _TRUE_VALUES
+
+
+def message_request_id(message: Any) -> str | None:
+    """Extract one bounded explicit request ID from a message-like object."""
+    pending = deque([message])
+    visited: set[int] = set()
+    searched = 0
+    while pending and searched < _MAX_SEARCH_NODES:
+        candidate = pending.popleft()
+        if candidate is None:
+            continue
+        identity = id(candidate)
+        if identity in visited:
+            continue
+        visited.add(identity)
+        searched += 1
+
+        if isinstance(candidate, dict):
+            for key in _DIRECT_ID_KEYS:
+                value = candidate.get(key)
+                if isinstance(value, str) and value:
+                    return value[:_MAX_REQUEST_ID_LENGTH]
+            pending.extend(
+                candidate.get(key) for key in _NESTED_KEYS
+                if key in candidate
+            )
+            continue
+
+        for key in _DIRECT_ID_KEYS:
+            value = getattr(candidate, key, None)
+            if isinstance(value, str) and value:
+                return value[:_MAX_REQUEST_ID_LENGTH]
+        pending.extend(
+            getattr(candidate, key, None) for key in _NESTED_KEYS
+            if hasattr(candidate, key)
+        )
+    return None
+
+
+def trace_performance_stage(
+    stage: str,
+    *,
+    message: Any = None,
+    request_id: str | None = None,
+    at_unix_ns: int | None = None,
+) -> None:
+    """Log one timestamped stage for an explicitly correlated request."""
+    if not performance_trace_enabled():
+        return
+    identifier = request_id or message_request_id(message)
+    if not identifier:
+        return
+    event = {
+        "at_unix_ns": int(at_unix_ns if at_unix_ns is not None
+                          else time.time_ns()),
+        "request_id": identifier[:_MAX_REQUEST_ID_LENGTH],
+        "stage": str(stage),
+    }
+    _LOG.info(
+        "performance_trace %s",
+        json.dumps(event, sort_keys=True, separators=(",", ":")),
+    )
+
+
+def trace_skill_reply_emission(message: Any) -> None:
+    """Trace a client-visible speech message at the shared bus emit boundary."""
+    if getattr(message, "msg_type", None) not in _SPEECH_REPLY_TYPES:
+        return
+    trace_performance_stage("skill_reply_emit", message=message)

--- a/test/unittests/test_performance_trace.py
+++ b/test/unittests/test_performance_trace.py
@@ -1,0 +1,79 @@
+"""Request-correlated trace coverage for the shared bus emission boundary."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ovos_bus_client.client import MessageBusClient
+from ovos_bus_client.message import Message
+from ovos_bus_client.performance import (
+    message_request_id,
+    trace_performance_stage,
+)
+
+
+def test_message_request_id_finds_nested_metadata():
+    message = Message(
+        "speak",
+        {},
+        {"metadata": {"qa_query_id": "request-nested"}},
+    )
+
+    assert message_request_id(message) == "request-nested"
+
+
+def test_speech_emit_traces_before_single_wire_send(monkeypatch):
+    monkeypatch.setenv("OVOS_PERFORMANCE_TRACE", "true")
+    monkeypatch.setattr(
+        "ovos_bus_client.performance.time.time_ns",
+        lambda: 456_000_000,
+    )
+    emitted = []
+    monkeypatch.setattr(
+        "ovos_bus_client.performance._LOG.info",
+        lambda template, payload: emitted.append(template % payload),
+    )
+    client = MessageBusClient()
+    client._send = MagicMock(
+        side_effect=lambda _message: emitted.append("wire_send")
+    )
+
+    client.emit(Message(
+        "speak",
+        {"utterance": "Hello"},
+        {"query_id": "request-speech"},
+    ))
+
+    assert len(emitted) == 2
+    assert '"stage":"skill_reply_emit"' in emitted[0]
+    assert '"request_id":"request-speech"' in emitted[0]
+    assert '"at_unix_ns":456000000' in emitted[0]
+    assert emitted[1] == "wire_send"
+    client._send.assert_called_once()
+
+
+def test_non_speech_emit_does_not_trace(monkeypatch):
+    monkeypatch.setenv("OVOS_PERFORMANCE_TRACE", "true")
+    log_info = MagicMock()
+    monkeypatch.setattr("ovos_bus_client.performance._LOG.info", log_info)
+    client = MessageBusClient()
+    client._send = MagicMock()
+
+    client.emit(Message(
+        "ovos.utterance.handled",
+        {},
+        {"query_id": "request-handled"},
+    ))
+
+    log_info.assert_not_called()
+    client._send.assert_called_once()
+
+
+def test_disabled_trace_does_not_extract_request_id(monkeypatch):
+    monkeypatch.delenv("OVOS_PERFORMANCE_TRACE", raising=False)
+    monkeypatch.setattr(
+        "ovos_bus_client.performance.message_request_id",
+        lambda _message: pytest.fail("disabled trace extracted request ID"),
+    )
+
+    trace_performance_stage("skill_reply_emit", message=Message("speak"))

--- a/test/unittests/test_performance_trace.py
+++ b/test/unittests/test_performance_trace.py
@@ -22,7 +22,8 @@ def test_message_request_id_finds_nested_metadata():
     assert message_request_id(message) == "request-nested"
 
 
-def test_speech_emit_traces_before_single_wire_send(monkeypatch):
+@pytest.mark.parametrize("message_type", ("speak", "ovos.utterance.speak"))
+def test_speech_emit_traces_before_single_wire_send(monkeypatch, message_type):
     monkeypatch.setenv("OVOS_PERFORMANCE_TRACE", "true")
     monkeypatch.setattr(
         "ovos_bus_client.performance.time.time_ns",
@@ -39,7 +40,7 @@ def test_speech_emit_traces_before_single_wire_send(monkeypatch):
     )
 
     client.emit(Message(
-        "speak",
+        message_type,
         {"utterance": "Hello"},
         {"query_id": "request-speech"},
     ))


### PR DESCRIPTION
## Summary

- add opt-in structured request correlation at the shared OVOS bus emission boundary
- trace only client-visible `speak` / `ovos.utterance.speak` messages before the single wire send
- keep request IDs in diagnostic logs and out of Prometheus labels
- avoid request-ID traversal entirely when tracing is disabled

This boundary covers both `OVOSSkill.speak()` and skills that intentionally emit a forwarded speech `Message` directly. It adds no traffic hook and does not mutate message data or context.

## Validation

- `pytest -q test/unittests`: 732 passed, 6 skipped, 85 subtests passed
- `ruff check ovos_bus_client/performance.py test/unittests/test_performance_trace.py`
- canary composition will be benchmarked with 32 runtime ownership partitions and 32 listener auth workers

No CI configuration was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in performance tracing for client-visible speech messages.
  * Trace records include bounded request correlation, timestamps, and processing stage details.
  * Tracing is disabled by default and can be enabled through configuration.

* **Documentation**
  * Documented how to enable and interpret performance tracing.

* **Tests**
  * Added coverage for request correlation, speech-message tracing, ordering, and disabled-tracing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->