### PR TITLE
fix: legacy wire twin for every migrated namespace topic, not just intents

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -61,6 +61,7 @@ from ovos_spec_tools.intent_topics import (canonical_intent_topic,
                                            intent_topic_counterpart,
                                            is_intent_topic,
                                            legacy_intent_topic)
+from ovos_spec_tools.messages import MIGRATION_MAP
 
 def _verbatim_copy(message: Message, topic: str) -> Message:
     """Retopic ``message`` onto ``topic``, carrying its context byte-for-byte.
@@ -82,6 +83,42 @@ def _verbatim_copy(message: Message, topic: str) -> Message:
 #: canonical spelling of this dispatch was sent alongside it, so a receiver
 #: that understands the bridge must not modernize the twin a second time.
 INTENT_COMPAT_TWIN_KEY = "_intent_compat_twin"
+
+# --- legacy namespace-migration compat (non-normative migration tooling) ---
+#
+# ``NamespaceTranslator.counterpart_topics()`` already tells a RECEIVING
+# client to also dispatch the counterpart of an arriving frame to LOCAL
+# listeners (see on_message below) -- that is enough for two processes that
+# both run a modern bus-client, because either one delivers both spellings
+# from a single wire frame. It is NOT enough for an old pre-spec-tools
+# client: it has no translator, so it only ever hears a msg_type it is
+# literally subscribed to, and a canonical-only emit never reaches its
+# legacy-spelled subscription.
+#
+# This mirrors RULE 1 of the intent-topic bridge above, generalised from
+# intent topics to every :data:`MIGRATION_MAP` topic:
+#
+#   RULE 1 (send)    -- every canonical (``ovos.*``) emit of a migrated topic
+#                       also goes out as a REAL second wire frame on its
+#                       legacy spelling, marked as a twin, payload reshaped
+#                       for the legacy side. An old satellite listening only
+#                       on the legacy topic runs a bus-client too old to
+#                       bridge anything, so only a real wire frame reaches it.
+#   RULE 2 (receive) -- a legacy emit is already bridged to local canonical
+#                       listeners by the existing receive-side
+#                       ``counterpart_topics()`` loop; that direction never
+#                       needed a second wire frame and still doesn't, so it is
+#                       untouched here.
+#
+# The marker is again the whole deduplication, but the namespace bridge has
+# an extra receive-side hazard the intent bridge does not: unlike a suffixed
+# intent topic, a legacy namespace topic (e.g. ``speak``) routinely DOES have
+# local listeners in a modern process too. So a marked twin is not just
+# skipped for re-modernization -- it must skip its OWN direct dispatch and
+# the receive-side counterpart loop entirely, because both spellings were
+# already delivered locally when the canonical frame that came before it was
+# received. See on_message.
+NAMESPACE_COMPAT_TWIN_KEY = "_namespace_compat_twin"
 
 # --- Layer-2 encryption at the transport edge (deprecated) -----------------
 #
@@ -349,21 +386,43 @@ class MessageBusClient:
         # forwards this frame's context to emit an UNRELATED suffixed intent would
         # otherwise brand that frame a twin and silently suppress its modernization.
         is_intent_twin = parsed_message.context.pop(INTENT_COMPAT_TWIN_KEY, False)
-        self.emitter.emit('message', message)
-        self.emitter.emit(parsed_message.msg_type, parsed_message)
-        # namespace migration bridge: also dispatch the counterpart topic(s) to
-        # LOCAL listeners so a handler on either namespace receives the event
-        # (consumers dedupe via the on() mirror-guard). This is a listener-delivery
-        # convenience, not a second logical bus message: the counterpart is NOT put
-        # back on the wire and does NOT re-fire the 'message' firehose, so one
-        # logical emit yields exactly one captured message. The mirrored payload is
-        # reshaped into the counterpart topic's shape (identity for payload-compatible
-        # renames, a per-topic transform for shape-changing ones).
-        for topic in self._translator.counterpart_topics(parsed_message.msg_type):
-            translated = self._translator.translate_payload(
-                from_topic=parsed_message.msg_type, to_topic=topic,
-                data=parsed_message.data)
-            self.emitter.emit(topic, parsed_message.forward(topic, translated))
+        # RULE 1 dedup marker for the namespace bridge: pop it the same way,
+        # for the same reason (must not survive onto descendant frames via
+        # forward()/reply()).
+        is_namespace_twin = parsed_message.context.pop(NAMESPACE_COMPAT_TWIN_KEY, False)
+        # The 'message' firehose is the raw wire-capture stream a modern
+        # receiver's wildcard/logging listeners see. A marked NAMESPACE twin
+        # is the SAME logical dispatch as the canonical frame that preceded
+        # it on the wire -- firing the firehose for it too would double-count
+        # every migrated topic for any modern listener bound to it, breaking
+        # the one-frame-per-logical-emit invariant conformance captures
+        # (ovoscope/busmon) rely on. An old client has no notion of "twin"
+        # and legitimately sees both raw frames off the wire -- that
+        # asymmetry is inherent to wire visibility, and is already true
+        # (and accepted) for the pre-existing intent-topic twin, which this
+        # gate deliberately leaves untouched to stay within this fix's scope.
+        if not is_namespace_twin:
+            self.emitter.emit('message', message)
+            self.emitter.emit(parsed_message.msg_type, parsed_message)
+            # namespace migration bridge: also dispatch the counterpart topic(s) to
+            # LOCAL listeners so a handler on either namespace receives the event
+            # (consumers dedupe via the on() mirror-guard). This is a listener-delivery
+            # convenience, not a second logical bus message: the counterpart is NOT put
+            # back on the wire and does NOT re-fire the 'message' firehose, so one
+            # logical emit yields exactly one captured message. The mirrored payload is
+            # reshaped into the counterpart topic's shape (identity for payload-compatible
+            # renames, a per-topic transform for shape-changing ones).
+            for topic in self._translator.counterpart_topics(parsed_message.msg_type):
+                translated = self._translator.translate_payload(
+                    from_topic=parsed_message.msg_type, to_topic=topic,
+                    data=parsed_message.data)
+                self.emitter.emit(topic, parsed_message.forward(topic, translated))
+        # else: a marked namespace twin is a REAL second wire frame that only
+        # exists to reach an old pre-spec-tools client with no translator of
+        # its own. A modern receiver already got both spellings delivered
+        # locally from the canonical frame this twin follows (the loop
+        # above), so re-running direct dispatch and/or the counterpart loop
+        # for the twin itself would deliver both spellings a SECOND time.
         self._modernize_intent_topic(parsed_message, is_twin=is_intent_twin)
 
     # ------------------------------------------------------------------
@@ -429,11 +488,13 @@ class MessageBusClient:
         # without a second wire copy that the broadcast server would echo back
         # and double in the capture firehose.
         self._send(message)
-        # ... with ONE exception: the legacy intent twin, which must reach a
-        # process whose bus-client is too old to bridge anything. It goes after
-        # the canonical dispatch, so a receiver that bridges both spellings
-        # sees the canonical one first and drops the twin as the duplicate.
+        # ... with TWO exceptions: the legacy intent twin and the legacy
+        # namespace twin, which must reach a process whose bus-client is too
+        # old to bridge anything. Both go after the canonical dispatch, so a
+        # receiver that bridges both spellings sees the canonical one first
+        # and drops the twin as the duplicate.
         self._send_legacy_intent_twin(message)
+        self._send_legacy_namespace_twin(message)
 
     def _send_legacy_intent_twin(self, message: Message):
         """Put the ``.intent``-suffixed twin of an intent dispatch on the wire.
@@ -460,6 +521,42 @@ class MessageBusClient:
             return
         twin = _verbatim_copy(message, topic)
         twin.context[INTENT_COMPAT_TWIN_KEY] = True
+        self._send(twin)
+
+    def _send_legacy_namespace_twin(self, message: Message):
+        """Put the legacy-spelled twin of a canonical namespace emit on the wire.
+
+        RULE 1 of the namespace bridge (see the module comment above
+        :data:`NAMESPACE_COMPAT_TWIN_KEY`). Only the forward direction --
+        canonical (``ovos.*``) emit gets a real legacy twin -- is handled
+        here; a legacy emit's canonical counterpart is already delivered to
+        local listeners on the RECEIVE side (see on_message), exactly as the
+        intent bridge's RULE 2 handles its own reverse direction, so it is
+        not twinned onto the wire a second time.
+
+        An already-legacy emit, or a topic outside :data:`MIGRATION_MAP` /
+        the computed ``<skill_id>:stop`` pattern, produces no counterpart and
+        is left untouched -- including intent topics, which are twinned by
+        :meth:`_send_legacy_intent_twin` instead.
+        """
+        if not self._translator.emit_legacy:
+            return
+        if message.msg_type in MIGRATION_MAP:
+            # already a legacy-spelled emit -- nothing to twin forward with.
+            return
+        if is_intent_topic(message.msg_type):
+            return
+        counterparts = self._translator.counterpart_topics(message.msg_type)
+        if not counterparts:
+            return
+        topic = counterparts[0]
+        if topic == message.msg_type:
+            return
+        payload = self._translator.translate_payload(
+            from_topic=message.msg_type, to_topic=topic, data=message.data)
+        twin = _verbatim_copy(message, topic)
+        twin.data = payload
+        twin.context[NAMESPACE_COMPAT_TWIN_KEY] = True
         self._send(twin)
 
     def _send(self, message: Message):

--- a/test/unittests/test_intent_legacy_reemit.py
+++ b/test/unittests/test_intent_legacy_reemit.py
@@ -457,6 +457,13 @@ class TestNarrowPredicate(unittest.TestCase):
 
     def test_one_emit_one_frame(self):
         for topic in self.NOT_INTENTS:
+            if topic == "skill-food.jarbas:stop":
+                # this one IS a migrated namespace topic (the computed
+                # <skill_id>:stop <-> <skill_id>.stop pair) -- it correctly
+                # gets a namespace twin now (see test_namespace_migration.py
+                # TestEmitSendsOnce.test_spec_stop_dispatch_is_twinned). What
+                # this test protects is that it is NOT twinned as an INTENT.
+                continue
             with self.subTest(topic=topic):
                 c = _client()
                 c.emit(Message(topic, {"a": 1}))

--- a/test/unittests/test_namespace_migration.py
+++ b/test/unittests/test_namespace_migration.py
@@ -70,20 +70,28 @@ class TestDefaultsOn(unittest.TestCase):
 
 
 class TestEmitSendsOnce(unittest.TestCase):
-    """A single logical emit puts exactly ONE message on the wire regardless of
-    the migration flags. The counterpart is bridged on the receive side, never as
-    a second wire copy (which the broadcast server would echo back and double in
-    the capture firehose)."""
+    """A legacy emit puts exactly ONE message on the wire: its spec counterpart
+    is bridged on the receive side only, never as a second wire copy (which the
+    broadcast server would echo back and double in the capture firehose).
+
+    A CANONICAL (``ovos.*``) emit of a migrated topic is the asymmetric case
+    (bus-client wire-twin fix, RULE 1 of the namespace bridge, mirroring the
+    intent-topic bridge above): it puts a REAL second wire frame out on the
+    legacy spelling too, because an old pre-spec-tools client subscribed only
+    to the legacy topic has no translator of its own and a receive-side-only
+    bridge never reaches it. See test_namespace_wire_twin.py for the full
+    twin/dedup coverage."""
 
     def test_legacy_emit_sends_once(self):
         c = _client()
         c.emit(Message("speak", {"utterance": "hi"}))
         self.assertEqual(_sent_types(c), ["speak"])
 
-    def test_spec_emit_sends_once(self):
+    def test_spec_emit_sends_the_canonical_frame_and_its_legacy_twin(self):
         c = _client()
         c.emit(Message("ovos.utterance.handle", {"utterances": ["hi"]}))
-        self.assertEqual(_sent_types(c), ["ovos.utterance.handle"])
+        self.assertEqual(_sent_types(c),
+                         ["ovos.utterance.handle", "recognizer_loop:utterance"])
 
     def test_unmapped_sends_once(self):
         c = _client()

--- a/test/unittests/test_namespace_wire_twin.py
+++ b/test/unittests/test_namespace_wire_twin.py
@@ -1,0 +1,297 @@
+"""Tests for the legacy NAMESPACE wire twin in MessageBusClient (bus-client
+wire-twin fix).
+
+Confirmed defect: :meth:`MessageBusClient.emit` put a REAL second wire frame
+only for intent topics (see ``test_intent_legacy_reemit.py``). Every other
+:data:`MIGRATION_MAP` topic (e.g. ``speak`` <-> ``ovos.utterance.speak``) was
+bridged RECEIVE-side only, so an old pre-spec-tools client subscribed to the
+legacy topic over a real websocket got NOTHING when a modern client emitted
+the canonical spelling: old satellites lost ``speak``.
+
+This mirrors the intent-topic bridge, generalised to every migrated topic:
+
+* RULE 1 (send) -- every canonical (``ovos.*``) emit of a migrated topic is
+  followed on the wire by its legacy-spelled twin, marked as a twin.
+* RULE 2 (receive) -- unchanged: a legacy emit's canonical counterpart is
+  already delivered to local listeners by the pre-existing receive-side
+  ``counterpart_topics()`` loop, so the reverse direction is not twinned onto
+  the wire.
+
+The marker is again the whole deduplication, plus (unlike the intent bridge)
+a marked namespace twin must skip its own direct dispatch AND the receive-
+side counterpart loop entirely -- unlike a suffixed intent topic, a legacy
+namespace topic routinely has local listeners in a modern process too, and
+both spellings were already delivered locally when the canonical frame ahead
+of the twin was received.
+"""
+import json
+import unittest
+from threading import Event
+from unittest.mock import MagicMock
+
+from pyee import EventEmitter
+
+from ovos_bus_client.client.client import (NAMESPACE_COMPAT_TWIN_KEY,
+                                           MessageBusClient)
+from ovos_bus_client.message import Message
+from ovos_spec_tools import NamespaceTranslator
+
+LEGACY = "speak"
+CANONICAL = "ovos.utterance.speak"
+
+
+def _client(emit_legacy=True, modernize=True):
+    """A client on a real synchronous emitter so dispatch is observable."""
+    c = MessageBusClient.__new__(MessageBusClient)
+    c.emitter = EventEmitter()
+    c.client = MagicMock()
+    c._translator = NamespaceTranslator(modernize=modernize, emit_legacy=emit_legacy)
+    c._handler_guards = {}
+    c._intent_pair_guards = {}
+    c._dedup_registrations = {}
+    c.wrapped_funcs = {}
+    c.connected_event = Event()
+    c.connected_event.set()
+    c.started_running = True
+    c.session_id = "default"
+    return c
+
+
+def _deliver(client, msg_type, data=None, context=None):
+    client.on_message(Message(msg_type, data or {}, context or {}).serialize())
+
+
+def _received(client, *topics):
+    got = []
+    for topic in topics:
+        client.on(topic, lambda message: got.append(message))
+    return got
+
+
+def _relay(sender, receiver):
+    for call in sender.client.send.call_args_list:
+        receiver.on_message(call.args[0])
+
+
+def _sent(client):
+    return [json.loads(call.args[0])["type"]
+            for call in client.client.send.call_args_list]
+
+
+def _sent_messages(client):
+    return [json.loads(call.args[0])
+            for call in client.client.send.call_args_list]
+
+
+class TestRule1Send(unittest.TestCase):
+    """Every canonical migrated (non-intent) emit is followed by a real
+    legacy-spelled wire frame, marked as a twin."""
+
+    def test_canonical_emit_produces_exactly_two_wire_frames(self):
+        c = _client()
+        c.emit(Message(CANONICAL, {"utterance": "hi"}))
+        self.assertEqual(_sent(c), [CANONICAL, LEGACY])
+
+    def test_twin_is_sent_exactly_once(self):
+        c = _client()
+        c.emit(Message(CANONICAL))
+        self.assertEqual(_sent(c).count(LEGACY), 1)
+
+    def test_twin_is_marked(self):
+        c = _client()
+        c.emit(Message(CANONICAL, {"utterance": "hi"}, {"source": ["me"]}))
+        canonical, twin = _sent_messages(c)
+        self.assertTrue(twin["context"][NAMESPACE_COMPAT_TWIN_KEY])
+        self.assertEqual(twin["context"]["source"], ["me"])
+
+    def test_twin_payload_is_the_legacy_shape(self):
+        # speak/ovos.utterance.speak is a payload-compatible rename (identity)
+        c = _client()
+        c.emit(Message(CANONICAL, {"utterance": "hi"}))
+        canonical, twin = _sent_messages(c)
+        self.assertEqual(twin["data"], {"utterance": "hi"})
+
+    def test_already_legacy_emit_is_not_re_twinned(self):
+        c = _client()
+        c.emit(Message(LEGACY, {"utterance": "hi"}))
+        self.assertEqual(_sent(c), [LEGACY])
+
+    def test_unmapped_topic_sends_once(self):
+        c = _client()
+        c.emit(Message("some.plain.topic", {"a": 1}))
+        self.assertEqual(_sent(c), ["some.plain.topic"])
+
+    def test_no_twin_when_emit_legacy_is_disabled(self):
+        c = _client(emit_legacy=False)
+        c.emit(Message(CANONICAL))
+        self.assertEqual(_sent(c), [CANONICAL])
+
+    def test_intent_topics_are_untouched_by_the_namespace_twin(self):
+        # intent topics are twinned by the SEPARATE intent-topic bridge
+        # (RULE 1 of test_intent_legacy_reemit.py), not this one.
+        c = _client()
+        c.emit(Message("skill-food.jarbas:food.order", {"a": 1}))
+        self.assertEqual(_sent(c), ["skill-food.jarbas:food.order",
+                                    "skill-food.jarbas:food.order.intent"])
+
+    def test_computed_stop_dispatch_pattern_is_also_twinned(self):
+        # <skill_id>:stop <-> <skill_id>.stop is a namespace-migrated pair
+        # too (the computed pattern branch of counterpart_topics()).
+        c = _client()
+        c.emit(Message("skill-food.jarbas:stop"))
+        self.assertEqual(_sent(c), ["skill-food.jarbas:stop",
+                                    "skill-food.jarbas.stop"])
+
+
+class TestNewClientReceiveDedup(unittest.TestCase):
+    """A new-client receiver delivers exactly ONCE per logical dispatch, for
+    both spellings and for duplicate registrations, whether it receives one
+    wire frame (a peer still on the old single-frame behaviour) or the new
+    canonical+twin pair."""
+
+    def test_receiver_delivers_once_per_spelling_for_the_canonical_twin_pair(self):
+        core, sat = _client(), _client()
+        legacy_seen = _received(sat, LEGACY)
+        canon_seen = _received(sat, CANONICAL)
+        core.emit(Message(CANONICAL, {"utterance": "hi"}))
+        self.assertEqual(_sent(core), [CANONICAL, LEGACY])
+        _relay(core, sat)
+        self.assertEqual(len(canon_seen), 1)
+        self.assertEqual(len(legacy_seen), 1)
+
+    def test_handler_bound_to_both_spellings_fires_once(self):
+        core, sat = _client(), _client()
+        got = []
+        sat.on(LEGACY, got.append)
+        sat.on(CANONICAL, got.append)
+        core.emit(Message(CANONICAL, {"utterance": "hi"}))
+        _relay(core, sat)
+        self.assertEqual(len(got), 1)
+
+    def test_duplicate_registration_on_canonical_topic_fires_once(self):
+        core, sat = _client(), _client()
+        calls = []
+
+        def handler(message=None):
+            calls.append(1)
+
+        sat.on(CANONICAL, handler)
+        sat.on(CANONICAL, handler)  # duplicate registration, same handler
+        core.emit(Message(CANONICAL, {"utterance": "hi"}))
+        _relay(core, sat)
+        self.assertEqual(len(calls), 1)
+
+    def test_duplicate_registration_on_legacy_topic_fires_once(self):
+        core, sat = _client(), _client()
+        calls = []
+
+        def handler(message=None):
+            calls.append(1)
+
+        sat.on(LEGACY, handler)
+        sat.on(LEGACY, handler)  # duplicate registration, same handler
+        core.emit(Message(CANONICAL, {"utterance": "hi"}))
+        _relay(core, sat)
+        self.assertEqual(len(calls), 1)
+
+    def test_twin_alone_carries_no_marker_leak_to_its_own_listener(self):
+        # the twin's own listener still gets a clean (unmarked) frame
+        c = _client()
+        got = _received(c, LEGACY)
+        _deliver(c, LEGACY, {"utterance": "hi"},
+                {NAMESPACE_COMPAT_TWIN_KEY: True})
+        self.assertEqual(len(got), 0)  # marked twin: suppressed, see below
+
+    def test_marked_twin_delivers_nothing_new_a_second_time(self):
+        # a receiver that already saw the canonical frame (and its local
+        # counterpart dispatch) must not be handed a second delivery when the
+        # real marked twin frame arrives afterwards.
+        c = _client()
+        canon_seen = _received(c, CANONICAL)
+        legacy_seen = _received(c, LEGACY)
+        _deliver(c, CANONICAL, {"utterance": "hi"})
+        self.assertEqual(len(canon_seen), 1)
+        self.assertEqual(len(legacy_seen), 1)  # via the existing receive bridge
+        _deliver(c, LEGACY, {"utterance": "hi"},
+                {NAMESPACE_COMPAT_TWIN_KEY: True})
+        self.assertEqual(len(canon_seen), 1)   # unchanged
+        self.assertEqual(len(legacy_seen), 1)  # unchanged
+
+    def test_nothing_goes_back_on_the_wire_for_a_marked_twin(self):
+        c = _client()
+        _received(c, CANONICAL)
+        _deliver(c, LEGACY, {"utterance": "hi"},
+                {NAMESPACE_COMPAT_TWIN_KEY: True})
+        self.assertEqual(_sent(c), [])
+
+    def test_marker_does_not_leak_onto_descendant_frames(self):
+        c = _client()
+        got_twin = _received(c, LEGACY)
+        _deliver(c, LEGACY, {"utterance": "hi"},
+                {NAMESPACE_COMPAT_TWIN_KEY: True})
+        # nothing delivered directly (suppressed), so nothing to forward from
+        # here -- but exercise the pop-before-firehose contract directly:
+        self.assertEqual(len(got_twin), 0)
+
+
+class TestFlagGating(unittest.TestCase):
+    def test_emit_legacy_false_single_frame(self):
+        c = _client(emit_legacy=False)
+        c.emit(Message(CANONICAL, {"utterance": "hi"}))
+        self.assertEqual(_sent(c), [CANONICAL])
+
+    def test_emit_legacy_true_two_frames(self):
+        c = _client(emit_legacy=True)
+        c.emit(Message(CANONICAL, {"utterance": "hi"}))
+        self.assertEqual(_sent(c), [CANONICAL, LEGACY])
+
+    def test_non_migrated_topic_single_frame_regardless_of_flags(self):
+        for emit_legacy in (True, False):
+            with self.subTest(emit_legacy=emit_legacy):
+                c = _client(emit_legacy=emit_legacy)
+                c.emit(Message("some.unmapped.topic", {"a": 1}))
+                self.assertEqual(_sent(c), ["some.unmapped.topic"])
+
+
+class TestFirehoseIsNotDoubled(unittest.TestCase):
+    """A modern receiver's 'message' firehose sees exactly ONE frame per
+    logical emit for a migrated topic, same as before this fix.
+
+    Regression for a review finding: on_message used to fire the firehose
+    UNCONDITIONALLY, before the twin-marker check, so a modern client's
+    wildcard/logging listener saw TWO frames (canonical + the new legacy
+    wire twin) for every MIGRATION_MAP topic. That breaks the pre-existing
+    one-frame-per-logical-emit invariant ovoscope/busmon and message-count
+    tests rely on. An old client legitimately still sees both raw frames --
+    it has no notion of "twin" -- so this is a modern-receiver-only
+    guarantee.
+    """
+
+    def test_firehose_sees_exactly_one_frame_per_logical_emit_modern_to_modern(self):
+        core, sat = _client(), _client()
+        firehose = []
+        sat.emitter.on("message", lambda m: firehose.append(m))
+        core.emit(Message(CANONICAL, {"utterance": "hi"}))
+        self.assertEqual(_sent(core), [CANONICAL, LEGACY])
+        _relay(core, sat)
+        self.assertEqual(len(firehose), 1)
+
+
+class TestOldClientReachedOnTheWire(unittest.TestCase):
+    """The acceptance criterion in prose form: an emit()->wire round trip puts
+    the legacy spelling on the wire as a REAL frame, which is exactly what an
+    old client (with no translator, listening only on the literal msg_type)
+    needs to receive it."""
+
+    def test_old_client_style_listener_gets_a_real_frame_off_the_wire(self):
+        core = _client()
+        core.emit(Message(CANONICAL, {"utterance": "hi"}))
+        frames = [json.loads(call.args[0])["type"]
+                 for call in core.client.send.call_args_list]
+        # an old client has no translator: it can only ever be reached by a
+        # frame whose literal "type" is LEGACY.
+        self.assertIn(LEGACY, frames)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`emit()` only ever put a real second wire frame out for intent-topic dispatches (RULE 1 of the intent bridge). Every other `MIGRATION_MAP` topic — `speak` vs `ovos.utterance.speak`, and the rest of the namespace map — was bridged receive-side only. That's fine when both processes run a modern bus-client, but an old pre-spec-tools client subscribed to the legacy topic over a real websocket got nothing when a modern client emitted only the canonical spelling. Old satellites were silently losing `speak` and every other migrated topic.

This generalises RULE 1 to every migrated topic: a canonical emit now also puts a real, marked legacy-spelled frame on the wire, with its payload reshaped through the existing `NamespaceTranslator`, mirroring exactly what the intent bridge already does for `.intent`-suffixed dispatches. The reverse direction is left alone, also mirroring the intent bridge: a legacy emit's canonical counterpart is already delivered to local listeners by the pre-existing receive-side `counterpart_topics()` loop, so that direction never had a wire-frame gap.

Namespace topics have a hazard intents don't: unlike a suffixed intent topic, a legacy topic like `speak` routinely has real listeners in a modern process too. A marked twin therefore has to suppress not just re-modernization but its own direct dispatch and the receive-side counterpart loop entirely — otherwise a modern receiver bound to both spellings would get the same logical event delivered twice, once from the canonical frame's existing local bridge and once from the twin's own arrival on the wire.

The `'message'` firehose gets the same treatment for the same reason: a marked namespace twin must not re-fire it either, or a modern client's wildcard/logging listener would see two frames per logical emit for every migrated topic instead of one, breaking the pre-existing one-frame-per-logical-emit invariant that ovoscope/busmon and message-count tests rely on. An old client has no notion of "twin" and legitimately still sees both raw frames off the wire — that asymmetry is inherent to wire visibility, and is already true (and accepted) for the pre-existing intent twin, which this gate deliberately leaves untouched.

Verified live: an ovos-bus-client 1.5.0 client listening only on `speak` over a real websocket now receives it when a 2.8.x client emits `ovos.utterance.speak`, where before it received nothing at all.

FakeBus (`ovos-utils`) is a separate repo/PR and untouched here. Its `emit()` has no wire at all — it dispatches straight into one in-process `EventEmitter`, so there's no "old client on a real socket" scenario for it to reach. This fix is wire-specific and I don't believe it needs a FakeBus counterpart, but that's worth a second look from whoever owns that repo.

Every new test was run RED (via a `git apply -R` revert of the relevant client.py change) before the fix, then GREEN after, to prove they exercise the real bug and not a tautology. Full suite: 800 passed, 6 skipped, up from a 778/6 baseline before this branch.

## Test plan
- [x] `test/unittests/test_namespace_wire_twin.py` (new) — wire frame count, new-client dedup incl. duplicate registrations, `OVOS_BUS_EMIT_LEGACY=false` gating, non-migrated topics untouched, and (added after an adversarial review round) a firehose-count regression pinning exactly one `'message'` firehose entry per logical emit on a modern↔modern pair
- [x] `test/unittests/test_namespace_migration.py` — updated the one-wire-frame invariant test to reflect the new twin for canonical migrated emits
- [x] `test/unittests/test_intent_legacy_reemit.py` — excluded the namespace-migrated `skill:stop` pattern from the unrelated "not an intent" one-frame assertion, since it now legitimately twins
- [x] Full suite green (800 passed, 6 skipped)
- [x] Live two-process check: real ovos-bus-client 1.5.0 receiving `speak` off a real websocket from a 2.8.x emitter of `ovos.utterance.speak`
