### PR TITLE
docs: prerelease-quirks changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Full developer docs live in [`docs/`](docs/):
 - [Common patterns](docs/patterns.md) — recipes for everyday use
 - [Testing](docs/testing.md) — `FakeBus`, isolating tests
 - [Migration from 1.x](docs/migration.md) — what moved out in 2.0
+- [Prerelease quirks](docs/prerelease-quirks.md) — what changed since the last stable release
 - [Development](docs/development.md) — repo layout, releases
 - [Glossary](docs/glossary.md) — terms
 

--- a/docs/namespace-migration.md
+++ b/docs/namespace-migration.md
@@ -144,6 +144,29 @@ closes the gap immediately.
 Nothing here is normative: no specification mandates the suffixed topic. New
 code must produce and consume canonical topics only.
 
+## Wire twin for non-intent namespace topics
+
+RULE 1/RULE 2 above cover intent-dispatch topics specifically. The same
+send-side rule also applies to every other topic in `MIGRATION_MAP`: a
+canonical (`ovos.*`) emit puts a real second wire frame on the legacy
+spelling (RULE 1), marked with the `_namespace_compat_twin` context key. The
+reverse direction needs no second wire frame — a legacy emit is already
+bridged to local canonical listeners on receive (RULE 2, via
+`counterpart_topics()`).
+
+This is gated by an escape-hatch flag: `OVOS_BUS_WIRE_LEGACY_TWINS` (env
+var) or `websocket.wire_legacy_twins` (config key), default `True`. Turn it
+off only when no listener on the bus still needs the real legacy-spelled
+wire frame. The supported target for this twin is stable `ovos-bus-client`
+1.5.0 (pre-`spec-tools`) and anything older, which has no
+`NamespaceTranslator` and cannot bridge a canonical-only emit itself.
+
+A receiver running an alpha in the 2.2.0a1..2.8.2a1 window is not a
+supported configuration (only the latest prerelease is supported): it
+already bridges both spellings locally from the canonical frame alone, so
+it double-delivers every migrated topic once the wire twin is also on the
+wire. Upgrade any such receiver.
+
 ## Rollout
 
 1. **Now** — both flags on by default; every migrated event is on both

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -1,0 +1,143 @@
+# Prerelease quirks
+
+This file lists everything that changed or broke since the last stable
+release, `1.5.0`. It is version-stamped and newest first. If you install an
+alpha of `ovos-bus-client`, read this before you file a bug: the behavior
+you are seeing may be documented here already.
+
+This file resets at the next stable release. At that point its contents
+become upgrade notes for the `1.5.0 -> next-stable` jump, and a new, empty
+quirks log starts.
+
+## 2.8.4a1
+
+Added an escape hatch for the namespace wire twin added in 2.8.3a1:
+`OVOS_BUS_WIRE_LEGACY_TWINS` (env var) or `websocket.wire_legacy_twins`
+(config key). Default is `True`. Turn it off only if you know no listener
+on the bus still needs the real legacy-spelled wire frame.
+
+## 2.8.3a1
+
+Every canonical (`ovos.*`) emit of a topic in `MIGRATION_MAP` now also puts
+a real second wire frame on the legacy spelling, not just intent-dispatch
+topics as before. This closes the gap for the actual supported population:
+stable `ovos-bus-client` 1.5.0 and anything older, which has no
+`NamespaceTranslator` at all and never sees a canonical-only emit reach a
+legacy-spelled subscription.
+
+Known quirk: a receiver running an alpha between 2.2.0a1 and 2.8.2a1 already
+bridges both spellings locally from the canonical frame alone. It is not a
+supported configuration (only the latest prerelease is supported), and it
+now double-delivers every migrated topic, because it gets both the local
+bridge and the new wire twin. Upgrade any such receiver to the current
+alpha.
+
+## 2.8.2a1
+
+`Session.__init__` and `get_message_lang()` used to call deprecated
+`ovos_config.locale` helpers on every construction, firing a
+`DeprecationWarning` on every utterance. Fixed: the tz path reads
+`get_config_tz()` directly; the lang path keeps calling the real helper
+through a small shared cache-aware wrapper, since `ovos-config` stable
+still keeps a private lang cache that `Configuration()` does not see.
+
+## 2.8.1a1
+
+Fixed a regression in double-registration handling. Wrapping every
+registration in a fresh closure (added for the intent-topic bridge and the
+namespace-migration mirror guard) broke the old behavior where registering
+the same handler twice on one topic collapsed onto one listener. `on()`
+already reused the wrapper for a repeat `(event_name, func)` pair; `once()`
+did not, so a handler bound via `once()` to both spellings of a mirrored
+topic could fire twice. `once()` now goes through the same dedup path as
+`on()`.
+
+## 2.8.0a1
+
+Added the legacy intent-topic bridge: a wire twin on emit, modernization on
+receive. Old cores build the per-intent dispatch topic as
+`<skill_id>:<intent_name>.intent` (leaking the padatious resource file
+extension); current `ovos-workshop` builds `<skill_id>:<intent_name>`. This
+release bridges both spellings so an old core and a new skill (or vice
+versa) still talk to each other. Documented in full in
+`docs/namespace-migration.md`. See RULE 1 (send) / RULE 2 (receive) in
+`ovos_bus_client/client/client.py`.
+
+## 2.7.3a1
+
+Fixed the bus CLIs (`ovos-speak`, `ovos-listen`, etc.) hanging forever when
+the messagebus is unreachable.
+
+## 2.7.2a1
+
+`blacklisted_pipelines` deployment default is now seeded from config
+instead of a hardcoded empty default.
+
+## 2.7.1a1
+
+A malformed `Session` on an inbound message is now rejected instead of
+silently accepted.
+
+## 2.7.0a1
+
+Legacy `Session.context` unified onto the canonical `intent_context` field.
+
+## 2.6.0a1 - 2.6.5a1
+
+Session/registry hardening: canonical Session list/dict fields always
+deserialize to empty containers instead of `None`; `SessionManager` keeps
+one live `Session` per id (singleton, no more duplicate instances);
+`Session.update_from` applies SESSION-1 deserialization semantics;
+`SessionManager` subclasses the `ovos-spec-tools` registry; the namespace
+bridge for a topic pair now bridges its counterpart on receive rather than
+emitting it as a second wire message; malformed bus/GUI frames are
+discarded instead of tearing down the connection; the bus-connected state
+is cleared on close/error.
+
+## 2.5.0a1 - 2.5.1a3
+
+`SessionManager` merges `intent_context` entry-by-entry
+(OVOS-CONTEXT-1 §5.3) instead of replacing the whole dict. A mirrored
+namespace payload is translated onto its counterpart topic correctly.
+`ovos.session.sync` now uses `SpecMessage.SESSION_SYNC`.
+
+## 2.4.0a1 - 2.4.1a1
+
+`Session` subclasses `ovos_spec_tools.Session` (canonical SESSION-1) with a
+back-compat shim. An unset `site_id` stays absent instead of being
+fabricated as `"unknown"` (BRIDGE-1 §3.3).
+
+## 2.3.0a1 - 2.3.0a2
+
+Namespace migration now uses the shared `NamespaceTranslator` from
+`ovos-spec-tools` instead of inline migration logic, with both flags on by
+default.
+
+## 2.2.0a1
+
+Namespace migration became **opt-in by default turned on**: both
+`modernize` and `emit_legacy` default to `True`, wired through
+`MessageBusClient` directly, with handler dedup for dual-listening
+callbacks (see `docs/namespace-migration.md`).
+
+## 2.1.2a2
+
+The transparent legacy `<->` `ovos.*` namespace migration first landed as
+opt-in (both flags default `False`). `EnclosureAPI` deprecated in favor of
+`ovos-gui-api-client`.
+
+## 2.1.0a1 - 2.1.2a1
+
+`Message` now subclasses `ovos_spec_tools.Message` with no API break.
+Restored legacy AES encryption at the websocket transport edge. Websocket
+`on_error` callbacks that are not exceptions are now ignored instead of
+raising.
+
+## 2.0.0a1 - 2.0.0a4
+
+Major version bump. The HiveMind agent protocol entry point
+(`hivemind.agent.protocol`) and the solver entry point
+(`neon.plugin.solver`) were removed from this package — see
+`docs/migration.md`. Language tags now go through
+`ovos_spec_tools.standardize_lang`. Test coverage raised from 19% to 93%
+real / 67% pytest-cov.


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Adds docs/prerelease-quirks.md: a version-stamped, newest-first list of everything that changed since the last stable release (1.5.0). This is a new standing rule across ovos-core, ovos-workshop and ovos-bus-client, so consumers running alphas have one place to check before filing a bug.

Every entry is checked against current source, not just the commit subject line. Along the way I found docs/namespace-migration.md did not cover the general namespace wire twin added in 2.8.3a1 or its OVOS_BUS_WIRE_LEGACY_TWINS escape hatch from 2.8.4a1, so I added a short section there too. README gets one link to the new file.

No code changes.