### PR TITLE
fix: gate the namespace wire twin behind an escape-hatch flag

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -120,6 +120,36 @@ INTENT_COMPAT_TWIN_KEY = "_intent_compat_twin"
 # received. See on_message.
 NAMESPACE_COMPAT_TWIN_KEY = "_namespace_compat_twin"
 
+#: Escape-hatch flag (env var ``OVOS_BUS_WIRE_LEGACY_TWINS`` / config key
+#: ``websocket.wire_legacy_twins``) gating :meth:`MessageBusClient.
+#: _send_legacy_namespace_twin`. DEFAULT TRUE -- symmetric with
+#: ``OVOS_BUS_EMIT_LEGACY``.
+#:
+#: #286 made every canonical (``ovos.*``) emit of a :data:`MIGRATION_MAP`
+#: topic also put a real second wire frame on the legacy spelling. This is
+#: the compat path for the actual supported population: the latest STABLE
+#: ``ovos-bus-client`` release (1.5.0, pre-spec-tools) and anything older --
+#: those clients have no :class:`NamespaceTranslator` at all, so a
+#: canonical-only emit never reaches their legacy-spelled subscription
+#: without a real wire twin.
+#:
+#: A receiver in the 2.2.0a1..2.8.2a1 ALPHA window is not a supported
+#: configuration (only the latest prerelease is supported, per project
+#: policy): it already bridges both spellings locally from the canonical
+#: frame alone (RULE 2 above, via ``counterpart_topics()`` in
+#: ``on_message``), so it double-delivers every migrated topic while
+#: sharing a bus with a 2.8.3a1+ sender. That is a transient hazard of
+#: running an outdated alpha, resolved by updating the receiver to
+#: 2.8.3a1+ (which dedups the twin via :data:`NAMESPACE_COMPAT_TWIN_KEY`)
+#: -- it is documented here, not defended against.
+#:
+#: Set this flag to false only on a bus where the operator knows no
+#: pre-spec-tools (stable <2.x) wire listeners are present, to get the
+#: bandwidth of the second frame back. A relay/hub that knows its own
+#: satellite population (e.g. a HiveMind hub bridging to known-old
+#: satellites) is the recommended place to scope this translation instead
+#: of flipping it bus-wide.
+
 # --- Layer-2 encryption at the transport edge (deprecated) -----------------
 #
 # OVOS-MSG-1 is transport-agnostic (§7 non-goals): the on-the-wire envelope
@@ -245,6 +275,9 @@ class MessageBusClient:
         self._translator = NamespaceTranslator(
             modernize=_bus_flag("OVOS_BUS_MODERNIZE", "modernize", default=True),
             emit_legacy=_bus_flag("OVOS_BUS_EMIT_LEGACY", "emit_legacy", default=True))
+        # escape hatch, default ON -- see the docstring above NAMESPACE_COMPAT_TWIN_KEY.
+        self._wire_legacy_twins = _bus_flag(
+            "OVOS_BUS_WIRE_LEGACY_TWINS", "wire_legacy_twins", default=True)
         self._handler_guards = {}        # func -> shared mirror-guard
         self._dedup_registrations = {}   # func -> [(event_name, wrapped), ...]
         # Intent-topic compat guards are keyed by the TOPIC PAIR, not by the
@@ -540,6 +573,12 @@ class MessageBusClient:
         :meth:`_send_legacy_intent_twin` instead.
         """
         if not self._translator.emit_legacy:
+            return
+        if not self._wire_legacy_twins:
+            # escape hatch -- see OVOS_BUS_WIRE_LEGACY_TWINS. Default ON, for
+            # stable (<2.x) pre-spec-tools wire listeners, which are the
+            # supported compat target. Only flip this off when the operator
+            # knows no such listener is on the bus.
             return
         if message.msg_type in MIGRATION_MAP:
             # already a legacy-spelled emit -- nothing to twin forward with.

--- a/test/unittests/test_intent_legacy_reemit.py
+++ b/test/unittests/test_intent_legacy_reemit.py
@@ -31,12 +31,13 @@ CANONICAL = "skill-food.jarbas:food.order"
 LEGACY = "skill-food.jarbas:food.order.intent"
 
 
-def _client(emit_legacy=True, modernize=True):
+def _client(emit_legacy=True, modernize=True, wire_legacy_twins=True):
     """A client on a real synchronous emitter so dispatch is observable."""
     c = MessageBusClient.__new__(MessageBusClient)
     c.emitter = EventEmitter()
     c.client = MagicMock()
     c._translator = NamespaceTranslator(modernize=modernize, emit_legacy=emit_legacy)
+    c._wire_legacy_twins = wire_legacy_twins
     c._handler_guards = {}
     c._intent_pair_guards = {}
     c._dedup_registrations = {}

--- a/test/unittests/test_namespace_migration.py
+++ b/test/unittests/test_namespace_migration.py
@@ -19,11 +19,12 @@ from ovos_bus_client.message import Message
 from ovos_spec_tools import NamespaceTranslator
 
 
-def _client(modernize=True, emit_legacy=True, emitter=None):
+def _client(modernize=True, emit_legacy=True, emitter=None, wire_legacy_twins=True):
     c = MessageBusClient.__new__(MessageBusClient)
     c.emitter = emitter if emitter is not None else MagicMock()
     c.client = MagicMock()
     c._translator = NamespaceTranslator(modernize=modernize, emit_legacy=emit_legacy)
+    c._wire_legacy_twins = wire_legacy_twins
     c._handler_guards = {}
     c._dedup_registrations = {}
     c.wrapped_funcs = {}

--- a/test/unittests/test_namespace_wire_twin.py
+++ b/test/unittests/test_namespace_wire_twin.py
@@ -27,12 +27,12 @@ of the twin was received.
 import json
 import unittest
 from threading import Event
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pyee import EventEmitter
 
 from ovos_bus_client.client.client import (NAMESPACE_COMPAT_TWIN_KEY,
-                                           MessageBusClient)
+                                           MessageBusClient, _bus_flag)
 from ovos_bus_client.message import Message
 from ovos_spec_tools import NamespaceTranslator
 
@@ -40,12 +40,13 @@ LEGACY = "speak"
 CANONICAL = "ovos.utterance.speak"
 
 
-def _client(emit_legacy=True, modernize=True):
+def _client(emit_legacy=True, modernize=True, wire_legacy_twins=True):
     """A client on a real synchronous emitter so dispatch is observable."""
     c = MessageBusClient.__new__(MessageBusClient)
     c.emitter = EventEmitter()
     c.client = MagicMock()
     c._translator = NamespaceTranslator(modernize=modernize, emit_legacy=emit_legacy)
+    c._wire_legacy_twins = wire_legacy_twins
     c._handler_guards = {}
     c._intent_pair_guards = {}
     c._dedup_registrations = {}
@@ -251,6 +252,64 @@ class TestFlagGating(unittest.TestCase):
                 c = _client(emit_legacy=emit_legacy)
                 c.emit(Message("some.unmapped.topic", {"a": 1}))
                 self.assertEqual(_sent(c), ["some.unmapped.topic"])
+
+
+class TestWireLegacyTwinsFlagGating(unittest.TestCase):
+    """``OVOS_BUS_WIRE_LEGACY_TWINS`` is the escape hatch for the namespace
+    wire twin, DEFAULT TRUE (symmetric with ``OVOS_BUS_EMIT_LEGACY``): the
+    twin exists to reach a STABLE (<2.x) pre-spec-tools wire listener, the
+    supported compat target, so it stays on unless an operator explicitly
+    knows no such listener shares the bus.
+
+    A 2.2.0a1..2.8.2a1 receiver double-delivers while sharing a bus with a
+    2.8.3a1+ sender running the default -- that outdated-alpha window is not
+    a supported configuration and is resolved by updating the receiver, not
+    by this flag.
+    """
+
+    def test_flag_defaults_true(self):
+        # no env var and empty config -> the default (True) is returned,
+        # exercising _bus_flag() itself rather than the _client() test
+        # helper's own default.
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "OVOS_BUS_WIRE_LEGACY_TWINS"}
+        with patch.dict("os.environ", env, clear=True), \
+                patch("ovos_config.Configuration", return_value={}):
+            self.assertTrue(_bus_flag("OVOS_BUS_WIRE_LEGACY_TWINS",
+                                      "wire_legacy_twins", default=True))
+
+    def test_env_can_disable(self):
+        with patch.dict("os.environ", {"OVOS_BUS_WIRE_LEGACY_TWINS": "false"}):
+            self.assertFalse(_bus_flag("OVOS_BUS_WIRE_LEGACY_TWINS",
+                                       "wire_legacy_twins", default=True))
+
+    def test_flag_explicitly_off_single_frame(self):
+        c = _client(wire_legacy_twins=False)
+        c.emit(Message(CANONICAL, {"utterance": "hi"}))
+        self.assertEqual(_sent(c), [CANONICAL])
+
+    def test_flag_explicitly_off_leaves_intent_twin_untouched(self):
+        # the namespace-twin flag must not affect the separate intent-topic
+        # bridge (RULE 1 of test_intent_legacy_reemit.py).
+        c = _client(wire_legacy_twins=False)
+        c.emit(Message("skill-food.jarbas:food.order", {"a": 1}))
+        self.assertEqual(_sent(c), ["skill-food.jarbas:food.order",
+                                    "skill-food.jarbas:food.order.intent"])
+
+    def test_flag_explicitly_off_receiver_still_dedups_a_twin_from_a_peer(self):
+        # marker-popping in on_message stays unconditional: a 2.8.4a1+
+        # receiver must dedup an incoming twin regardless of its OWN send
+        # flag, because the twin came from a peer that has it on.
+        c = _client(wire_legacy_twins=False)
+        canon_seen = _received(c, CANONICAL)
+        legacy_seen = _received(c, LEGACY)
+        _deliver(c, CANONICAL, {"utterance": "hi"})
+        self.assertEqual(len(canon_seen), 1)
+        self.assertEqual(len(legacy_seen), 1)  # via the receive-side bridge
+        _deliver(c, LEGACY, {"utterance": "hi"},
+                {NAMESPACE_COMPAT_TWIN_KEY: True})
+        self.assertEqual(len(canon_seen), 1)   # unchanged: twin deduped
+        self.assertEqual(len(legacy_seen), 1)  # unchanged: twin deduped
 
 
 class TestFirehoseIsNotDoubled(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.
> Verified against current `origin/dev` source and a live pytest run in this session (not re-verified by a human): the #286 client.py diff, the pre-change test baseline, and the post-change green run.

#286 made every canonical (`ovos.*`) emit of a `MIGRATION_MAP` topic also put a real second wire frame on the legacy spelling, unconditionally. That is the right compat path for the actually-supported population: the latest stable `ovos-bus-client` release (1.5.0, pre-spec-tools) and anything older, which has no `NamespaceTranslator` at all and can only ever be reached by a literal wire frame on the spelling it is subscribed to.

It also has a documented side effect on receivers in the 2.2.0a1..2.8.2a1 alpha window: those clients already bridge both spellings locally from the canonical frame alone (the existing `counterpart_topics()` receive-side loop), so a real twin on top of that is a second, indistinguishable delivery of the same logical event to every handler bound on either spelling. Per current project policy, only the latest prerelease is a supported configuration, so that window is not a compat obligation this client needs to defend against — it's a transient hazard of running an outdated alpha, resolved by updating the receiver to 2.8.3a1+ (which already dedups the twin via `NAMESPACE_COMPAT_TWIN_KEY`).

This PR adds `OVOS_BUS_WIRE_LEGACY_TWINS` (env var, or `websocket.wire_legacy_twins` in config, read through the existing `_bus_flag` helper), default TRUE, symmetric with `OVOS_BUS_EMIT_LEGACY`. Setting it false drops the namespace twin entirely — single frame, canonical spelling only — for buses where the operator knows no pre-spec-tools stable listener is present and wants the bandwidth back. Marker-popping in `on_message` stays unconditional regardless of this flag's own value, so a 2.8.4a1+ receiver still dedups an incoming twin sent by a peer that has the flag on. The intent-twin machinery and `OVOS_BUS_EMIT_LEGACY` semantics are untouched.

Recommended pattern for protecting genuinely old satellites without paying the wire-twin cost bus-wide: do the translation at a relay/hub that knows its own satellite population (e.g. a HiveMind hub bridging to known-old satellites), not in every sender.

## Test plan
- [x] Existing `#286` suite (`test_namespace_wire_twin.py`, `test_namespace_migration.py`, `test_intent_legacy_reemit.py`) client-construction helpers updated to set the new attribute explicitly; all pre-existing invariants pass unchanged because the new default matches the old unconditional behavior.
- [x] Added `TestWireLegacyTwinsFlagGating`: flag defaults true via `_bus_flag`, env var can disable it, explicit-off produces a single frame, explicit-off does not touch the separate intent-topic bridge, and a receiver with the flag off still dedups an incoming twin from a peer.
- [x] Red-verified: reverting only the `client.py` change (tests unchanged) fails `test_flag_explicitly_off_single_frame`.
- [x] Full suite: 805 passed / 6 skipped (baseline before this change: 800 passed / 6 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)