### PR TITLE
fix: silence deprecation warning noise on hot path

### DIFF
--- a/ovos_bus_client/apis/events.py
+++ b/ovos_bus_client/apis/events.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional, Union
 from ovos_utils.events import EventContainer, create_basic_wrapper
 from ovos_bus_client.message import Message, dig_for_message
 from ovos_utils.log import LOG
-from ovos_config.locale import get_default_tz
+from ovos_config.locale import get_config_tz
 from ovos_utils.time import now_local
 
 
@@ -79,7 +79,7 @@ class EventSchedulerInterface:
             # ensure correct timezone before conversion to unix timestamp
             # naive datetime objects method relies on the platform C mktime() function to perform the conversion
             # and may not match mycroft.conf
-            when = when.replace(tzinfo=get_default_tz())
+            when = when.replace(tzinfo=get_config_tz())
         if not name:
             name = self.skill_id + handler.__name__
         unique_name = self._create_unique_name(name)

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1,5 +1,6 @@
 import enum
 import time
+import warnings
 from threading import Event, RLock
 from typing import Optional, List, Tuple, Union, Iterable, Dict, Any
 from uuid import uuid4
@@ -21,6 +22,28 @@ from ovos_bus_client.version import VERSION_MAJOR
 # Deprecations are removed at the next major bump. Derive the version from
 # version.py so the warning text can never drift out of date.
 _NEXT_MAJOR_VERSION = f"{VERSION_MAJOR + 1}.0.0"
+
+
+def _get_default_lang() -> str:
+    """Read the runtime-configured default lang.
+
+    This is a hot path (every ``Session``/``Message`` without an explicit
+    lang goes through it), so it must not spam a DeprecationWarning on every
+    call. ``ovos_config.locale.get_default_lang()`` is deprecated in favor of
+    reading ``Configuration()`` directly -- but only in ovos-config releases
+    where the two are equivalent. Older ovos-config releases (still allowed
+    by this package's ``ovos-config<3.0.0`` floor) keep a private
+    ``_lang`` module-global set by ``setup_locale()``/``set_default_lang()``
+    that ``Configuration()`` does NOT see, and in those releases
+    ``get_default_lang()`` isn't deprecated at all. There is no public
+    accessor that is cache-aware on both release lines, so we keep calling
+    the real (possibly deprecated) function -- preserving behavior on every
+    supported ovos-config version -- and just swallow its own warning here.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning,
+                                message=".*ovos_config.Configuration.*")
+        return get_default_lang()
 
 # Bidirectional-wire back-compat: the canonical parent applies SESSION-1 §2.1
 # omit-when-empty semantics and stores an *empty* collection field as ``None``.
@@ -684,7 +707,7 @@ class Session(_SpecSession):
                                Configuration().get("intents", {}).get("blacklisted_intents", []))
         blacklisted_pipelines = (blacklisted_pipelines or
                                  Configuration().get("intents", {}).get("blacklisted_pipelines", []))
-        lang = standardize_lang(lang or get_default_lang())
+        lang = standardize_lang(lang or _get_default_lang())
         # OVOS-BRIDGE-1 §3.3: site_id is the opaque group identifier. A deployer
         # MAY configure one (the bridge's own determination, step 1), but an
         # unset site_id MUST stay absent — it is NOT fabricated as a sentinel

--- a/ovos_bus_client/util/__init__.py
+++ b/ovos_bus_client/util/__init__.py
@@ -18,12 +18,11 @@ Tools and constructs that are useful together with the messagebus.
 from ovos_utils import json_loads
 
 from ovos_config.config import read_mycroft_config
-from ovos_config.locale import get_default_lang
 from ovos_utils.json_helper import merge_dict
 from ovos_spec_tools import standardize_lang
 from ovos_bus_client import MessageBusClient
 from ovos_bus_client.message import dig_for_message, Message
-from ovos_bus_client.session import SessionManager
+from ovos_bus_client.session import SessionManager, _get_default_lang
 from ovos_bus_client.util.scheduler import EventScheduler
 
 
@@ -47,7 +46,7 @@ def get_message_lang(message=None):
         sess = SessionManager.get(message)
         return sess.lang
 
-    return standardize_lang(get_default_lang())
+    return standardize_lang(_get_default_lang())
 
 
 def get_websocket(host, port, route='/', ssl=False, threaded=True):

--- a/test/unittests/test_audioservice.py
+++ b/test/unittests/test_audioservice.py
@@ -1,7 +1,13 @@
 from unittest import TestCase, mock
 
+import pytest
+
 from ovos_bus_client.message import Message
 from ovos_bus_client.apis.ocp import ClassicAudioServiceInterface
+
+# ClassicAudioServiceInterface is a deprecated shim (use OCPInterface); this
+# module deliberately keeps exercising it for coverage, filtered per-test.
+pytestmark = pytest.mark.filterwarnings("ignore:use OCPInterface instead:DeprecationWarning")
 
 
 class TestAudioServiceControls(TestCase):

--- a/test/unittests/test_enclosure_api.py
+++ b/test/unittests/test_enclosure_api.py
@@ -4,8 +4,17 @@ import warnings
 from unittest import TestCase
 from unittest.mock import MagicMock
 
+import pytest
+
 from ovos_bus_client.apis.enclosure import EnclosureAPI
 from ovos_bus_client.message import Message
+
+# EnclosureAPI itself is a deprecated shim (moved to ovos-gui-api-client).
+# This module deliberately keeps exercising it for coverage; the deprecation
+# noise is filtered per-test rather than globally.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:EnclosureAPI moved to ovos-gui-api-client:DeprecationWarning"
+)
 
 
 def _last_emitted(bus) -> Message:

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -12,7 +12,7 @@ except (ImportError, ModuleNotFoundError):
 
 
 from unittest.mock import MagicMock, patch
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 from ovos_bus_client.util.scheduler import EventScheduler
 
 

--- a/test/unittests/test_message.py
+++ b/test/unittests/test_message.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from time import time
 from unittest import TestCase
 import json
@@ -145,6 +146,10 @@ class TestFunctions(unittest.TestCase):
         self.assertIsNone(dig_for_message())
 
 
+@pytest.mark.filterwarnings("ignore:deprecated without replacement:DeprecationWarning")
+@pytest.mark.filterwarnings(
+    "ignore:deprecated, use ovos_config.Configuration\\(\\) object directly:DeprecationWarning"
+)
 class TestLanguageExtraction(TestCase):
     def test_no_lang_in_message(self):
         """No lang in message should result in lang from active locale."""

--- a/test/unittests/test_message_extra.py
+++ b/test/unittests/test_message_extra.py
@@ -1,6 +1,7 @@
 """Coverage tests for ovos_bus_client.message — reply/forward/response/publish,
 CollectionMessage, GUIMessage, encryption helpers, dig_for_message edge cases."""
 import unittest
+import pytest
 from unittest import TestCase
 
 from ovos_bus_client.message import (CollectionMessage, GUIMessage, Message,
@@ -88,6 +89,7 @@ class TestResponse(TestCase):
         self.assertEqual(resp.context["source"], "D")
 
 
+@pytest.mark.filterwarnings("ignore:Message.publish is deprecated:DeprecationWarning")
 class TestPublish(TestCase):
     def test_publish_emits_deprecation_warning(self):
         """``publish`` is not part of OVOS-MSG-1 and is scheduled for

--- a/test/unittests/test_misc_coverage.py
+++ b/test/unittests/test_misc_coverage.py
@@ -7,12 +7,15 @@ from datetime import timedelta
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from ovos_bus_client.apis.enclosure import EnclosureAPI
 from ovos_bus_client.apis.events import EventSchedulerInterface
 from ovos_bus_client.apis.gui import GUIInterface
 from ovos_bus_client.message import Message
 
 
+@pytest.mark.filterwarnings("ignore:EnclosureAPI moved to ovos-gui-api-client:DeprecationWarning")
 class TestEnclosureExtra(TestCase):
     def setUp(self):
         self.bus = MagicMock()

--- a/test/unittests/test_ocp_api.py
+++ b/test/unittests/test_ocp_api.py
@@ -5,11 +5,17 @@ from datetime import timedelta
 from unittest import TestCase
 from unittest.mock import MagicMock
 
+import pytest
+
 from ovos_bus_client.apis.ocp import (ClassicAudioServiceInterface,
                                       OCPAudioServiceInterface, OCPInterface,
                                       OCPVideoServiceInterface,
                                       OCPWebServiceInterface)
 from ovos_bus_client.message import Message
+
+# ClassicAudioServiceInterface is a deprecated shim (use OCPInterface); this
+# module deliberately keeps exercising it for coverage, filtered per-test.
+pytestmark = pytest.mark.filterwarnings("ignore:use OCPInterface instead:DeprecationWarning")
 
 
 def _last(bus) -> Message:

--- a/test/unittests/test_util.py
+++ b/test/unittests/test_util.py
@@ -2,7 +2,7 @@ import time
 import unittest
 
 from os.path import isfile
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 
 
 class TestScheduler(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Session.__init__ and get_message_lang() were calling the deprecated ovos_config.locale.get_default_lang()/get_default_tz() helpers on every construction, which meant a DeprecationWarning fired on every live utterance.

get_default_tz() is a pure Configuration() passthrough on every supported ovos-config release, so its one caller (apis/events.py) now calls get_config_tz() directly — no behavior change. get_default_lang() needed more care: on the latest ovos-config prerelease it's also just Configuration().get("lang", "en-us"), but this package's floor (ovos-config<3.0.0) also allows the older stable release line, which keeps a private module-global lang cache set by setup_locale()/set_default_lang() that Configuration() does not observe (and isn't even deprecated there). Since no public accessor is cache-aware on both lines, Session and get_message_lang now go through a small shared helper that still calls the real get_default_lang() — so a runtime setup_locale()/set_default_lang() switch keeps reaching Session.lang exactly as before on every supported ovos-config version — and just swallows that one function's own warning locally. Verified against both the latest ovos-config prerelease (2.3.8a2) and the latest stable release (2.1.1) in separate clean venvs, including test_no_lang_in_message specifically (it round-trips a runtime locale switch through get_message_lang()).

Two test files still imported FakeBus from the deprecated ovos_utils.messagebus path; switched to the canonical ovos_utils.fakebus.

The rest of the noise was tests deliberately covering deprecated shims (Message.publish, EnclosureAPI, ClassicAudioServiceInterface/OCPInterface, ovos_config.locale.setup_locale with no replacement) — now filtered per-test with specific message patterns, coverage kept.

Full suite with -W default, verified in two independent clean venvs (ovos-config 2.3.8a2 and 2.1.1): 264 warnings before, 0 after. 770 passed, 6 skipped — unchanged in both.