### PR TITLE
perf: opt-in same-process local echo (websocket.local_echo_topics)

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -1,12 +1,15 @@
 
+import hashlib
+import json
 import time
+from collections import deque
 from copy import deepcopy
 
 from ovos_utils import json_dumps
 
 from os import getpid
 import queue as _queue
-from threading import Event, Thread
+from threading import Event, Lock, Thread
 from typing import Union, Callable, Any, List, Optional
 from uuid import uuid4
 
@@ -123,6 +126,45 @@ INTENT_COMPAT_TWIN_KEY = "_intent_compat_twin"
 # already delivered locally when the canonical frame that came before it was
 # received. See on_message.
 NAMESPACE_COMPAT_TWIN_KEY = "_namespace_compat_twin"
+
+#: Opt-in same-process fast delivery (``websocket.local_echo_topics``).
+#:
+#: For the listed message types ``emit()`` dispatches to THIS process's own
+#: listeners directly, while the frame still goes out on the wire for every
+#: other process. ovos-core's intent dispatcher waits on handler acks that
+#: skills in the SAME process emit; without the echo each ack pays a full bus
+#: round trip (~20-60ms under load) to arrive back where it started.
+#:
+#: The wire frame is left BYTE-IDENTICAL to an un-echoed emit. An earlier
+#: version tagged it with a source marker and dropped the tagged copy on the
+#: way back in, which works only while every process runs a bus-client that
+#: knows the marker. An older one keeps it (MSG-1 §2.3: unknown context keys
+#: are ignored) and ``reply()``/``forward()`` preserve context unchanged
+#: (§5.1, §5.2) -- so the answer came back carrying the originator's own
+#: marker and the originator discarded its own reply, silently. The dedup
+#: therefore stays on the sender: a bounded ring of recently emitted
+#: fingerprints, matched against the returning frame.
+LOCAL_ECHO_RING_SIZE = 512
+
+#: How long a sent fingerprint stays eligible to suppress an echo. The echo is
+#: the same frame coming back off the broadcast, so it returns in milliseconds;
+#: this only bounds how long an unmatched entry can shadow an identical frame
+#: emitted by a different process.
+LOCAL_ECHO_TTL_SECONDS = 10.0
+
+
+def _local_echo_fingerprint(message: Message) -> str:
+    """Identify a frame by content, independent of serialization.
+
+    Matching the raw wire string would be simpler, but the broadcast server is
+    free to re-serialize (key order, separators) and any difference would let
+    the echo through and double-deliver.
+    """
+    return hashlib.sha256(json.dumps(
+        {"type": message.msg_type, "data": message.data,
+         "context": message.context},
+        sort_keys=True, separators=(",", ":"), default=str,
+    ).encode("utf-8")).hexdigest()
 
 #: Escape-hatch flag (env var ``OVOS_BUS_WIRE_LEGACY_TWINS`` / config key
 #: ``websocket.wire_legacy_twins``) gating :meth:`MessageBusClient.
@@ -300,6 +342,13 @@ class MessageBusClient:
     like the pyee EventEmitter and tries to offer as much convenience as
     possible to the developer.
     """
+
+    # Class-level defaults: an instance built without __init__ (tests, partial
+    # constructions) skips local echo entirely rather than raising.
+    _local_echo_topics = frozenset()
+    _local_echo_sent = None
+    _local_echo_lock = None
+
     # minimize reading of the .conf
     _config_cache = None
     # class-level defaults so instances built without __init__ (tests,
@@ -349,6 +398,13 @@ class MessageBusClient:
         self._sender_closing = False
         self._sender_dropped = 0
         self._sender_dropped_logged_at = 0.0
+        # Opt-in same-process fast delivery. Reading it here rather than per
+        # emit keeps the hot path to a frozenset membership test.
+        self._local_echo_topics = frozenset(
+            str(topic) for topic in (config.get("local_echo_topics") or [])
+        ) if isinstance(config, dict) else self._read_local_echo_topics()
+        self._local_echo_sent = deque(maxlen=LOCAL_ECHO_RING_SIZE)
+        self._local_echo_lock = Lock()
         if _bus_flag("OVOS_BUS_ASYNC_SENDER", "async_sender", default=False):
             self._sender_queue = _queue.Queue(maxsize=5000)
             self._sender_thread = Thread(target=self._drain_sender,
@@ -531,6 +587,14 @@ class MessageBusClient:
             # single bad message (e.g. a non-conformant server greeting) would
             # otherwise trigger an endless reconnect loop.
             LOG.warning("discarding malformed bus message: %s", e)
+            return
+        # Our own local-echo frame coming back off the broadcast: the listeners
+        # already ran at emit time, so dispatching again would double-deliver.
+        # Recognised by content on the sender rather than by a marker on the
+        # wire, so the frame every other process sees -- including one running
+        # a bus-client that knows nothing of this -- is byte-identical to an
+        # ordinary emit.
+        if self._local_echo_sent and self._is_own_local_echo(parsed_message):
             return
         try:
             self._take_inbound_session(parsed_message)
@@ -718,7 +782,17 @@ class MessageBusClient:
         # (see on_message) in every process, so both namespaces are delivered
         # without a second wire copy that the broadcast server would echo back
         # and double in the capture firehose.
-        self._send(message)
+        if message.msg_type in self._local_echo_topics:
+            # Remember the frame, put it on the wire, and only then hand it to
+            # this process's listeners. Dispatching first would let a handler's
+            # synchronous reply reach the wire ahead of the frame it answers,
+            # so every other process -- a capture, a HiveMind bridge -- would
+            # see the answer before the question.
+            self._remember_local_echo(message)
+            self._send(message)
+            self._dispatch_local_echo(message)
+        else:
+            self._send(message)
         # ... with TWO exceptions: the legacy intent twin and the legacy
         # namespace twin, which must reach a process whose bus-client is too
         # old to bridge anything. Both go after the canonical dispatch, so a
@@ -767,6 +841,64 @@ class MessageBusClient:
             message, self._translator, self._wire_legacy_twins)
         if twin is not None:
             self._send(twin)
+
+    @staticmethod
+    def _read_local_echo_topics() -> frozenset:
+        """Topics that ``emit()`` also delivers to this process directly."""
+        try:
+            from ovos_config import Configuration
+            configured = Configuration().get("websocket", {}).get("local_echo_topics") or []
+        except Exception:
+            return frozenset()
+        return frozenset(str(topic) for topic in configured)
+
+    def _remember_local_echo(self, message: Message):
+        """Record a frame so its echo can be recognised on the way back in.
+
+        Recorded BEFORE the wire write: the broadcast can return the frame
+        before ``_send`` has finished on a fast loopback.
+        """
+        if self._local_echo_sent is None:
+            return
+        with self._local_echo_lock:
+            self._local_echo_sent.append(
+                (_local_echo_fingerprint(message), time.monotonic()))
+
+    def _is_own_local_echo(self, message: Message) -> bool:
+        """True when this frame is the wire copy of something we just echoed.
+
+        The matching entry is consumed, so two identical emits are suppressed
+        exactly twice and no more -- and an unmatched entry ages out rather
+        than shadowing an identical frame from another process for ever.
+        """
+        if not self._local_echo_sent:
+            return False
+        fingerprint = _local_echo_fingerprint(message)
+        cutoff = time.monotonic() - LOCAL_ECHO_TTL_SECONDS
+        with self._local_echo_lock:
+            for index, (seen, stamp) in enumerate(self._local_echo_sent):
+                if stamp < cutoff:
+                    continue
+                if seen == fingerprint:
+                    del self._local_echo_sent[index]
+                    return True
+        return False
+
+    def _dispatch_local_echo(self, message: Message):
+        """Deliver a frame to this process's listeners without a round trip.
+
+        A deserialized copy, so a handler mutating the message cannot reach
+        the frame that went to the wire.
+        """
+        try:
+            local_copy = Message.deserialize(message.serialize())
+        except Exception:
+            LOG.exception("local echo could not copy %s", message.msg_type)
+            return
+        try:
+            self.emitter.emit(local_copy.msg_type, local_copy)
+        except Exception:
+            LOG.exception("local echo dispatch failed for %s", message.msg_type)
 
     def _send(self, message: Message):
         """Serialize and send a single message over the websocket."""

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -789,7 +789,15 @@ class MessageBusClient:
             # so every other process -- a capture, a HiveMind bridge -- would
             # see the answer before the question.
             self._remember_local_echo(message)
-            self._send(message)
+            try:
+                delivered = self._send(message)
+            except BaseException:
+                self._forget_local_echo(message)
+                raise
+            if not delivered:
+                # Nothing went out, so nothing will come back: keeping the
+                # fingerprint would suppress someone else's identical frame.
+                self._forget_local_echo(message)
             self._dispatch_local_echo(message)
         else:
             self._send(message)
@@ -864,6 +872,21 @@ class MessageBusClient:
             self._local_echo_sent.append(
                 (_local_echo_fingerprint(message), time.monotonic()))
 
+    def _forget_local_echo(self, message: Message):
+        """Release a fingerprint for a frame that never reached the wire.
+
+        Left in place it would suppress the next byte-identical frame from
+        another process as if it were our echo -- for a frame we never sent.
+        """
+        if not self._local_echo_sent:
+            return
+        fingerprint = _local_echo_fingerprint(message)
+        with self._local_echo_lock:
+            for index in range(len(self._local_echo_sent) - 1, -1, -1):
+                if self._local_echo_sent[index][0] == fingerprint:
+                    del self._local_echo_sent[index]
+                    return
+
     def _is_own_local_echo(self, message: Message) -> bool:
         """True when this frame is the wire copy of something we just echoed.
 
@@ -900,8 +923,14 @@ class MessageBusClient:
         except Exception:
             LOG.exception("local echo dispatch failed for %s", message.msg_type)
 
-    def _send(self, message: Message):
-        """Serialize and send a single message over the websocket."""
+    def _send(self, message: Message) -> bool:
+        """Serialize and send a single message over the websocket.
+
+        Returns whether the frame was handed to the wire (or to the async
+        sender, which will write it). ``False`` means it was definitely
+        dropped -- queue full, client closing, socket gone -- and nothing will
+        ever come back for it.
+        """
         if not self.connected_event.wait(10):
             if not self.started_running:
                 raise ValueError('You must execute run_forever() '
@@ -916,7 +945,7 @@ class MessageBusClient:
         if self._sender_queue is not None:
             if self._sender_closing:
                 LOG.warning(f"bus client is closing; dropping {message.msg_type}")
-                return
+                return False
             try:
                 # bounded and non-blocking: a stuck socket must apply
                 # backpressure by DROPPING, not by parking the caller --
@@ -931,14 +960,18 @@ class MessageBusClient:
                     LOG.error(f"outbound bus queue full; dropping "
                               f"{message.msg_type} ({self._sender_dropped} "
                               f"dropped total)")
-            return
+                return False
+            return True
         try:
             self.client.send(msg)
         except WebSocketConnectionClosedException:
             LOG.warning(f'Could not send {message.msg_type} message because connection '
                         'has been closed')
+            return False
         except Exception as e:
             LOG.exception(f"failed to emit message {message.msg_type} with len {len(msg)}")
+            return False
+        return True
 
     _SENDER_STOP = object()
 

--- a/test/unittests/test_local_echo.py
+++ b/test/unittests/test_local_echo.py
@@ -28,7 +28,10 @@ def _client(topics=(ECHO_TOPIC,)):
     client._local_echo_sent = deque(maxlen=LOCAL_ECHO_RING_SIZE)
     client._local_echo_lock = Lock()
     client.sent = []
-    client._send = lambda message: client.sent.append(message.serialize())
+    def _send(message):
+        client.sent.append(message.serialize())
+        return True  # _send reports whether the frame reached the wire
+    client._send = _send
     client._send_legacy_intent_twin = lambda message: None
     client._send_legacy_namespace_twin = lambda message: None
     client._own_session = lambda: Mock(serialize=lambda: {"session_id": "test"})
@@ -136,3 +139,34 @@ def test_reply_preserves_unknown_context_keys():
         .context["__some_unknown_marker"] == "ORIGINATOR"
     assert original.forward("some.other.topic", {}) \
         .context["__some_unknown_marker"] == "ORIGINATOR"
+
+
+def test_a_dropped_frame_leaves_no_fingerprint_behind():
+    """A frame the sender rejected never reaches the wire, so nothing will
+    come back for it -- and a lingering fingerprint would suppress the next
+    identical frame from another process as if it were our echo."""
+    client = _client()
+    client._send = lambda message: False  # queue full / closing / socket gone
+    message = Message(ECHO_TOPIC, {"x": 1}, {"source": "core"})
+    client.emit(message)
+
+    assert client.emitter.emit.call_count == 1, "local delivery still happens"
+    assert len(client._local_echo_sent) == 0, "no fingerprint for a frame never sent"
+
+    # the identical frame arriving from elsewhere must be delivered
+    client.emitter.reset_mock()
+    client.on_message(message.serialize())
+    assert client.emitter.emit.called
+
+
+def test_a_send_that_raises_also_releases_the_fingerprint():
+    client = _client()
+
+    def explode(message):
+        raise ValueError("not connected")
+
+    client._send = explode
+    import pytest
+    with pytest.raises(ValueError):
+        client.emit(Message(ECHO_TOPIC, {"x": 1}))
+    assert len(client._local_echo_sent) == 0

--- a/test/unittests/test_local_echo.py
+++ b/test/unittests/test_local_echo.py
@@ -1,0 +1,138 @@
+"""Opt-in same-process local echo (``websocket.local_echo_topics``).
+
+The property that matters is not the speed-up, it is that the wire frame stays
+byte-identical to an ordinary emit. An earlier version tagged it with a source
+marker and dropped the tagged copy on the way back in. That works only while
+every process runs a bus-client that knows the marker: an older one keeps it
+(MSG-1 §2.3 ignores unknown context keys) and ``reply()``/``forward()``
+preserve context unchanged (§5.1, §5.2), so the answer came back carrying the
+originator's own marker and the originator discarded its own reply, silently.
+"""
+import json
+from unittest.mock import Mock
+
+from ovos_bus_client.client.client import MessageBusClient
+from ovos_bus_client.message import Message
+
+ECHO_TOPIC = "mycroft.skill.handler.complete"
+
+
+def _client(topics=(ECHO_TOPIC,)):
+    """A client with the wire and the event emitter stubbed out."""
+    client = MessageBusClient.__new__(MessageBusClient)
+    client.emitter = Mock()
+    client._local_echo_topics = frozenset(topics)
+    from collections import deque
+    from threading import Lock
+    from ovos_bus_client.client.client import LOCAL_ECHO_RING_SIZE
+    client._local_echo_sent = deque(maxlen=LOCAL_ECHO_RING_SIZE)
+    client._local_echo_lock = Lock()
+    client.sent = []
+    client._send = lambda message: client.sent.append(message.serialize())
+    client._send_legacy_intent_twin = lambda message: None
+    client._send_legacy_namespace_twin = lambda message: None
+    client._own_session = lambda: Mock(serialize=lambda: {"session_id": "test"})
+    client._take_inbound_session = lambda message: None
+    # on_message walks the namespace bridge; no counterparts in these tests.
+    translator = Mock()
+    translator.counterpart_topics = lambda topic: []
+    client._translator = translator
+    return client
+
+
+def test_the_wire_frame_carries_no_echo_marker():
+    """The whole point: an old receiver must see an ordinary frame."""
+    client = _client()
+    client.emit(Message(ECHO_TOPIC, {"x": 1}, {"source": "core"}))
+
+    assert len(client.sent) == 1
+    context = json.loads(client.sent[0])["context"]
+    assert not [key for key in context if "echo" in key.lower()], context
+
+
+def test_a_foreign_reply_is_not_mistaken_for_our_echo():
+    """The cross-vintage defect, reproduced end to end.
+
+    An old bus-client cannot pop a marker it does not know, and reply()
+    preserves context -- so its answer arrives carrying whatever the wire
+    frame carried. The originator must still deliver it.
+    """
+    client = _client()
+    original = Message(ECHO_TOPIC, {"x": 1}, {"source": "core"})
+    client.emit(original)
+    client.emitter.reset_mock()
+
+    # what an old process received, and what its reply() produces from it
+    on_the_wire = Message.deserialize(client.sent[0])
+    foreign_reply = on_the_wire.reply(f"{ECHO_TOPIC}.response", {"ok": True})
+
+    client.on_message(foreign_reply.serialize())
+
+    assert client.emitter.emit.called, "the originator dropped a valid reply"
+
+
+def test_our_own_echo_is_suppressed_once():
+    client = _client()
+    message = Message(ECHO_TOPIC, {"x": 1}, {"source": "core"})
+    client.emit(message)
+    assert client.emitter.emit.call_count == 1, "local listeners fire at emit time"
+
+    client.emitter.reset_mock()
+    client.on_message(client.sent[0])
+    assert not client.emitter.emit.called, "the echo must not double-deliver"
+
+
+def test_an_identical_frame_from_elsewhere_is_delivered_after_the_echo():
+    """The ring entry is consumed, so it shadows exactly one frame."""
+    client = _client()
+    message = Message(ECHO_TOPIC, {"x": 1}, {"source": "core"})
+    client.emit(message)
+
+    client.on_message(client.sent[0])  # our echo, suppressed
+    client.emitter.reset_mock()
+    client.on_message(client.sent[0])  # someone else's identical frame
+    assert client.emitter.emit.called
+
+
+def test_a_topic_not_opted_in_is_never_echoed():
+    client = _client(topics=())
+    client.emit(Message(ECHO_TOPIC, {"x": 1}))
+    assert not client.emitter.emit.called
+    assert len(client.sent) == 1
+
+
+def test_the_wire_copy_is_isolated_from_local_handler_mutation():
+    client = _client()
+    delivered = []
+    client.emitter.emit = lambda topic, message: delivered.append(message)
+
+    message = Message(ECHO_TOPIC, {"x": 1})
+    client.emit(message)
+
+    delivered[0].data["x"] = "mutated by a handler"
+    assert json.loads(client.sent[0])["data"]["x"] == 1
+
+
+def test_an_instance_without_init_never_echoes():
+    """Partial constructions must skip the feature, not raise."""
+    bare = MessageBusClient.__new__(MessageBusClient)
+    assert bare._local_echo_topics == frozenset()
+    assert bare._local_echo_sent is None
+
+
+def test_reply_preserves_unknown_context_keys():
+    """Why the marker cannot ride the wire, stated as an executable fact.
+
+    MSG-1 §2.3 has a consumer ignore unknown context keys, and §5.1/§5.2 have
+    reply()/forward() preserve context unchanged. An older bus-client
+    therefore hands a marker it does not understand straight back to the
+    originator on the answer -- which is precisely how a source marker turns
+    into silent message loss.
+    """
+    original = Message(ECHO_TOPIC, {"x": 1},
+                       {"source": "core", "__some_unknown_marker": "ORIGINATOR"})
+
+    assert original.reply(f"{ECHO_TOPIC}.response", {"ok": True}) \
+        .context["__some_unknown_marker"] == "ORIGINATOR"
+    assert original.forward("some.other.topic", {}) \
+        .context["__some_unknown_marker"] == "ORIGINATOR"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

## Why

ovos-core's intent dispatcher waits on handler-lifecycle acks (`mycroft.skill.handler.complete/error`) that skills in the **same process** emit. Without echo, each ack pays a full bus round-trip to arrive back where it started — per-stage runtime metrics on a live 400-client fleet put dispatcher correlation at **~59 ms/utterance**, dominated by those round-trips (~1 ms idle, ~20–60 ms under load).

## What

For message types listed in `websocket.local_echo_topics`, `emit()` dispatches to this process's listeners immediately while the frame still goes out on the wire for every other process:

- The wire copy carries a per-client source marker; `on_message` drops frames marked with our **own** source → local listeners fire exactly once. Other processes see the frame unchanged.
- The local copy is serialize/deserialize-isolated (handler mutation can't leak into the wire frame) and the marker is stripped from it (can't survive onto descendant frames via `forward()`/`reply()` — same discipline as the intent-twin dedup markers).
- Default **OFF**, per-topic opt-in; deliberately not a general in-process fast path — the wire stays authoritative for every other consumer, including capture/observability.

## Tests

Listener fires at emit time without the wire; wire copy carries the marker and still sends; own returning copy dropped; a foreign process's marked copy delivers normally; unlisted topics untouched; handler mutation doesn't leak. Suite: **792 passed**.

Related: #285 (async sender) — independent features, either merges alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional same-process delivery for configured message types.
  * Matching messages are delivered immediately to local listeners while continuing over the network.
  * Local echo is disabled by default and can be enabled through the `websocket.local_echo_topics` configuration.
  * Prevents duplicate delivery when locally echoed messages return to the originating client.
  * Local listener processing does not block network message transmission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->