### PR TITLE
fix: make close() stop a client that is reconnecting

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -18,6 +18,23 @@ quirks log starts.
 no-op: no error, the event just never updated. Fixed by emitting the
 spelling the scheduler actually listens on.
 
+`close()` used to only close the currently-active websocket object. A
+client caught inside `on_error()`'s reconnect backoff (sleep, recreate the
+websocket, recurse into `run_forever()` -- all on the same thread
+`run_in_thread()` started) ignored that and reconnected again after
+`close()` had already returned, so the receiver thread could outlive
+`close()` indefinitely instead of stopping within a bounded join. `close()`
+now sets a `_closing` flag that the reconnect path checks before sleeping,
+before recreating the websocket, and before recursing, so a client mid-
+backoff actually stops.
+
+The flag is initialised in `__init__` and reset in `run_in_thread()`
+BEFORE the new thread is started, not inside `run_forever()`'s body: a
+`close()` landing between `run_in_thread()` returning and the thread
+actually reaching `run_forever()` would otherwise be undone the instant
+the thread got there, and the client would reconnect right after being
+told to close.
+
 ## 2.8.4a3
 
 Importing `ovos_bus_client.session` no longer emits an ovos-config

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -265,6 +265,13 @@ class MessageBusClient:
         self.retry = 5
         self.connected_event = Event()
         self.started_running = False
+        # Set by close() to short-circuit the reconnect-backoff recursion in
+        # on_error(): that handler sleeps, recreates the websocket and
+        # recurses into run_forever() on the SAME thread run_in_thread()
+        # started, so close()ing only the currently-active websocket object
+        # does not stop a client that is mid-backoff -- it just reconnects
+        # again after close() has already returned control to the caller.
+        self._closing = False
         self.wrapped_funcs = {}
         # namespace translation on emit (orthogonal, both ON by default during
         # the migration window so every migrated event travels on BOTH the
@@ -370,12 +377,19 @@ class MessageBusClient:
         except Exception as e:
             LOG.error(f'Exception closing websocket at {self.client.url}: {e}')
 
+        if self._closing:
+            return
+
         LOG.warning("Message Bus Client "
                     "will reconnect in %.1f seconds.", self.retry)
         time.sleep(self.retry)
+        if self._closing:
+            return
         self.retry = min(self.retry * 2, 60)
         try:
             self.emitter.emit('reconnecting')
+            if self._closing:
+                return
             self.client = self.create_client()
             self.run_forever()
         except WebSocketException:
@@ -950,12 +964,25 @@ class MessageBusClient:
     def close(self):
         """
         Close the websocket connection.
+
+        Also stops a client that is currently inside on_error()'s
+        reconnect-backoff (sleep -> recreate websocket -> recurse into
+        run_forever(), all on the same thread): without this flag that
+        recursion is unaffected by closing the momentarily-active websocket
+        object, and the receiver thread survives close() indefinitely.
         """
+        self._closing = True
         self.client.close()
         self.connected_event.clear()
 
     def run_in_thread(self):
         """Launches the run_forever in a separate daemon thread."""
+        # Reset BEFORE the thread starts, not inside run_forever(): if the
+        # reset happened in run_forever() a close() landing between the
+        # thread's creation and it actually reaching run_forever() would be
+        # undone the instant the thread got there, and the client would
+        # reconnect right after being told to close.
+        self._closing = False
         t = Thread(target=self.run_forever)
         t.daemon = True
         t.start()

--- a/test/unittests/test_client.py
+++ b/test/unittests/test_client.py
@@ -54,6 +54,91 @@ class TestMessageBusClient(unittest.TestCase):
         # TODO
         pass
 
+    def test_close_stops_reconnecting_client(self):
+        """on_error()'s reconnect path (sleep -> recreate websocket ->
+        recurse into run_forever(), all on the receiver thread) must be
+        stopped by close(), even while it is mid-backoff. Before the
+        ``_closing`` flag, close() only closed the momentarily-active
+        websocket object and had no effect on the recursion, so the
+        receiver thread survived close() indefinitely."""
+
+        class FlakyWSApp:
+            """Fails to connect every time, driving on_error() in a loop."""
+
+            def __init__(self, on_error=None, **_kwargs):
+                self.keep_running = True
+                self._on_error = on_error
+
+            def run_forever(self, *_args, **_kwargs):
+                self._on_error(ConnectionRefusedError())
+
+            def close(self):
+                self.keep_running = False
+
+        mc = MessageBusClient()
+        mc.retry = 0  # keep the backoff sleep negligible
+        mc.create_client = lambda: FlakyWSApp(on_error=mc.on_error)
+        mc.client = mc.create_client()
+
+        t = mc.run_in_thread()
+        import time as _time
+        _time.sleep(0.05)  # let it spin through on_error a few times
+        mc.close()
+        t.join(2)
+        self.assertFalse(t.is_alive())
+
+    def test_close_before_thread_starts_prevents_reconnect(self):
+        """A close() landing between run_in_thread() returning and the
+        thread actually reaching run_forever() must not be undone. The
+        ``_closing`` reset must happen in run_in_thread() BEFORE the thread
+        starts (or in __init__), never inside run_forever()'s body: resetting
+        it there would clear a close() that already landed the instant the
+        thread got there, and the client would reconnect right after being
+        told to close."""
+
+        calls = []
+
+        class FlakyWSApp:
+            def __init__(self, on_error=None, **_kwargs):
+                self.keep_running = True
+                self._on_error = on_error
+
+            def run_forever(self, *_args, **_kwargs):
+                calls.append(1)
+                self._on_error(ConnectionRefusedError())
+
+            def close(self):
+                self.keep_running = False
+
+        mc = MessageBusClient()
+        mc.retry = 0
+        mc.create_client = lambda: FlakyWSApp(on_error=mc.on_error)
+        mc.client = mc.create_client()
+
+        captured = {}
+
+        def fake_thread(target=None, **_kwargs):
+            captured['target'] = target
+            fake_t = Mock()
+            fake_t.daemon = False
+            fake_t.start = Mock()  # intentionally a no-op: the thread body
+            # is invoked manually below, AFTER close(), to simulate a
+            # thread that has not yet reached run_forever() when close()
+            # lands.
+            fake_t.is_alive = Mock(return_value=False)
+            return fake_t
+
+        with patch('ovos_bus_client.client.client.Thread', side_effect=fake_thread):
+            mc.run_in_thread()  # resets _closing=False, "starts" the fake thread
+            mc.close()          # close() lands before the thread body ever runs
+            captured['target']()  # the thread finally reaches run_forever()
+
+        # run_forever() must have made exactly one connection attempt and
+        # on_error() must not have slept/recreated/reconnected, because
+        # _closing was already True by the time it got there.
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(mc._closing)
+
     def test_on_message(self):
         # TODO
         pass


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`MessageBusClient.close()` only closed the websocket object that happened to be active at the moment it was called. It never had any way to stop the reconnect logic in `on_error()`, which on a transport error sleeps for the current backoff, recreates the websocket, and recurses into `run_forever()` — all on the same OS thread `run_in_thread()` started. Calling `close()` while the client was mid-sleep or about to recreate its websocket did nothing to that recursion: the thread reconnected again right after `close()` had already returned control to the caller, so a shutdown path could leave the receiver thread running indefinitely instead of exiting within a bounded window.

The fix adds a `_closing` flag, initialised in `__init__` and set by `close()`. The reconnect path in `on_error()` checks it three times — before the backoff sleep, before recreating the websocket, and before recursing into `run_forever()` — and returns immediately if it is set, letting the thread unwind instead of reconnecting. The flag is reset in `run_in_thread()`, right before the new thread is started — deliberately not inside `run_forever()`'s body. An earlier version of this fix reset it there, which reintroduced a narrower race: `run_in_thread()` returns as soon as the thread object exists, and if `close()` landed in the gap before that thread actually reached `run_forever()`, the reset inside `run_forever()` would clear the flag `close()` had just set, and the client reconnected anyway. `close()`'s existing behavior (closing the active websocket object and clearing `connected_event`) is unchanged; nothing about the wire protocol or the public API surface changed beyond the new internal flag.

Two regression tests live in `test/unittests/test_client.py`. `test_close_stops_reconnecting_client` replaces `create_client()` with a fake `WebSocketApp` whose `run_forever()` always raises `ConnectionRefusedError` into `on_error()`, driving the client into a tight reconnect loop, then calls `close()` and joins the receiver thread with a 2s timeout, asserting the thread is not alive. `test_close_before_thread_starts_prevents_reconnect` patches `Thread` so the thread body is captured but not run, calls `run_in_thread()` then `close()` (simulating `close()` landing before the thread ever reaches `run_forever()`), then invokes the captured thread body directly and asserts it made exactly one connection attempt with no reconnect. I confirmed both are real regression tests, not tautologies: reverting only the `client.py` change (keeping both tests) makes both fail — the first because the thread is still alive after the 2s join, the second with a `RecursionError` (the buggy `run_forever()`-body reset clears the flag `close()` had already set, so the fake connection failure recurses without ever stopping). Restoring the fix makes both pass. I ran the full `ovos-bus-client` unit test suite after the fix: 808 passed, 6 skipped, no regressions.

This is the root cause behind `OpenVoiceOS/ovos-core#870`'s open finding: that PR closes the bus client during shutdown and joins its receiver thread with a bounded timeout, but until this fix lands and releases, a client caught in reconnect-backoff at shutdown time can still outlive that join. #870's own regression test is currently fully mocked and cannot detect this failure mode; a materially better test for #870 needs this fix released first, since a real (non-mocked) `MessageBusClient` pointed at a closed port only actually stops reconnecting once `_closing` exists and is reset at the right point in `run_in_thread()`.

Everything above was verified by actually running the test and the full suite against this branch, not by reading the code and assuming; the fail-before/pass-after flip was produced by `git apply -R`/`git apply` on the source file only, keeping the test fixed.

