### PR TITLE
fix: allow ovos-config 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "ovos-config>=1.0.0,<3.0.0",
+    "ovos-config>=1.0.0,<4.0.0",
     "ovos-utils>=0.8.2,<1.0.0",
     "ovos-spec-tools[langcodes]>=1.7.0a1",  # narrowed is_intent_topic + intent-pair mirror guard
     "websocket-client>=0.54.0",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-config 3.0.0a1 is a breaking release that introduces AssistantConfig and removes the remote-config APIs. An adversarial sweep of this repo found no use of any API that was removed in that release, so the `<3.0.0` upper bound on the `ovos-config` dependency only blocks a compatible upgrade without protecting against any real incompatibility.

This raises the cap to `<4.0.0`, keeping the existing floor. This repo has no ovos-config-capping transitive dependency, so a normal install resolves `ovos-config==3.0.1a1` directly. The full unit test suite passed with 832 tests passing and 6 skipped, with no failures attributable to the new dependency version.

Merge after ovos-config 3.0.1a1: 3.0.0a1 is missing follow-up hardening that ships in 3.0.1a1.