### PR TITLE
fix: avoid calling deprecated get_default_lang() at session import time

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,13 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `1.5.0 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## 2.8.4a3
+
+Importing `ovos_bus_client.session` no longer emits an ovos-config
+deprecation notice. The module-level default `Session` resolves its default
+lang by reading `Configuration()` directly instead of calling the
+deprecated `get_default_lang()`. The `ovos-config` floor is now `1.0.0`.
+
 ## 2.8.4a1
 
 Added an escape hatch for the namespace wire twin added in 2.8.3a1:

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1,12 +1,10 @@
 import enum
 import time
-import warnings
 from threading import Event, RLock
 from typing import Optional, List, Tuple, Union, Iterable, Dict, Any
 from uuid import uuid4
 
 from ovos_config.config import Configuration
-from ovos_config.locale import get_default_lang
 from ovos_utils.log import LOG, log_deprecation
 from ovos_spec_tools import standardize_lang, SpecMessage
 from ovos_spec_tools.context import resolve_key
@@ -27,23 +25,13 @@ _NEXT_MAJOR_VERSION = f"{VERSION_MAJOR + 1}.0.0"
 def _get_default_lang() -> str:
     """Read the runtime-configured default lang.
 
-    This is a hot path (every ``Session``/``Message`` without an explicit
-    lang goes through it), so it must not spam a DeprecationWarning on every
-    call. ``ovos_config.locale.get_default_lang()`` is deprecated in favor of
-    reading ``Configuration()`` directly -- but only in ovos-config releases
-    where the two are equivalent. Older ovos-config releases (still allowed
-    by this package's ``ovos-config<3.0.0`` floor) keep a private
-    ``_lang`` module-global set by ``setup_locale()``/``set_default_lang()``
-    that ``Configuration()`` does NOT see, and in those releases
-    ``get_default_lang()`` isn't deprecated at all. There is no public
-    accessor that is cache-aware on both release lines, so we keep calling
-    the real (possibly deprecated) function -- preserving behavior on every
-    supported ovos-config version -- and just swallow its own warning here.
+    This is a hot path: every ``Session``/``Message`` without an explicit
+    lang goes through it, including the module-level default session built
+    at import time. Reading ``Configuration()`` directly is what ovos-config
+    has recommended since ``get_default_lang()`` was deprecated in
+    ovos-config 1.0.0.
     """
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning,
-                                message=".*ovos_config.Configuration.*")
-        return get_default_lang()
+    return Configuration().get("lang", "en-us")
 
 # Bidirectional-wire back-compat: the canonical parent applies SESSION-1 §2.1
 # omit-when-empty semantics and stores an *empty* collection field as ``None``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "ovos-config>=0.0.12,<3.0.0",
+    "ovos-config>=1.0.0,<3.0.0",
     "ovos-utils>=0.8.2,<1.0.0",
     "ovos-spec-tools[langcodes]>=1.7.0a1",  # narrowed is_intent_topic + intent-pair mirror guard
     "websocket-client>=0.54.0",

--- a/test/unittests/test_deprecation_noise.py
+++ b/test/unittests/test_deprecation_noise.py
@@ -1,0 +1,27 @@
+"""Importing ``ovos_bus_client.session`` builds a default ``Session`` at
+module top-level, which resolves the default lang. That resolution must not
+call ovos-config's deprecated ``get_default_lang()`` on ovos-config releases
+where it is deprecated, or every process that imports this package emits a
+DeprecationWarning it never asked for.
+
+Runs in a fresh interpreter: module top-level code runs once per process, so
+counting in-process would hide the very notice under test.
+"""
+
+import subprocess
+import sys
+import unittest
+
+
+class TestSessionImportDeprecationNoise(unittest.TestCase):
+    def test_session_import_emits_no_deprecation_notice(self):
+        proc = subprocess.run(
+            [sys.executable, "-c", "import ovos_bus_client.session"],
+            capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, f"import failed:\n{proc.stderr}")
+        self.assertNotIn("Deprecation version=", proc.stdout)
+        self.assertNotIn("Deprecation version=", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`ovos_bus_client.session` builds a module-level default `Session` at import time, and resolving its default lang called ovos-config's deprecated `get_default_lang()` on every single import of this package. That fires a `DeprecationWarning`/log notice unconditionally, with no way for a consumer to opt out, and trips deprecation-noise gates in downstream packages such as ovos-plugin-manager's `test_deprecation_noise.py`, which fail as soon as they import anything that pulls in `ovos_bus_client.session`.

The fix makes `_get_default_lang()` read `Configuration().get("lang", "en-us")` directly instead of calling `get_default_lang()`. There is no version branch: on every ovos-config release from 1.0.0 onward, `get_default_lang()` is literally that same `Configuration()` read (verified against `ovos_config/locale.py` on ovos-config's `dev` branch), so calling it directly is behavior-preserving, not a workaround. This package's `ovos-config` floor is bumped from `>=0.0.12` to `>=1.0.0` to guarantee that equivalence; ovos-config's current stable release is 2.1.1, well above the new floor.

`test/unittests/test_deprecation_noise.py` imports `ovos_bus_client.session` in a fresh subprocess and asserts no deprecation notice is emitted on stdout/stderr. Fail-before evidence: running this test against `origin/dev`'s unmodified `session.py` fails with `AssertionError: 'Deprecation version=' unexpectedly found in '... Deprecation version=1.0.0. Caller=ovos_bus_client.session:46 ...'`; running it against this branch's `session.py` passes. The full unit suite (`test/unittests`) passes: 806 passed, 6 skipped, 112 subtests passed, with no regressions.

Claims verified by actually running code (not by re-reading the source and assuming): the fail-before/fail-after test transition above, the full-suite run, and the `pyproject.toml` floor bump. The claim about `ovos_config.locale.get_default_lang()` being equivalent to `Configuration().get("lang", "en-us")` on every ovos-config release >=1.0.0 was verified by reading `ovos_config/locale.py` on ovos-config's `dev` branch, not by executing ovos-config's own test suite.
