### PR TITLE
feat: scheduled events service implementing SCHEDULER-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Full developer docs live in [`docs/`](docs/):
 - [Configuration](docs/configuration.md) — host, port, route, ssl
 - [Sessions](docs/session.md) — `Session`, `SessionManager`, `IntentContextManager`
 - [Waiters and collectors](docs/waiter_and_collector.md) — request/response and multi-reply patterns
-- [High-level APIs](docs/apis.md) — `GUIInterface`, `OCPInterface`, `EnclosureAPI`, scheduler
+- [High-level APIs](docs/apis.md) — `GUIInterface`, `OCPInterface`, `EnclosureAPI`
+- [Scheduled events](docs/scheduler.md) — firing an event at a wall-clock instant, once or on a recurrence
 - [CLI tools](docs/scripts.md) — `ovos-speak`, `ovos-listen`, `ovos-say-to`, `ovos-simple-cli`
 - [Common patterns](docs/patterns.md) — recipes for everyday use
 - [Testing](docs/testing.md) — `FakeBus`, isolating tests

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,8 @@ agent backends, or anything else that talks to an OVOS messagebus.
 ### Intermediate
 
 7. [Waiters and collectors](waiter_and_collector.md) — request/response and multi-reply patterns.
-8. [High-level APIs](apis.md) — `GUIInterface`, `OCPInterface`, `EnclosureAPI`, `EventSchedulerInterface`.
+8. [High-level APIs](apis.md) — `GUIInterface`, `OCPInterface`, `EnclosureAPI`.
+8. [Scheduled events](scheduler.md) — `ScheduledEventService`, `EventSchedulerInterface`.
 9. [CLI tools](scripts.md) — `ovos-listen`, `ovos-speak`, `ovos-say-to`, `ovos-simple-cli`.
 10. [Common patterns](patterns.md) — request/reply, broadcast, session scoping, reconnect.
 11. [Testing](testing.md) — `FakeBus`, isolating tests, asserting bus traffic.

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -96,37 +96,25 @@ The class is a thin emitter — every method maps one-to-one to a Mycroft
 enclosure message type. Read the source for the full method list; it is more
 exhaustive than this doc would be useful at.
 
-## `EventSchedulerInterface` — `ovos_bus_client/apis/events.py:12`
+## `EventSchedulerInterface` — `ovos_bus_client/apis/events.py`
 
-Schedule one-shot and repeating events through the OVOS event scheduler.
+Fire a named event on the bus at a wall-clock instant, once or on a
+recurrence.
 
 ```python
+from datetime import datetime, timedelta, timezone
 from ovos_bus_client.apis.events import EventSchedulerInterface
-from datetime import datetime, timedelta
 
-es = EventSchedulerInterface(bus=bus, skill_id="my.skill")
-
-es.schedule_event(
-    handler=my_callback,
-    when=datetime.now() + timedelta(minutes=5),
-    data={"reason": "wake up"},
-    name="wakeup_timer",
-)
-
-es.schedule_repeating_event(
-    handler=heartbeat,
-    when=datetime.now(),
-    frequency=60,           # seconds
-    name="heartbeat",
-)
+events = EventSchedulerInterface(bus=bus, skill_id="my.skill")
+events.schedule("wakeup", handler=my_callback,
+                at=datetime.now(timezone.utc) + timedelta(minutes=5),
+                data={"reason": "wake up"})
 ```
 
-Cancel with `cancel_scheduled_event(name)`. Inspect with
-`get_scheduled_event_status(name)` (`events.py:185`). Tear everything down
-with `shutdown()` (`events.py:224`).
-
-Names are namespaced by `skill_id` internally (`events.py:44`) so two skills
-can use the same logical name without colliding.
+Read them back with `get(id)` and `list()`, drop one with `cancel(id)`, and
+tear the interface down with `shutdown()`. Timing forms, recurrence rules,
+the misfire policy and the store are covered in
+[Scheduled events](scheduler.md).
 
 ## Pattern: passing `source_message`
 

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,35 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `1.5.0 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## 2.9.1a2
+
+The event scheduler was rewritten against SCHEDULER-1 and now speaks a
+`scheduler.*` request/response protocol alongside the `mycroft.scheduler.*`
+topics, which keep working for one stable cycle and log a deprecation notice
+naming the release that drops them. `EventScheduler` is the new service under
+its old name, so nothing that starts it needs to change.
+
+Four behaviour changes are worth knowing about before you upgrade. The store
+moved from the XDG configuration directory to the XDG state directory, where
+it belongs; an existing `schedule.json` is copied there on first start and the
+original left in place. Recurring
+schedules now survive a restart instead of being deleted on shutdown. A
+one-shot that was due while the service was down now fires late within its
+grace period, or is reported on `scheduler.missed`, rather than being dropped
+silently. And scheduling the same name twice replaces rather than appends, so
+a skill that re-creates its schedules on boot no longer doubles them.
+
+The client derives a schedule's id from the event name alone when you do not
+pass one, so a component keeps one schedule per event and re-scheduling
+replaces it. Give explicit ids when one event needs several schedules.
+
+Two smaller changes can surface as a behaviour difference. A fired event now
+carries a fresh context holding only `context["scheduler"]`, so a session
+captured when the schedule was created is no longer replayed hours later. And
+`mycroft.scheduler.get_event` answers with `{"event": ..., "schedule": [...]}`
+instead of a bare list, because the message spec refuses a list-shaped
+payload and the old reply could not be constructed at all.
+
 ## 2.8.5a2
 
 `EventSchedulerInterface.update_scheduled_event()` emitted

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,151 @@
+# Scheduled events
+
+The scheduler fires a named event on the bus at a wall-clock instant, once
+or on a recurrence, on behalf of a component. It is the clock that alarms,
+timers, reminders and housekeeping jobs run on; the component that owns the
+schedule owns the meaning of the event, and the scheduler owns only the
+timing.
+
+The service is `ovos_bus_client.util.scheduled_events.ScheduledEventService`,
+also importable as `EventScheduler` from `ovos_bus_client.util.scheduler`,
+which is the name `ovos-core` starts it by. The component-facing client is
+`EventSchedulerInterface` in `ovos_bus_client.apis.events`. Both implement
+SCHEDULER-1; this page is the practical guide, the specification is the
+contract.
+
+## Scheduling from a component
+
+```python
+from datetime import datetime, timedelta, timezone
+from ovos_bus_client.apis.events import EventSchedulerInterface
+
+events = EventSchedulerInterface(bus=bus, skill_id="my.skill")
+
+schedule_id = events.schedule(
+    "wakeup",
+    handler=self.handle_wakeup,
+    at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    data={"alarm": "kitchen"},
+)
+```
+
+`schedule` namespaces the event to the component, so the message that
+eventually reaches the bus is `my.skill.wakeup`. It registers the handler
+before it sends the request, so an occurrence that is due immediately is
+not lost, and it waits for the scheduler's answer: a refusal is raised as
+`SchedulerError` carrying the wire error code, never swallowed.
+
+`at` must be a time-zone-aware datetime. A naive one is refused unless you
+pass `zone="Europe/Lisbon"` to say which zone to read it in — the process's
+local zone is never assumed on your behalf, because that is how an alarm
+ends up an hour out after a daylight-saving change.
+
+The other three timing forms are a fixed period, a wall-clock recurrence,
+and a relative delay:
+
+```python
+events.schedule("sync", every={"seconds": 3600})
+events.schedule("wake", local={"time": "07:30", "zone": "Europe/Lisbon",
+                               "days": ["mon", "tue", "wed", "thu", "fri"]})
+events.schedule("timer", in_seconds=300)
+```
+
+A fixed period is anchored on the schedule, not on the last fire, so a late
+fire does not make the whole series drift. A `local` recurrence is evaluated
+in the zone you named: when a spring-forward gap means the wall clock never
+reads your time, the occurrence is the first instant after the gap; when a
+fall-back overlap means it reads it twice, the occurrence is the first of
+the two. A relative delay runs off the monotonic clock while the service is
+up, so a clock correction cannot make it fire early or late.
+
+Bound a recurrence with `until` (an instant) or `count` (a number of
+occurrences). Mark a schedule `ephemeral=True` when it is meaningless
+outside your process; anything else outlives your restarts and the
+scheduler's.
+
+## Identity and replacement
+
+A schedule is identified by the pair (owner, id). Scheduling the same
+identity again replaces it atomically — there is no update request, and
+there are no duplicates. If you do not pass `schedule_id`, the client
+derives one from the event name alone. That means a component keeps one
+schedule per event: calling `schedule` again for the same event replaces it
+whatever the new timing is, so re-creating your schedules on start is the
+intended pattern and costs nothing. When one event genuinely needs several
+schedules — three alarms all firing `my.skill.alarm` — give each an explicit
+`schedule_id`, or the second will replace the first.
+
+An administrative component can read or cancel across every owner by sending
+`owner: "*"`, but only when its component id appears in the `scheduler.admins`
+allowlist in the configuration, which is empty by default. No schedule can be
+created under `*`. The allowlist is a misconfiguration guard, not a security
+boundary: on an unauthenticated bus any process can claim any component id, so
+it stops an honest component reaching across owners by accident and nothing
+more.
+
+Read them back with `events.get(schedule_id)` and `events.list()`. Both
+return the stored record alongside computed state: the next occurrence, the
+due instant of the last fire, the dues missed since that fire, and how many
+occurrences are left. Cancel with `events.cancel(schedule_id)`, which tells
+you whether the schedule existed.
+
+## The fired event
+
+The message the scheduler emits is a new message originating at the
+scheduler. Its `data` is the record's `data`, and its context carries only
+
+```python
+message.context["scheduler"]  # {"id", "owner", "due", "fired", "remaining"}
+```
+
+Nothing of the request that created the schedule is replayed — in
+particular no session identifier, which would be long dead by the time an
+alarm rings. Put whatever you need at fire time into `data`.
+
+## What happens when an occurrence is missed
+
+An occurrence is missed when it was due while the scheduler was down, or
+when the fire lands later than `grace_s` after the due instant. The
+record's `misfire` field decides what the scheduler does with it: `late`
+(the default) fires the most recent missed occurrence and drops the older
+ones, `skip` fires none, and `all` fires every one of them oldest first.
+
+Either way the scheduler emits `scheduler.missed` for the schedule, listing
+the dues that were missed and the ones it fired late. Treat it as the
+signal that something did not happen on time and decide what to tell the
+user. After a restart the scheduler reports every occurrence it produces,
+including one that may already have reached the bus in the instant before a
+crash, so deduplicate on the pair (id, due).
+
+When replay finishes the scheduler emits `scheduler.ready` with the number
+of schedules it restored, the number that had missed occurrences, and
+whether the clock is trusted yet. A device without a battery-backed clock
+starts with a wall clock behind the newest instant its store recorded as
+already past; in that state the scheduler still accepts and persists
+requests but does not evaluate them, and it replays once the clock catches
+up or `system.clock.synced` arrives.
+
+## The store
+
+Schedules live in `schedule.json` in the XDG state directory. Every accepted
+change is written with an atomic replace before the response goes out, and
+the due of each fired occurrence is written immediately after that event and
+before the next one leaves, so a crash leaves either the old state or the new
+one. Delivery is therefore at least once: a kill in the window between an
+event reaching the bus and its due reaching the store repeats that one
+occurrence on the next start, and nothing earlier. Handlers for a schedule
+that matters should be idempotent on the pair (id, due).
+
+A store left in the configuration directory by an older release is copied to
+the state directory on first start. The original is left where it is, so a
+downgrade still finds it; the copy is marked so it is not repeated.
+
+## The legacy protocol
+
+The `mycroft.scheduler.*` topics and the `schedule_event`,
+`schedule_repeating_event`, `update_scheduled_event`,
+`cancel_scheduled_event` and `get_scheduled_event_status` client methods
+still work and are answered by the same service, which maps an epoch float
+to an instant, `repeat` to a fixed period, and the `skill_id:` prefix of the
+event name to an owner. They emit a deprecation notice naming the release
+that drops them. New code uses the methods above.

--- a/ovos_bus_client/apis/events.py
+++ b/ovos_bus_client/apis/events.py
@@ -1,6 +1,8 @@
 import time
+import warnings
 from datetime import datetime, timedelta
 from typing import Callable, Optional, Union
+from zoneinfo import ZoneInfo
 
 from ovos_utils.events import EventContainer, create_basic_wrapper
 from ovos_bus_client.message import Message, dig_for_message
@@ -8,9 +10,38 @@ from ovos_utils.log import LOG
 from ovos_config.locale import get_config_tz
 from ovos_utils.time import now_local
 
+from ovos_bus_client.version import VERSION_MAJOR
+
+#: the legacy ``mycroft.scheduler.*`` wrappers go with the wire topics
+LEGACY_REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
+
+
+class SchedulerError(RuntimeError):
+    """A scheduler request the service refused, or did not answer."""
+
+    def __init__(self, error: str, reason: str):
+        super().__init__(f"{error}: {reason}")
+        self.error = error
+        self.reason = reason
+
+
+def _legacy_notice(method: str, replacement: str):
+    warnings.warn(
+        f"EventSchedulerInterface.{method} speaks the pre-specification "
+        f"mycroft.scheduler.* protocol; use {replacement} instead. It will "
+        f"be removed in ovos-bus-client {LEGACY_REMOVAL_VERSION}.",
+        DeprecationWarning, stacklevel=3)
+
 
 class EventSchedulerInterface:
-    """Interface for accessing the event scheduler over the message bus."""
+    """Interface for accessing the event scheduler over the message bus.
+
+    The SCHEDULER-1 methods :meth:`schedule`, :meth:`cancel`, :meth:`get`
+    and :meth:`list` send a request and wait for its answer, raising
+    :class:`SchedulerError` when the scheduler refuses. The older
+    ``*_scheduled_event`` methods speak the legacy protocol and are kept
+    for one stable cycle.
+    """
 
     def __init__(self, bus=None, skill_id=None):
         self.skill_id = skill_id or self.__class__.__name__.lower()
@@ -119,6 +150,7 @@ class EventSchedulerInterface:
         @param name: Event name, must be unique in the context of this object
         @param context: Message context to send to `handler`
         """
+        _legacy_notice("schedule_event", "schedule()")
         self._schedule_event(handler, when, data, name, context=context)
 
     def schedule_repeating_event(self,
@@ -138,6 +170,7 @@ class EventSchedulerInterface:
         @param interval:  time in seconds between calls
         @param context: Message context to send to `handler`
         """
+        _legacy_notice("schedule_repeating_event", "schedule()")
         # Ensure name is defined to avoid re-scheduling
         name = name or self.skill_id + handler.__name__
 
@@ -160,6 +193,7 @@ class EventSchedulerInterface:
             name (str): reference name of event (from original scheduling)
             data (dict): new data to update event with
         """
+        _legacy_notice("update_scheduled_event", "schedule()")
         data = {
             'event': self._create_unique_name(name),
             'data': data or {}
@@ -174,6 +208,7 @@ class EventSchedulerInterface:
         Args:
             name (str): reference name of event (from original scheduling)
         """
+        _legacy_notice("cancel_scheduled_event", "cancel()")
         unique_name = self._create_unique_name(name)
         data = {'event': unique_name}
         if name in self.scheduled_repeats:
@@ -195,6 +230,7 @@ class EventSchedulerInterface:
         Raises:
             Exception: Raised if event is not found
         """
+        _legacy_notice("get_scheduled_event_status", "get()")
         event_name = self._create_unique_name(name)
         data = {'name': event_name}
 
@@ -203,8 +239,8 @@ class EventSchedulerInterface:
         msg = message.forward('mycroft.scheduler.get_event', data)
         status = self.bus.wait_for_response(msg, reply_type=reply_name)
 
-        if status:
-            event_time = int(status.data[0][0])
+        if status and status.data.get("schedule"):
+            event_time = int(status.data["schedule"][0])
             current_time = int(time.time())
             time_left_in_seconds = event_time - current_time
             LOG.info(time_left_in_seconds)
@@ -227,3 +263,102 @@ class EventSchedulerInterface:
         """
         self.cancel_all_repeating_events()
         self.events.clear()
+
+    # --- SCHEDULER-1 -------------------------------------------------------
+
+    def _request(self, topic: str, data: dict, timeout: float = 3.0) -> dict:
+        """Send a request and return the answer, raising when refused."""
+        message = self._get_source_message()
+        response = self.bus.wait_for_response(
+            message.forward(topic, dict(data, owner=self.skill_id)),
+            reply_type=f"{topic}.response", timeout=timeout)
+        if response is None:
+            raise SchedulerError("timeout", f"no answer to {topic}")
+        if not response.data.get("ok"):
+            raise SchedulerError(response.data.get("error", "unknown"),
+                                 response.data.get("reason", ""))
+        return response.data
+
+    def _default_id(self, event: str) -> str:
+        """The id of the one schedule this component keeps for ``event``.
+
+        It comes from the event name alone, never from the timing, so
+        scheduling the same event again replaces the previous schedule
+        rather than orphaning it. Pass ``schedule_id`` to keep several
+        schedules for one event.
+        """
+        return event[len(self.skill_id) + 1:] or "schedule"
+
+    def schedule(self, event: str, handler: Optional[Callable[..., None]] = None,
+                 at: Optional[datetime] = None,
+                 every: Optional[dict] = None,
+                 local: Optional[dict] = None,
+                 in_seconds: Optional[float] = None,
+                 data: Optional[dict] = None,
+                 schedule_id: Optional[str] = None,
+                 zone: Optional[str] = None,
+                 **options) -> str:
+        """Create or replace a schedule and return its id.
+
+        ``event`` is namespaced to this component when it is not already.
+        ``at`` must be a time-zone-aware datetime unless ``zone`` names the
+        zone to read it in. ``handler`` is subscribed before the request
+        goes out, so an occurrence due immediately is not lost.
+
+        Without ``schedule_id`` the component keeps one schedule per
+        event, and calling this again for the same event replaces it. Give
+        distinct ids when one event needs several schedules.
+        """
+        if not event.startswith(f"{self.skill_id}."):
+            event = f"{self.skill_id}.{event}"
+        timing = {}
+        if at is not None:
+            if not isinstance(at, datetime):
+                raise TypeError(f"at must be a datetime, got {at!r}")
+            if at.tzinfo is None:
+                if zone is None:
+                    raise ValueError("at is a naive datetime and no zone was "
+                                     "given; pass an aware datetime or zone=")
+                at = at.replace(tzinfo=ZoneInfo(zone))
+            timing["at"] = at.isoformat()
+        if every is not None:
+            timing["every"] = every
+        if local is not None:
+            timing["local"] = local
+        if in_seconds is not None:
+            timing["in"] = {"seconds": in_seconds}
+        if len(timing) != 1:
+            raise ValueError("exactly one of at, in_seconds, every, local "
+                             "is required")
+
+        schedule_id = schedule_id or self._default_id(event)
+        if handler is not None:
+            wrapped = create_basic_wrapper(
+                handler, lambda e: LOG.exception(
+                    f"error in scheduled event handler: {e}"))
+            self.events.add(event, wrapped,
+                            once=at is not None or in_seconds is not None)
+
+        request = {"id": schedule_id, "event": event, "data": data or {}}
+        request.update(timing)
+        request.update(options)
+        self._request("scheduler.schedule", request)
+        return schedule_id
+
+    def cancel(self, schedule_id: str) -> bool:
+        """Delete a schedule. Returns whether it existed."""
+        existed = self._request("scheduler.cancel",
+                                {"id": schedule_id})["existed"]
+        return existed
+
+    def get(self, schedule_id: str) -> Optional[dict]:
+        """Read one of this component's schedules as ``record`` plus
+        computed ``state``, or None when it does not exist."""
+        answer = self._request("scheduler.get", {"id": schedule_id})
+        if not answer["existed"]:
+            return None
+        return {"record": answer["record"], "state": answer["state"]}
+
+    def list(self) -> list:
+        """Read every schedule this component owns."""
+        return self._request("scheduler.list", {})["schedules"]

--- a/ovos_bus_client/util/scheduled_events.py
+++ b/ovos_bus_client/util/scheduled_events.py
@@ -1,0 +1,922 @@
+"""SCHEDULER-1: the service that fires a named event on the bus at a
+wall-clock instant, once or on a recurrence, on behalf of a component.
+
+The service owns the ``scheduler.*`` topic family and, for one stable
+cycle, the ``mycroft.scheduler.*`` topics that preceded it.
+"""
+import json
+import os
+import time
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
+from threading import Event, Lock, Thread
+from typing import List, Optional, Tuple
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from ovos_config.config import Configuration
+from ovos_config.locations import get_xdg_config_save_path
+from ovos_config.meta import get_xdg_base
+from ovos_utils.log import LOG
+from ovos_utils.xdg_utils import xdg_state_home
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.version import VERSION_MAJOR
+
+#: topics kept as aliases for the pre-specification protocol
+LEGACY_REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
+
+#: compact UTF-8 JSON bytes allowed in a record's ``data``
+MAX_DATA_BYTES = 16384
+#: cap on the instants reported in one ``scheduler.missed``
+MAX_REPORTED = 100
+#: occurrences one evaluation will work through; a longer backlog drains
+#: over the ticks that follow
+MAX_BACKLOG = 10000
+TICK_SECONDS = 0.5
+#: a wall-clock/monotonic divergence above this is a step, not drift
+CLOCK_STEP_THRESHOLD = 2.0
+
+WEEKDAYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+#: what one schedule owes the bus in this evaluation
+_Plan = namedtuple("_Plan", "schedule key due emitted reported fired_late")
+
+
+class ScheduleError(ValueError):
+    """A request the scheduler refuses, carrying its wire error code."""
+
+    def __init__(self, code: str, reason: str):
+        super().__init__(reason)
+        self.code = code
+        self.reason = reason
+
+
+def parse_instant(value, field: str) -> datetime:
+    """Parse an RFC 3339 instant. An instant without an offset is refused:
+    without one the string does not name a point on the time line."""
+    if not isinstance(value, str):
+        raise ScheduleError("bad_instant", f"{field} must be an RFC 3339 string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise ScheduleError("bad_instant", f"{field} is not RFC 3339: {value}")
+    if parsed.tzinfo is None:
+        raise ScheduleError("bad_instant", f"{field} has no UTC offset: {value}")
+    return parsed
+
+
+def format_instant(when: datetime) -> str:
+    return when.isoformat()
+
+
+def _parse_clock(value) -> Tuple[int, int, int]:
+    if not isinstance(value, str):
+        raise ScheduleError("bad_recurrence", "local.time must be HH:MM or HH:MM:SS")
+    parts = value.split(":")
+    if len(parts) not in (2, 3):
+        raise ScheduleError("bad_recurrence", f"local.time is not HH:MM[:SS]: {value}")
+    try:
+        hour, minute = int(parts[0]), int(parts[1])
+        second = int(parts[2]) if len(parts) == 3 else 0
+    except ValueError:
+        raise ScheduleError("bad_recurrence", f"local.time is not HH:MM[:SS]: {value}")
+    if not (0 <= hour < 24 and 0 <= minute < 60 and 0 <= second < 60):
+        raise ScheduleError("bad_recurrence", f"local.time out of range: {value}")
+    return hour, minute, second
+
+
+def _positive_number(value, field: str, code: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        raise ScheduleError(code, f"{field} must be a number > 0")
+    return value
+
+
+class Schedule:
+    """One validated record plus the state the service keeps for it.
+
+    ``cursor`` is the instant up to and including which occurrences have
+    been consumed, and ``last_fired`` the due instant of the most recent
+    occurrence that reached the bus. Together they are the whole of the
+    no-double-fire guarantee: an occurrence is only produced strictly
+    after the cursor, and never at or before ``last_fired``.
+    """
+
+    def __init__(self, record: dict, cursor: Optional[datetime] = None,
+                 consumed: int = 0, anchored: bool = True,
+                 last_fired: Optional[datetime] = None,
+                 missed: Optional[List[str]] = None,
+                 estimate: Optional[datetime] = None,
+                 deadline: Optional[float] = None):
+        self.record = record
+        self.consumed = consumed
+        self.anchored = anchored
+        self.last_fired = last_fired
+        self.missed = list(missed or [])
+        # ``in`` schedules run off the monotonic clock while the service is
+        # up; the wall estimate is what survives a restart
+        self.estimate = estimate
+        self.deadline = deadline
+        if "in" in record and self.estimate is None:
+            seconds = record["in"]["seconds"]
+            self.estimate = datetime.now(timezone.utc) + timedelta(seconds=seconds)
+            self.deadline = time.monotonic() + seconds
+        self.cursor = cursor if cursor is not None else self._initial_cursor()
+
+    @property
+    def key(self) -> Tuple[str, str]:
+        return self.record["owner"], self.record["id"]
+
+    def _initial_cursor(self) -> datetime:
+        one_second = timedelta(seconds=1)
+        if "at" in self.record:
+            return parse_instant(self.record["at"], "at") - one_second
+        if "in" in self.record:
+            return datetime.now(timezone.utc) - one_second
+        if "every" in self.record:
+            return parse_instant(self.record["every"]["start"], "every.start") - one_second
+        return datetime.now(timezone.utc)
+
+    def anchor(self, now: datetime):
+        """Re-anchor a recurrence whose first occurrence was relative to a
+        clock that was not yet synchronized."""
+        if self.anchored:
+            return
+        self.anchored = True
+        if "local" in self.record:
+            self.cursor = now
+        elif "every" in self.record:
+            seconds = self.record["every"]["seconds"]
+            self.record["every"]["start"] = format_instant(
+                now + timedelta(seconds=seconds))
+            self.cursor = now
+
+    def retime(self, now: datetime):
+        """Project an ``in`` schedule onto the wall clock. A wall-clock step
+        moves the estimate, never the delay the owner asked for."""
+        if self.deadline is None:
+            return
+        left = self.deadline - time.monotonic()
+        self.estimate = now + timedelta(seconds=max(left, 0.0))
+        if left <= 0:
+            self.estimate = now
+
+    def next_after(self, after: datetime,
+                   consumed: Optional[int] = None) -> Optional[datetime]:
+        """The first occurrence strictly after ``after``, or None.
+
+        ``consumed`` overrides the record's own tally, so that planning can
+        walk a backlog without spending it.
+        """
+        if consumed is None:
+            consumed = self.consumed
+        if "count" in self.record and consumed >= self.record["count"]:
+            return None
+        if self.last_fired is not None and after < self.last_fired:
+            after = self.last_fired
+        occurrence = self._raw_next_after(after)
+        if occurrence is None:
+            return None
+        if "until" in self.record and \
+                occurrence > parse_instant(self.record["until"], "until"):
+            return None
+        return occurrence
+
+    def _raw_next_after(self, after: datetime) -> Optional[datetime]:
+        if "at" in self.record:
+            at = parse_instant(self.record["at"], "at")
+            return at if at > after else None
+        if "in" in self.record:
+            return self.estimate if self.estimate > after else None
+        if "every" in self.record:
+            start = parse_instant(self.record["every"]["start"], "every.start")
+            seconds = self.record["every"]["seconds"]
+            if after < start:
+                return start
+            # occurrences are anchored on start, never on the previous fire
+            elapsed = (after - start).total_seconds()
+            return start + timedelta(seconds=(int(elapsed // seconds) + 1) * seconds)
+        return self._next_local_after(after)
+
+    def _next_local_after(self, after: datetime) -> Optional[datetime]:
+        local = self.record["local"]
+        zone = ZoneInfo(local["zone"])
+        hour, minute, second = _parse_clock(local["time"])
+        days = local.get("days") or list(WEEKDAYS)
+        day = after.astimezone(zone).date()
+        for _ in range(400):
+            if WEEKDAYS[day.weekday()] in days:
+                occurrence = self._wall_clock_instant(day, hour, minute, second, zone)
+                # a spring-forward gap can push the reading onto the next
+                # day, which the owner did not ask for
+                landed = occurrence.astimezone(zone)
+                if occurrence > after and WEEKDAYS[landed.weekday()] in days:
+                    return occurrence
+            day += timedelta(days=1)
+        return None
+
+    @staticmethod
+    def _wall_clock_instant(day, hour, minute, second, zone) -> datetime:
+        """The instant at which the wall clock in ``zone`` reads the given
+        time on ``day``. Across a spring-forward gap the wall clock never
+        reads it, and the occurrence is the first instant after the gap;
+        across a fall-back overlap it reads it twice, and the occurrence
+        is the first of the two."""
+        naive = datetime(day.year, day.month, day.day, hour, minute, second)
+        first = naive.replace(tzinfo=zone, fold=0)
+        if first.astimezone(timezone.utc).astimezone(zone).replace(tzinfo=None) == naive:
+            return first
+        # the wall clock skipped this reading: the occurrence is the first
+        # instant at which the wall clock reads at or past it
+        low = (naive - timedelta(hours=6)).replace(tzinfo=zone).astimezone(timezone.utc)
+        high = (naive + timedelta(hours=6)).replace(tzinfo=zone).astimezone(timezone.utc)
+        while (high - low) > timedelta(seconds=1):
+            middle = low + (high - low) / 2
+            if middle.astimezone(zone).replace(tzinfo=None) < naive:
+                low = middle
+            else:
+                high = middle
+        return high.astimezone(zone)
+
+    def remaining(self) -> Optional[int]:
+        if "at" in self.record or "in" in self.record:
+            return 0
+        if "count" in self.record:
+            return max(0, self.record["count"] - self.consumed)
+        return None
+
+    def state(self, now: datetime) -> dict:
+        nxt = self.next_after(max(self.cursor, now))
+        return {"next": format_instant(nxt) if nxt else None,
+                "last_fired": format_instant(self.last_fired) if self.last_fired else None,
+                "missed": list(self.missed),
+                "remaining": self.remaining()}
+
+    def as_stored(self) -> dict:
+        return {"record": self.record, "cursor": format_instant(self.cursor),
+                "consumed": self.consumed, "anchored": self.anchored,
+                "missed": list(self.missed),
+                "estimate": format_instant(self.estimate) if self.estimate else None,
+                "last_fired": format_instant(self.last_fired) if self.last_fired else None}
+
+    @classmethod
+    def from_stored(cls, stored: dict) -> "Schedule":
+        last_fired = stored.get("last_fired")
+        estimate = stored.get("estimate")
+        return cls(stored["record"],
+                   cursor=parse_instant(stored["cursor"], "cursor"),
+                   consumed=stored.get("consumed", 0),
+                   anchored=stored.get("anchored", True),
+                   last_fired=parse_instant(last_fired, "last_fired") if last_fired else None,
+                   missed=stored.get("missed"),
+                   estimate=parse_instant(estimate, "estimate") if estimate else None)
+
+
+def validate_record(data: dict, namespaced: bool = True,
+                    previous: Optional[dict] = None) -> dict:
+    """Validate a request against §3.1 and return the record to store."""
+    if not isinstance(data, dict):
+        raise ScheduleError("invalid_record", "request data must be an object")
+
+    schedule_id = data.get("id")
+    owner = data.get("owner")
+    event = data.get("event")
+    for name, value in (("id", schedule_id), ("owner", owner)):
+        if not isinstance(value, str) or not value:
+            raise ScheduleError("invalid_record", f"{name} is required")
+    if not isinstance(event, str) or not event:
+        raise ScheduleError("bad_event", "event is required")
+    if namespaced:
+        prefix = f"{owner}."
+        name = event[len(prefix):] if event.startswith(prefix) else None
+        if not name or ":" in name:
+            raise ScheduleError(
+                "bad_event", f"event must be <owner>.<name> for owner {owner}, "
+                             f"with a non-empty name free of ':'; got {event}")
+
+    timings = [k for k in ("at", "in", "every", "local")
+               if k in data and data[k] is not None]
+    if len(timings) != 1:
+        raise ScheduleError("invalid_record",
+                            "exactly one of at, in, every, local is required")
+    timing = timings[0]
+
+    payload = data.get("data") or {}
+    if not isinstance(payload, dict):
+        raise ScheduleError("invalid_record", "data must be an object")
+    try:
+        size = len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    except (TypeError, ValueError):
+        raise ScheduleError("invalid_record", "data is not JSON serializable")
+    if size > MAX_DATA_BYTES:
+        raise ScheduleError("payload_too_large",
+                            f"data is {size} bytes, the limit is {MAX_DATA_BYTES}")
+
+    record = {"id": schedule_id, "owner": owner, "event": event, "data": payload}
+    bounded = timing in ("every", "local")
+
+    if timing in ("at", "in"):
+        if data.get("until") is not None or data.get("count") is not None:
+            raise ScheduleError("invalid_record",
+                                "until and count are for recurring schedules")
+    if timing == "at":
+        record["at"] = format_instant(parse_instant(data["at"], "at"))
+    elif timing == "in":
+        delay = data["in"]
+        if not isinstance(delay, dict):
+            raise ScheduleError("invalid_record", "in must be an object")
+        record["in"] = {"seconds": _positive_number(delay.get("seconds"),
+                                                    "in.seconds", "invalid_record")}
+    elif timing == "every":
+        every = data["every"]
+        if not isinstance(every, dict):
+            raise ScheduleError("bad_recurrence", "every must be an object")
+        seconds = _positive_number(every.get("seconds"), "every.seconds",
+                                   "bad_recurrence")
+        start = every.get("start")
+        if start is not None:
+            start = format_instant(parse_instant(start, "every.start"))
+        elif previous and previous.get("every", {}).get("seconds") == seconds:
+            # an owner re-creating an unchanged recurrence keeps its phase
+            start = previous["every"]["start"]
+        else:
+            start = format_instant(datetime.now(timezone.utc) + timedelta(seconds=seconds))
+        record["every"] = {"seconds": seconds, "start": start}
+    else:
+        local = data["local"]
+        if not isinstance(local, dict):
+            raise ScheduleError("bad_recurrence", "local must be an object")
+        _parse_clock(local.get("time"))
+        zone = local.get("zone")
+        if not isinstance(zone, str) or not zone:
+            raise ScheduleError("bad_recurrence", "local.zone is required")
+        try:
+            ZoneInfo(zone)
+        except (ZoneInfoNotFoundError, ValueError):
+            raise ScheduleError("bad_recurrence", f"unknown time zone: {zone}")
+        days = local.get("days")
+        if days is not None and (not isinstance(days, list) or not days or
+                                 any(d not in WEEKDAYS for d in days)):
+            raise ScheduleError("bad_recurrence",
+                                "local.days must be a non-empty list of mon..sun")
+        record["local"] = {"time": local["time"], "zone": zone}
+        if days is not None:
+            record["local"]["days"] = list(days)
+
+    if bounded:
+        if data.get("until") is not None:
+            record["until"] = format_instant(parse_instant(data["until"], "until"))
+        if data.get("count") is not None:
+            count = data["count"]
+            if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+                raise ScheduleError("invalid_record", "count must be an integer >= 1")
+            record["count"] = count
+
+    misfire = data.get("misfire", "late")
+    if misfire not in ("late", "skip", "all"):
+        raise ScheduleError("invalid_record", "misfire must be late, skip or all")
+    record["misfire"] = misfire
+
+    grace = data.get("grace_s", 60)
+    if not isinstance(grace, (int, float)) or isinstance(grace, bool) or grace < 0:
+        raise ScheduleError("invalid_record", "grace_s must be a number >= 0")
+    record["grace_s"] = grace
+
+    ephemeral = data.get("ephemeral", False)
+    if not isinstance(ephemeral, bool):
+        raise ScheduleError("invalid_record", "ephemeral must be a boolean")
+    record["ephemeral"] = ephemeral
+
+    return record
+
+
+def default_store_path(filename: str = "schedule.json") -> str:
+    return os.path.join(xdg_state_home(), get_xdg_base(), filename)
+
+
+class ScheduledEventService(Thread):
+    """The SCHEDULER-1 service.
+
+    Requests arrive on ``scheduler.schedule``, ``scheduler.cancel``,
+    ``scheduler.get`` and ``scheduler.list``; each is answered exactly
+    once on the matching ``.response`` topic. Accepted state reaches the
+    store before the response goes out, and the due instant of every
+    fired occurrence reaches it immediately after the event, so an
+    occurrence is delivered at least once and never twice.
+    """
+
+    def __init__(self, bus, store_path: Optional[str] = None,
+                 autostart: bool = True, admins: Optional[list] = None):
+        super().__init__(daemon=True)
+        self.bus = bus
+        self.store_path = store_path or default_store_path()
+        self.schedules = {}
+        self.lock = Lock()
+
+        self._wall_reference = time.time()
+        self._mono_reference = time.monotonic()
+        #: newest instant any past run wrote; a wall clock behind it is a
+        #: board that has not reached its time source yet
+        self._written_at: Optional[datetime] = None
+        self._clock_synced = True
+
+        self._legacy_notices = set()
+        #: component ids allowed to act under the pseudo-owner ``*``; an
+        #: empty allowlist means no caller can
+        if admins is None:
+            admins = Configuration().get("scheduler", {}).get("admins") or []
+        self.admins = list(admins)
+
+        self._migrate_legacy_store()
+        self._load()
+        self._clock_synced = self._written_at is None or self._now() >= self._written_at
+
+        self._handlers = (
+            ("scheduler.schedule", self.handle_schedule),
+            ("scheduler.cancel", self.handle_cancel),
+            ("scheduler.get", self.handle_get),
+            ("scheduler.list", self.handle_list),
+            ("system.clock.synced", self.handle_clock_synced),
+            ("mycroft.scheduler.schedule_event", self.handle_legacy_schedule),
+            ("mycroft.scheduler.remove_event", self.handle_legacy_remove),
+            ("mycroft.scheduler.update_event", self.handle_legacy_update),
+            ("mycroft.scheduler.get_event", self.handle_legacy_get),
+            ("mycroft.scheduler.list_events", self.handle_legacy_list))
+        for topic, handler in self._handlers:
+            self.bus.on(topic, handler)
+
+        self._running = Event()
+        self._stopping = Event()
+        if autostart:
+            self.start()
+            self._running.wait(10)
+        else:
+            self._stopping.set()
+            self._running.clear()
+
+    # --- clock ------------------------------------------------------------
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _clock_stepped(self) -> float:
+        """Seconds by which the wall clock moved beyond the passage of time
+        since the last reading. Zero when the two clocks agree."""
+        wall, mono = time.time(), time.monotonic()
+        drift = (wall - self._wall_reference) - (mono - self._mono_reference)
+        self._wall_reference, self._mono_reference = wall, mono
+        return drift if abs(drift) > CLOCK_STEP_THRESHOLD else 0.0
+
+    # --- persistence ------------------------------------------------------
+
+    def _migrate_legacy_store(self):
+        """The store used to live in the configuration directory. Move it
+        once so that schedules written by the previous service are read."""
+        if os.path.isfile(self.store_path):
+            return
+        old = os.path.join(get_xdg_config_save_path(), "schedule.json")
+        if not os.path.isfile(old) or os.path.isfile(f"{old}.migrated"):
+            return
+        try:
+            with open(old) as handle:
+                legacy = json.load(handle)
+            for name, entries in legacy.items():
+                for entry in entries:
+                    payload = entry[2] if len(entry) > 2 else {}
+                    record = self._legacy_record(name, entry[0], entry[1], payload)
+                    self.schedules[record["owner"], record["id"]] = Schedule(record)
+        except Exception as err:
+            LOG.error(f"could not migrate the legacy schedule store: {err}")
+            return
+        self._persist()
+        # the original stays where it is, so a downgrade still finds it
+        open(f"{old}.migrated", "w").close()
+        LOG.info(f"migrated {len(self.schedules)} schedules to {self.store_path}")
+
+    def _load(self):
+        if not os.path.isfile(self.store_path):
+            return
+        try:
+            with open(self.store_path) as handle:
+                stored = json.load(handle)
+        except Exception as err:
+            LOG.error(f"unreadable schedule store {self.store_path}: {err}")
+            return
+        written_at = stored.get("written_at")
+        if written_at:
+            try:
+                self._written_at = parse_instant(written_at, "written_at")
+            except ScheduleError as err:
+                LOG.warning(f"ignoring unreadable store timestamp: {err}")
+        for entry in stored.get("schedules", []):
+            try:
+                schedule = Schedule.from_stored(entry)
+            except ScheduleError as err:
+                LOG.error(f"dropping unreadable schedule: {err}")
+                continue
+            self.schedules[schedule.key] = schedule
+            # only instants that were already in the past when they were
+            # written count; a schedule due next week says nothing about
+            # whether this device knows what time it is
+            if schedule.last_fired and (self._written_at is None or
+                                        schedule.last_fired > self._written_at):
+                self._written_at = schedule.last_fired
+
+    def _persist(self):
+        """Atomic replace: a reader sees the previous file or the new one."""
+        directory = os.path.dirname(self.store_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        payload = {"version": 1, "written_at": format_instant(self._now()),
+                   "schedules": [s.as_stored() for s in self.schedules.values()
+                                 if not s.record["ephemeral"]]}
+        tmp = f"{self.store_path}.tmp"
+        with open(tmp, "w") as handle:
+            json.dump(payload, handle)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, self.store_path)
+
+    # --- request handling -------------------------------------------------
+
+    @staticmethod
+    def _identity(message: Message) -> Optional[str]:
+        """The authenticated component identity the bus carries, if any."""
+        return message.context.get("skill_id")
+
+    def _check_owner(self, message: Message, owner, wildcard: bool = False) -> str:
+        if not isinstance(owner, str) or not owner:
+            raise ScheduleError("invalid_record", "owner is required")
+        identity = self._identity(message)
+        if owner == "*":
+            if not wildcard:
+                raise ScheduleError("not_owner",
+                                    "* is not an owner a schedule can belong to")
+            if not identity or identity not in self.admins:
+                raise ScheduleError(
+                    "not_owner",
+                    f"{identity or 'an anonymous caller'} is not allowed to act "
+                    f"across every owner")
+            return owner
+        if identity and identity != owner:
+            raise ScheduleError("not_owner",
+                                f"{identity} may not act on schedules of {owner}")
+        return owner
+
+    def _respond(self, message: Message, data: dict):
+        self.bus.emit(message.response(data))
+
+    def _fail(self, message: Message, err: ScheduleError):
+        LOG.warning(f"{message.msg_type} refused: {err.reason}")
+        self._respond(message, {"ok": False, "error": err.code, "reason": err.reason})
+
+    def handle_schedule(self, message: Message):
+        try:
+            owner = self._check_owner(message, message.data.get("owner"))
+            with self.lock:
+                previous = self.schedules.get((owner, message.data.get("id")))
+                record = validate_record(
+                    message.data, previous=previous.record if previous else None)
+                key = (owner, record["id"])
+                replaced = key in self.schedules
+                schedule = Schedule(record, anchored=self._clock_synced)
+                self.schedules[key] = schedule
+                try:
+                    self._persist()
+                except OSError:
+                    # a request that could not be stored did not happen; the
+                    # running process must not disagree with the store it
+                    # will be restarted from
+                    if replaced:
+                        self.schedules[key] = previous
+                    else:
+                        self.schedules.pop(key, None)
+                    raise
+                nxt = schedule.next_after(max(schedule.cursor, self._now()))
+        except ScheduleError as err:
+            return self._fail(message, err)
+        except OSError as err:
+            return self._fail(message, ScheduleError(
+                "internal", f"the schedule store could not be written: {err}"))
+        self._respond(message, {"ok": True, "id": record["id"], "owner": owner,
+                                "next": format_instant(nxt) if nxt else None,
+                                "replaced": replaced})
+
+    def handle_cancel(self, message: Message):
+        try:
+            owner = self._check_owner(message, message.data.get("owner"),
+                                      wildcard=True)
+            schedule_id = message.data.get("id")
+            if not isinstance(schedule_id, str) or not schedule_id:
+                raise ScheduleError("invalid_record", "id is required")
+            with self.lock:
+                if owner == "*":
+                    keys = [k for k in self.schedules if k[1] == schedule_id]
+                else:
+                    keys = [k for k in ((owner, schedule_id),) if k in self.schedules]
+                dropped = {key: self.schedules.pop(key) for key in keys}
+                if keys:
+                    try:
+                        self._persist()
+                    except OSError:
+                        self.schedules.update(dropped)
+                        raise
+        except ScheduleError as err:
+            return self._fail(message, err)
+        except OSError as err:
+            return self._fail(message, ScheduleError(
+                "internal", f"the schedule store could not be written: {err}"))
+        self._respond(message, {"ok": True, "id": schedule_id, "owner": owner,
+                                "existed": bool(keys)})
+
+    def _view(self, schedule: Schedule) -> dict:
+        return {"record": dict(schedule.record),
+                "state": schedule.state(self._now())}
+
+    def handle_get(self, message: Message):
+        try:
+            owner = self._check_owner(message, message.data.get("owner"))
+            schedule_id = message.data.get("id")
+            if not isinstance(schedule_id, str) or not schedule_id:
+                raise ScheduleError("invalid_record", "id is required")
+            with self.lock:
+                schedule = self.schedules.get((owner, schedule_id))
+                view = self._view(schedule) if schedule else None
+        except ScheduleError as err:
+            return self._fail(message, err)
+        data = {"ok": True, "id": schedule_id, "owner": owner,
+                "existed": view is not None,
+                "record": view["record"] if view else None,
+                "state": view["state"] if view else None}
+        self._respond(message, data)
+
+    def handle_list(self, message: Message):
+        try:
+            owner = self._check_owner(message, message.data.get("owner"),
+                                      wildcard=True)
+            with self.lock:
+                views = [self._view(s) for k, s in self.schedules.items()
+                         if owner == "*" or k[0] == owner]
+        except ScheduleError as err:
+            return self._fail(message, err)
+        self._respond(message, {"ok": True, "owner": owner, "schedules": views})
+
+    def handle_clock_synced(self, message: Message):
+        if not self._clock_synced:
+            LOG.info("clock synchronized, replaying deferred schedules")
+        self._clock_synced = True
+        self._clock_stepped()
+        self.replay()
+
+    # --- evaluation -------------------------------------------------------
+
+    def run(self):
+        LOG.info("ScheduledEventService started")
+        self._stopping.clear()
+        self._running.set()
+        self.replay()
+        while not self._stopping.wait(TICK_SECONDS):
+            try:
+                self.tick()
+            except Exception as err:
+                LOG.exception(err)
+        LOG.info("ScheduledEventService stopped")
+
+    def tick(self):
+        step = self._clock_stepped()
+        if not self._clock_synced:
+            if self._written_at is None or self._now() >= self._written_at:
+                LOG.info("wall clock reached a plausible reading, replaying")
+                self._clock_synced = True
+                return self.replay()
+            return
+        if step:
+            LOG.info(f"wall clock stepped by {step:.0f}s, re-evaluating schedules")
+        self._evaluate()
+
+    def replay(self):
+        """Announce readiness, then apply the misfire policy to everything
+        that was due while the service was down."""
+        restored = len(self.schedules)
+        plan = self._plan(replaying=True)
+        self.bus.emit(Message("scheduler.ready", {
+            "schedules": restored,
+            "missed": len(plan),
+            "clock": "synchronized" if self._clock_synced else "unsynchronized"}))
+        self._execute(plan)
+
+    def _evaluate(self):
+        self._execute(self._plan())
+
+    def _plan(self, replaying: bool = False) -> list:
+        """Work out what every schedule owes the bus, without consuming
+        anything: consumption belongs next to the emission it pays for."""
+        if not self._clock_synced:
+            return []
+        now = self._now()
+        plans = []
+        with self.lock:
+            for key in list(self.schedules):
+                schedule = self.schedules[key]
+                schedule.anchor(now)
+                schedule.retime(now)
+                due = []
+                cursor = schedule.cursor
+                consumed = schedule.consumed
+                while len(due) < MAX_BACKLOG:
+                    occurrence = schedule.next_after(cursor, consumed)
+                    if occurrence is None or occurrence > now:
+                        break
+                    due.append(occurrence)
+                    cursor = occurrence
+                    consumed += 1
+                if not due:
+                    continue
+                grace = schedule.record["grace_s"]
+                late = [d for d in due if (now - d).total_seconds() > grace]
+                on_time = [d for d in due if d not in late]
+                policy = schedule.record["misfire"]
+                fired_late = list(late) if policy == "all" else \
+                    late[-1:] if policy == "late" else []
+                # after a restart an occurrence may have reached the bus
+                # already and lost its record to the crash window, so every
+                # occurrence replay produces is reported too; owners dedupe
+                # on (id, due)
+                plans.append(_Plan(schedule=schedule, key=key, due=due,
+                                   emitted=sorted(fired_late + on_time),
+                                   reported=due if replaying else late,
+                                   fired_late=fired_late))
+        return plans
+
+    def _execute(self, plans: list):
+        for plan in plans:
+            if plan.reported:
+                self._report(plan)
+            self._deliver(plan)
+
+    def _report(self, plan):
+        reported, fired_late = plan.reported, plan.fired_late
+        self.bus.emit(Message("scheduler.missed", {
+            "id": plan.schedule.record["id"],
+            "owner": plan.schedule.record["owner"],
+            "missed": [format_instant(d) for d in reported[:MAX_REPORTED]],
+            "fired_late": [format_instant(d) for d in fired_late[:MAX_REPORTED]],
+            "truncated": len(reported) > MAX_REPORTED or
+                         len(fired_late) > MAX_REPORTED,
+            "next": self._next_instant(plan.schedule)}))
+
+    def _deliver(self, plan):
+        """Emit one occurrence, then persist the consumption it represents,
+        then the next. A kill anywhere in here can repeat at most the
+        occurrence that was in flight."""
+        schedule = plan.schedule
+        base = schedule.consumed
+        index = {occurrence: position for position, occurrence in enumerate(plan.due)}
+        for occurrence in plan.emitted:
+            schedule.cursor = occurrence
+            schedule.consumed = base + index[occurrence] + 1
+            self._fire(schedule, occurrence)
+            with self.lock:
+                self._persist()
+        # occurrences the policy dropped are consumed all the same
+        schedule.cursor = max(schedule.cursor, plan.due[-1])
+        schedule.consumed = base + len(plan.due)
+        if plan.emitted:
+            schedule.missed = [format_instant(d) for d in plan.reported
+                               if d > plan.emitted[-1]]
+        else:
+            schedule.missed.extend(format_instant(d) for d in plan.reported)
+        del schedule.missed[:-MAX_REPORTED]
+        with self.lock:
+            if "at" in schedule.record or "in" in schedule.record or \
+                    schedule.next_after(schedule.cursor) is None:
+                self.schedules.pop(plan.key, None)
+            self._persist()
+
+    def _next_instant(self, schedule: Schedule) -> Optional[str]:
+        nxt = schedule.next_after(max(schedule.cursor, self._now()))
+        return format_instant(nxt) if nxt else None
+
+    def _fire(self, schedule: Schedule, due: datetime):
+        """Emit one occurrence. The message originates here: nothing of the
+        request that created the schedule is carried into it."""
+        record = schedule.record
+        context = {"scheduler": {"id": record["id"], "owner": record["owner"],
+                                 "due": format_instant(due),
+                                 "fired": format_instant(self._now()),
+                                 "remaining": schedule.remaining()}}
+        LOG.debug(f"scheduled event fired: {record['id']}")
+        self.bus.emit(Message(record["event"], dict(record["data"]), context))
+        if schedule.last_fired is None or due > schedule.last_fired:
+            schedule.last_fired = due
+
+    # --- legacy adapter ---------------------------------------------------
+
+    def _legacy_notice(self, topic: str):
+        if topic not in self._legacy_notices:
+            self._legacy_notices.add(topic)
+            LOG.warning(f"{topic} is deprecated in favour of the scheduler.* "
+                        f"topics and will be removed in ovos-bus-client "
+                        f"{LEGACY_REMOVAL_VERSION}")
+
+    @staticmethod
+    def _legacy_owner(name: str) -> str:
+        return name.split(":", 1)[0] if ":" in name else "legacy"
+
+    def _legacy_record(self, name: str, when: float, repeat, data) -> dict:
+        instant = format_instant(datetime.fromtimestamp(when, timezone.utc))
+        record = {"id": name, "owner": self._legacy_owner(name), "event": name,
+                  "data": data or {}}
+        if repeat:
+            record["every"] = {"seconds": repeat, "start": instant}
+        else:
+            record["at"] = instant
+        return validate_record(record, namespaced=False)
+
+    def handle_legacy_schedule(self, message: Message):
+        self._legacy_notice(message.msg_type)
+        name = message.data.get("event")
+        when = message.data.get("time")
+        if not name or when is None:
+            LOG.error("legacy schedule request is missing event or time")
+            return
+        try:
+            record = self._legacy_record(name, when, message.data.get("repeat"),
+                                         message.data.get("data"))
+        except ScheduleError as err:
+            LOG.error(f"legacy schedule request refused: {err.reason}")
+            return
+        with self.lock:
+            # replacing rather than appending is what stops a skill that
+            # re-creates its schedules on boot from doubling them
+            self.schedules[record["owner"], record["id"]] = Schedule(
+                record, anchored=self._clock_synced)
+            self._persist()
+
+    def handle_legacy_remove(self, message: Message):
+        self._legacy_notice(message.msg_type)
+        name = message.data.get("event")
+        if not name:
+            return
+        with self.lock:
+            if self.schedules.pop((self._legacy_owner(name), name), None):
+                self._persist()
+
+    def handle_legacy_update(self, message: Message):
+        self._legacy_notice(message.msg_type)
+        name = message.data.get("event")
+        with self.lock:
+            schedule = self.schedules.get((self._legacy_owner(name or ""), name))
+            if schedule is None:
+                return
+            schedule.record["data"] = message.data.get("data") or {}
+            self._persist()
+
+    def _legacy_entry(self, schedule: Schedule) -> list:
+        nxt = schedule.next_after(max(schedule.cursor, self._now()))
+        return [nxt.timestamp() if nxt else 0,
+                schedule.record.get("every", {}).get("seconds"),
+                schedule.record["data"], {}]
+
+    def handle_legacy_get(self, message: Message):
+        self._legacy_notice(message.msg_type)
+        name = message.data.get("name")
+        with self.lock:
+            schedule = self.schedules.get((self._legacy_owner(name or ""), name))
+            entry = self._legacy_entry(schedule) if schedule else None
+        # the wire refuses a list-shaped payload, so the tuple the previous
+        # service tried to return travels under a key
+        self.bus.emit(message.reply(f"mycroft.event_status.callback.{name}",
+                                    data={"event": name, "schedule": entry}))
+
+    def handle_legacy_list(self, message: Message):
+        self._legacy_notice(message.msg_type)
+        with self.lock:
+            events = {s.record["id"]: [self._legacy_entry(s)]
+                      for s in self.schedules.values()}
+        self.bus.emit(message.response(data={"scheduled_events": events}))
+
+    # --- lifecycle --------------------------------------------------------
+
+    @property
+    def is_running(self) -> bool:
+        return not self._stopping.is_set()
+
+    @is_running.setter
+    def is_running(self, value: bool):
+        if value:
+            self._stopping.clear()
+        else:
+            self._stopping.set()
+
+    def shutdown(self):
+        self._stopping.set()
+        # only this service's own subscriptions go; an unrelated observer
+        # on the same topic is none of our business
+        for topic, handler in self._handlers:
+            self.bus.remove(topic, handler)
+        if self.is_alive():
+            self.join(30)
+        with self.lock:
+            self._persist()
+        self._running.clear()

--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -12,367 +12,91 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""
-The scheduler module allows setting up scheduled messages.
+"""The pre-specification name and entry point of the scheduler service.
 
-A scheduled message will be kept and not sent until the system clock time
-criteria is met.
+``EventScheduler`` is the SCHEDULER-1 service under the name the rest of
+the stack starts it by. The behaviour is the specification's; the
+``mycroft.scheduler.*`` topics and the epoch-float API remain available
+through the legacy adapter for one stable cycle.
 """
-import datetime
-import json
-import shutil
+import os
 import time
-from os.path import isfile, join, expanduser
-from threading import Event
-from threading import Thread, Lock
 from typing import Optional
 
-from ovos_config.config import Configuration
-from ovos_config.locations import get_xdg_data_save_path, get_xdg_config_save_path
-from ovos_utils.log import LOG
-from ovos_utils.time import now_local
 from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import (
+    ScheduledEventService, default_store_path)
 
 
 def repeat_time(sched_time: float, repeat: float) -> float:
-    """
-    Next scheduled time for repeating event. Guarantees that the
-    time is not in the past (but could skip interim events)
+    """Next scheduled time for a repeating event, anchored on the schedule.
 
     Args:
-        sched_time (float): Scheduled unix time for the event
-        repeat (float):     Repeat period in seconds
+        sched_time: unix time of the occurrence that just passed
+        repeat: period in seconds
 
-    Returns: (float) time for next event
+    Returns: unix time of the next occurrence
     """
-    next_time = sched_time + repeat
-    while next_time < time.time():
-        # Schedule at an offset to assure no doubles
-        next_time = time.time() + abs(repeat)
+    period = abs(repeat)
+    next_time = sched_time + period
+    now = time.time()
+    if next_time < now:
+        # stay on the schedule's phase rather than re-anchoring on the miss
+        periods = (now - sched_time) // period + 1
+        next_time = sched_time + periods * period
     return next_time
 
 
-class EventScheduler(Thread):
-    """
-    Create an event scheduler thread. Will send messages at a
-    predetermined time to the registered targets.
+class EventScheduler(ScheduledEventService):
+    """SCHEDULER-1 service, reachable under its historical name.
 
-    Arguments:
-        bus:            Mycroft messagebus client
-        schedule_file:  filename used to store pending events to on
-                        shutdown. File is created in XDG_DATA_HOME
-        autostart: if True, start scheduler on init
+    Args:
+        bus: message bus client
+        schedule_file: store file name, resolved inside the XDG state
+            directory unless an absolute path is given
+        autostart: start the thread on construction
     """
 
-    def __init__(self, bus, schedule_file: str = 'schedule.json', autostart: bool = True):
-        super().__init__()
-
-        self.events = {}
-        self.event_lock = Lock()
-
-        # to check if its our first connection to the internet via clock_skew
-        self._last_sync: datetime.datetime = now_local()
-        self._dropped_events = 0
-        self._past_date = datetime.datetime(day=1, month=12, year=2024, tzinfo=self._last_sync.tzinfo)
-        LOG.debug(f"Boot time clock: {self._last_sync}")
-
-        self.bus = bus
-
-        core_conf = Configuration()
-        data_dir = core_conf.get('data_dir') or get_xdg_data_save_path()
-        old_schedule_path = join(expanduser(data_dir), schedule_file)
-
-        self.schedule_file = join(get_xdg_config_save_path(), schedule_file)
-        if isfile(old_schedule_path):
-            shutil.move(old_schedule_path, self.schedule_file)
-
-        if self.schedule_file:
-            self.load()
-
-        self.bus.on('mycroft.scheduler.schedule_event', self.handle_schedule_event)
-        self.bus.on('mycroft.scheduler.remove_event', self.handle_remove_event)
-        self.bus.on('mycroft.scheduler.update_event', self.handle_update_event)
-        self.bus.on('mycroft.scheduler.get_event', self.handle_get_event)
-        self.bus.on('mycroft.scheduler.list_events', self.handle_list_events)
-        self.bus.on('system.clock.synced', self.handle_system_clock_sync)  # emitted by raspOVOS
-
-        self._running = Event()
-        self._stopping = Event()
-        if autostart:
-            self.start()
-            self._running.wait(10)
-        else:
-            # Explicitly define event states
-            self._stopping.set()
-            self._running.clear()
+    def __init__(self, bus, schedule_file: str = "schedule.json",
+                 autostart: bool = True):
+        store = schedule_file if os.path.isabs(schedule_file) \
+            else default_store_path(schedule_file)
+        super().__init__(bus, store_path=store, autostart=autostart)
 
     @property
-    def is_running(self) -> bool:
-        """
-        Return True while scheduler is running
-        """
-        return not self._stopping.is_set()
-
-    @is_running.setter
-    def is_running(self, value: bool):
-        if value is True:
-            self._stopping.clear()
-        elif value is False:
-            self._stopping.set()
-
-    def load(self):
-        """
-        Load json data with active events from json file.
-        """
-        if isfile(self.schedule_file):
-            json_data = {}
-            with open(self.schedule_file) as schedule_file:
-                try:
-                    json_data = json.load(schedule_file)
-                except Exception as exc:
-                    LOG.error(exc)
-            current_time = time.time()
-            with self.event_lock:
-                for key in json_data:
-                    event_list = json_data[key]
-                    # discard non repeating events that has already happened
-                    self.events[key] = [tuple(evt) for evt in event_list
-                                        if evt[0] > current_time or evt[1]]
-
-    def run(self):
-        """
-        Check events periodically until stopped
-        """
-        LOG.info("EventScheduler Started")
-        self._stopping.clear()
-        self._running.set()
-        while not self._stopping.wait(0.5):
-            try:
-                self.check_state()
-            except Exception as e:
-                LOG.exception(e)
-        LOG.info("EventScheduler Stopped")
-
-    def check_state(self):
-        """
-        Check if any event should be triggered.
-        """
-        with self.event_lock:
-            # Check all events
-            pending_messages = []
-            for event in self.events:
-                current_time = time.time()
-                e = self.events[event]
-                # Get scheduled times that has passed
-                passed = ((t, r, d, c) for
-                          (t, r, d, c) in e if t <= current_time)
-                # and remaining times that we're still waiting for
-                remaining = [(t, r, d, c) for
-                             t, r, d, c in e if t > current_time]
-                # Trigger registered methods
-                for sched_time, repeat, data, context in passed:
-                    pending_messages.append(Message(event, data, context))
-                    # if this is a repeated event add a new trigger time
-                    if repeat:
-                        next_time = repeat_time(sched_time, repeat)
-                        remaining.append((next_time, repeat, data, context))
-                # update list of events
-                self.events[event] = remaining
-
-        # Remove events that are now completed
-        self.clear_empty()
-
-        # Finally, emit the queued up events that triggered
-        for msg in pending_messages:
-            LOG.debug(f"Call scheduled event: {msg.msg_type}")
-            self.bus.emit(msg)
+    def schedule_file(self) -> str:
+        return self.store_path
 
     def schedule_event(self, event: str, sched_time: float,
                        repeat: Optional[float] = None,
                        data: Optional[dict] = None,
                        context: Optional[dict] = None):
-        """
-        Add event to pending event schedule.
+        """Add an event to the schedule using the epoch-float API.
 
-        Arguments:
-            event (str): Handler for the event
-            sched_time (float): epoch time of event
-            repeat ([type], optional): Defaults to None. [description]
-            data ([type], optional): Defaults to None. [description]
-            context (dict, optional): context (dict, optional): message
-                                      context to send when the
-                                      handler is called
+        The ``context`` argument is accepted and ignored: a fired event
+        carries a fresh context (SCHEDULER-1 §4.2).
         """
-        if self._last_sync < self._past_date:
-            # this works around problems in raspOVOS images and other
-            # systems without RTC that didnt sync clock with the internet yet
-            # eg. issue demonstration without this:
-            #   date time skill schedulling the hour change sound N times (+1hour every time until present)
-            LOG.error("Refusing to schedule event, system clock is in the past!")
-            self._dropped_events += 1
-            return
-        
-        data = data or {}
-        with self.event_lock:
-            # get current list of scheduled times for event, [] if missing
-            event_list = self.events.get(event, [])
-
-            # Don't schedule if the event is repeating and already scheduled
-            if repeat and event in self.events:
-                LOG.debug(f'Repeating event {event} is already scheduled, '
-                          f'discarding')
-            else:
-                LOG.debug(f"Scheduled event: {event} for time {sched_time}")
-                # add received event and time
-                event_list.append((sched_time, repeat, data, context))
-                self.events[event] = event_list
-                if sched_time < time.time():
-                    LOG.warning(f"Added event is scheduled in the past and "
-                                f"will be called immediately: {event}")
-
-    def handle_schedule_event(self, message: Message):
-        """
-        Messagebus interface to the schedule_event method.
-        Required data in the message envelope is
-            event: event to emit
-            time:  time to emit the event
-
-        Optional data is
-            repeat: repeat interval
-            data:   data to send along with the event
-        """
-        event = message.data.get('event')
-        sched_time = message.data.get('time')
-        repeat = message.data.get('repeat')
-        data = message.data.get('data')
-        context = message.context
-        if event and sched_time:
-            self.schedule_event(event, sched_time, repeat, data, context)
-        elif not event:
-            LOG.error('Scheduled event msg_type not provided')
-        else:
-            LOG.error('Scheduled event time not provided')
+        self.handle_legacy_schedule(
+            Message("mycroft.scheduler.schedule_event",
+                    {"event": event, "time": sched_time, "repeat": repeat,
+                     "data": data}))
 
     def remove_event(self, event: str):
-        """
-        Remove an event from the list of scheduled events.
-
-        Arguments:
-            event (str): event identifier
-        """
-        with self.event_lock:
-            if event in self.events:
-                self.events.pop(event)
-
-    def handle_system_clock_sync(self, message: Message):
-        # clock sync, are we in the past?
-        if self._last_sync < self._past_date:
-            LOG.warning(f"Clock was in the past!!! {self._dropped_events} scheduled events have been dropped")
-        self._last_sync = now_local()
-        LOG.info(f"clock sync: {self._last_sync}")
-
-    def handle_remove_event(self, message: Message):
-        """
-        Messagebus interface to the remove_event method.
-        """
-        event = message.data.get('event')
-        self.remove_event(event)
+        """Remove an event from the schedule."""
+        self.handle_legacy_remove(
+            Message("mycroft.scheduler.remove_event", {"event": event}))
 
     def update_event(self, event: str, data: dict):
-        """
-        Change an existing event's data.
+        """Change the data an existing event fires with."""
+        self.handle_legacy_update(
+            Message("mycroft.scheduler.update_event",
+                    {"event": event, "data": data}))
 
-        This will only update the first call if multiple calls are registered
-        to the same event identifier.
-
-        Arguments:
-            event (str): event identifier
-            data (dict): new data
-        """
-        with self.event_lock:
-            # if there is an active event with this name
-            if len(self.events.get(event, [])) > 0:
-                event_time, repeat, _, context = self.events[event][0]
-                self.events[event][0] = (event_time, repeat, data, context)
-
-    def handle_update_event(self, message: Message):
-        """
-        Messagebus interface to the update_event method.
-        """
-        event = message.data.get('event')
-        data = message.data.get('data')
-        self.update_event(event, data)
-
-    def handle_list_events(self, message: Message):
-        """
-        Messagebus interface to the list_events method.
-        """
-        with self.event_lock:
-            events_snapshot = dict(self.events)
-        self.bus.emit(message.response(data={"scheduled_events": events_snapshot}))
-
-    def handle_get_event(self, message: Message):
-        """
-        Messagebus interface to get_event.
-
-        Emits another event sending event status.
-        """
-        event_name = message.data.get("name")
-        event = None
-        with self.event_lock:
-            if event_name in self.events:
-                event = self.events[event_name]
-        emitter_name = f'mycroft.event_status.callback.{event_name}'
-        self.bus.emit(message.reply(emitter_name, data=event))
+    def check_state(self):
+        """Fire every occurrence that is due."""
+        self._evaluate()
 
     def store(self):
-        """
-        Write current schedule to disk.
-        """
-        with self.event_lock:
-            with open(self.schedule_file, 'w') as schedule_file:
-                json.dump(self.events, schedule_file)
-
-    def clear_repeating(self):
-        """
-        Remove repeating events from events dict.
-        """
-        with self.event_lock:
-            for evt in self.events:
-                self.events[evt] = [tup for tup in self.events[evt]
-                                    if tup[1] is None]
-
-    def clear_empty(self):
-        """
-        Remove empty event entries from events dict.
-        """
-        with self.event_lock:
-            self.events = {k: self.events[k] for k in self.events
-                           if self.events[k] != []}
-
-    def shutdown(self):
-        """
-        Stop the running thread.
-        """
-        try:
-            self._stopping.set()
-            # Remove listeners
-            self.bus.remove_all_listeners('mycroft.scheduler.get_event')
-            self.bus.remove_all_listeners('mycroft.scheduler.list_events')
-            self.bus.remove_all_listeners('mycroft.scheduler.remove_event')
-            self.bus.remove_all_listeners('mycroft.scheduler.schedule_event')
-            self.bus.remove_all_listeners('mycroft.scheduler.update_event')
-            self.bus.remove_all_listeners('system.clock.synced')
-            # Wait for thread to finish
-            self.join(30)
-            # Prune event list in preparation for saving
-            self.clear_repeating()
-            self.clear_empty()
-            # Store all pending scheduled events
-            self.store()
-            self._running.clear()
-        except Exception as e:
-            self._running.clear()
-            if not isinstance(e, OSError):
-                self.store()
-            raise e
+        """Write the schedule to disk."""
+        with self.lock:
+            self._persist()

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -1,144 +1,114 @@
-"""
-Test cases regarding the event scheduler.
+"""The scheduler service under its historical name, ``EventScheduler``.
+
+These exercise the epoch-float API and the ``mycroft.scheduler.*`` topics
+that the rest of the stack still speaks.
 """
 
-import unittest
+import os
+import tempfile
 import time
+import unittest
 
-try:
-    from pyee import ExecutorEventEmitter
-except (ImportError, ModuleNotFoundError):
-    from pyee.executor import ExecutorEventEmitter
-
-
-from unittest.mock import MagicMock, patch
 from ovos_utils.fakebus import FakeBus
-from ovos_bus_client.util.scheduler import EventScheduler
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduler import EventScheduler, repeat_time
+
+
+class TestRepeatTime(unittest.TestCase):
+    def test_next_occurrence_is_in_the_future(self):
+        past = time.time() - 100
+        self.assertGreaterEqual(repeat_time(past, 30), time.time())
+
+    def test_a_missed_period_keeps_the_schedule_phase(self):
+        start = time.time() - 95
+        self.assertAlmostEqual((repeat_time(start, 30) - start) % 30, 0, places=3)
+
+    def test_a_negative_period_is_read_as_its_magnitude(self):
+        self.assertGreaterEqual(repeat_time(time.time(), -30), time.time())
 
 
 class TestEventScheduler(unittest.TestCase):
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_create(self, mock_open, mock_json_dump, mock_load, mock_thread):
-        """
-        Test creating and shutting down event_scheduler.
-        """
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
-        es.shutdown()
-        self.assertEqual(mock_json_dump.call_args[0][0], {})
+    def setUp(self):
+        self.bus = FakeBus()
+        self.emitted = []
+        self.bus.on("message", self._record)
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.scheduler = EventScheduler(self.bus, self.store, autostart=False)
 
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_add_remove(self, mock_open, mock_json_dump, mock_load, mock_thread):
-        """
-        Test add an event and then remove it.
-        """
-        # Thread start is mocked so will not actually run the thread loop
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
+    def tearDown(self):
+        self.scheduler.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
 
-        # 900000000000 should be in the future for a long time
-        es.schedule_event("test", 90000000000, None)
-        es.schedule_event("test-2", 90000000000, None)
+    def _record(self, message):
+        if isinstance(message, str):
+            message = Message.deserialize(message)
+        self.emitted.append(message)
 
-        es.check_state()  # run one cycle
-        self.assertTrue("test" in es.events)
-        self.assertTrue("test-2" in es.events)
+    def test_an_absolute_path_is_used_as_the_store(self):
+        self.assertEqual(self.scheduler.schedule_file, self.store)
+        self.assertFalse(self.scheduler.is_running)
 
-        es.remove_event("test")
-        es.check_state()  # run one cycle
-        self.assertTrue("test" not in es.events)
-        self.assertTrue("test-2" in es.events)
-        es.shutdown()
+    def test_add_and_remove(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        self.scheduler.schedule_event("skill:test-2", time.time() + 3600)
+        self.assertIn(("skill", "skill:test"), self.scheduler.schedules)
 
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_save(self, mock_open, mock_dump, mock_load, mock_thread):
-        """
-        Test save functionality.
-        """
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
+        self.scheduler.remove_event("skill:test")
+        self.assertNotIn(("skill", "skill:test"), self.scheduler.schedules)
+        self.assertIn(("skill", "skill:test-2"), self.scheduler.schedules)
 
-        # 900000000000 should be in the future for a long time
-        es.schedule_event("test", 900000000000, None)
-        es.schedule_event("test-repeat", 910000000000, 60)
-        es.check_state()
+    def test_a_due_event_is_emitted_with_its_data(self):
+        self.scheduler.schedule_event("skill:test", time.time(), data={"a": 1})
+        self.scheduler.check_state()
+        fired = [m for m in self.emitted if m.msg_type == "skill:test"]
+        self.assertEqual(len(fired), 1)
+        self.assertEqual(fired[0].data, {"a": 1})
 
-        es.shutdown()
+    def test_a_one_shot_is_dropped_once_it_has_fired(self):
+        self.scheduler.schedule_event("skill:test", time.time())
+        self.scheduler.check_state()
+        self.assertEqual(self.scheduler.schedules, {})
 
-        # Make sure the dump method wasn't called with test-repeat
-        self.assertEqual(mock_dump.call_args[0][0], {"test": [(900000000000, None, {}, None)]})
+    def test_scheduling_the_same_name_twice_does_not_duplicate(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        self.scheduler.schedule_event("skill:test", time.time() + 7200)
+        self.assertEqual(len(self.scheduler.schedules), 1)
 
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_send_event(self, mock_open, mock_dump, mock_load, mock_thread):
-        """
-        Test save functionality.
-        """
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
+    def test_repeating_events_survive_a_restart(self):
+        self.scheduler.schedule_event("skill:tick", time.time() + 3600, repeat=60)
+        self.scheduler.shutdown()
 
-        # 0 should be in the future for a long time
-        es.schedule_event("test", time.time(), None)
+        revived = EventScheduler(self.bus, self.store, autostart=False)
+        self.addCleanup(revived.shutdown)
+        self.assertIn(("skill", "skill:tick"), revived.schedules)
 
-        es.check_state()
-        self.assertEqual(emitter.emit.call_args[0][0].msg_type, "test")
-        self.assertEqual(emitter.emit.call_args[0][0].data, {})
-        es.shutdown()
+    def test_update_event_changes_the_data(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600,
+                                      data={"a": 1})
+        self.scheduler.update_event("skill:test", {"a": 2})
+        self.assertEqual(
+            self.scheduler.schedules["skill", "skill:test"].record["data"],
+            {"a": 2})
 
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_list_events_handler(self, mock_open, mock_dump, mock_load, mock_thread):
-        """
-        Test list_events_handler returns all scheduled events.
-        """
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
+    def test_list_events_handler_answers_with_every_schedule(self):
+        self.scheduler.schedule_event("skill:one", time.time() + 36000)
+        self.scheduler.schedule_event("skill:two", time.time() + 7200, repeat=60)
+        self.scheduler.handle_legacy_list(
+            Message("mycroft.scheduler.list_events", {},
+                    {"source": ["a"], "destination": ["b"]}))
+        answers = [m for m in self.emitted if "scheduled_events" in m.data]
+        self.assertEqual(set(answers[-1].data["scheduled_events"]),
+                         {"skill:one", "skill:two"})
 
-        # Schedule a couple of events
-        es.schedule_event("test-event-1", 900000000000, None, {"data": "test1"})
-        es.schedule_event("test-event-2", 910000000000, 60, {"data": "test2"})
+    def test_the_store_is_written_on_every_mutation(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        self.assertTrue(os.path.isfile(self.store))
 
-        # Create a mock message
-        mock_message = MagicMock()
-        mock_message.context = {"source": "test"}
 
-        # Call the handler
-        es.handle_list_events(mock_message)
-
-        # Verify message.reply was called with correct msg_type and data
-        mock_message.response.assert_called_once()
-        call_args = mock_message.response.call_args
-        self.assertIn("scheduled_events", call_args[1]["data"])
-
-        # Verify emitter.emit was called with the reply message
-        emitter.emit.assert_called()
-
-        # Verify the scheduled events contain our test events
-        scheduled_events = call_args[1]["data"]["scheduled_events"]
-        self.assertIn("test-event-1", scheduled_events)
-        self.assertIn("test-event-2", scheduled_events)
-
-        es.shutdown()
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_events_api.py
+++ b/test/unittests/test_events_api.py
@@ -135,9 +135,8 @@ class TestUpdateAndCancel(TestCase):
     def test_get_scheduled_event_status_returns_seconds_left(self):
         future = int((datetime.now() + timedelta(seconds=90)).timestamp())
         self.bus.wait_for_response.return_value = Message(
-            "callback", {0: [future]},
+            "callback", {"event": "my.skill:t", "schedule": [future, None, {}, {}]},
         )
-        # response.data[0][0] — confusingly indexed but matches source
         left = self.api.get_scheduled_event_status("t")
         self.assertGreater(left, 60)
 

--- a/test/unittests/test_scheduler_client.py
+++ b/test/unittests/test_scheduler_client.py
@@ -1,0 +1,178 @@
+"""The SCHEDULER-1 client methods on ``EventSchedulerInterface``."""
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import TestCase
+
+from ovos_utils.fakebus import FakeBus
+
+from ovos_bus_client.apis.events import EventSchedulerInterface, SchedulerError
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import ScheduledEventService
+
+
+class TestSchedulerClient(TestCase):
+    """The client talks to a real service over an in-memory bus."""
+
+    def setUp(self):
+        self.bus = FakeBus()
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.service = ScheduledEventService(self.bus, store_path=self.store,
+                                             autostart=False)
+        self.api = EventSchedulerInterface(bus=self.bus, skill_id="skill.a")
+
+    def tearDown(self):
+        self.service.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
+
+    def test_schedule_returns_an_id_and_get_reads_it_back(self):
+        when = datetime.now(timezone.utc) + timedelta(hours=1)
+        schedule_id = self.api.schedule("ring", at=when, data={"k": 1})
+        record = self.api.get(schedule_id)["record"]
+        self.assertEqual(record["event"], "skill.a.ring")
+        self.assertEqual(record["data"], {"k": 1})
+
+    def test_the_default_id_comes_from_the_event_name_alone(self):
+        now = datetime.now(timezone.utc)
+        ids = {self.api.schedule("ring", at=now + timedelta(hours=n))
+               for n in range(1, 6)}
+        # five calls for one event leave one schedule, whatever the timing
+        self.assertEqual(ids, {"ring"})
+        self.assertEqual(len(self.api.list()), 1)
+
+    def test_a_changed_recurrence_replaces_rather_than_orphans(self):
+        self.api.schedule("sync", every={"seconds": 600})
+        self.api.schedule("sync", every={"seconds": 60})
+        records = [s["record"] for s in self.api.list()]
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["every"]["seconds"], 60)
+
+    def test_the_default_id_does_not_depend_on_the_handler(self):
+        when = datetime.now(timezone.utc) + timedelta(hours=1)
+        first = self.api.schedule("ring", handler=lambda m: None, at=when)
+        second = self.api.schedule("ring", handler=lambda m: None, at=when)
+        self.assertEqual(first, second)
+
+    def test_an_explicit_id_keeps_several_schedules_for_one_event(self):
+        now = datetime.now(timezone.utc)
+        self.api.schedule("ring", at=now + timedelta(hours=1), schedule_id="a")
+        self.api.schedule("ring", at=now + timedelta(hours=2), schedule_id="b")
+        self.assertEqual({s["record"]["id"] for s in self.api.list()}, {"a", "b"})
+
+    def test_a_naive_datetime_is_refused_without_a_zone(self):
+        with self.assertRaises(ValueError):
+            self.api.schedule("ring", at=datetime.now() + timedelta(hours=1))
+
+    def test_a_naive_datetime_is_accepted_with_an_explicit_zone(self):
+        schedule_id = self.api.schedule("ring", zone="Europe/Lisbon",
+                                        at=datetime.now() + timedelta(hours=1))
+        self.assertIsNotNone(self.api.get(schedule_id))
+
+    def test_a_refusal_reaches_the_caller_as_an_error(self):
+        with self.assertRaises(SchedulerError) as caught:
+            self.api.schedule("ring", at=datetime.now(timezone.utc),
+                              data={"blob": "x" * 20000})
+        self.assertEqual(caught.exception.error, "payload_too_large")
+
+    def test_the_handler_is_registered_before_the_request_goes_out(self):
+        seen = []
+        self.api.schedule("ring", handler=lambda m: seen.append(m),
+                          at=datetime.now(timezone.utc) - timedelta(seconds=1))
+        self.service._evaluate()
+        self.assertEqual(len(seen), 1)
+
+    def test_cancel_reports_whether_the_schedule_existed(self):
+        schedule_id = self.api.schedule(
+            "ring", at=datetime.now(timezone.utc) + timedelta(hours=1))
+        self.assertTrue(self.api.cancel(schedule_id))
+        self.assertFalse(self.api.cancel(schedule_id))
+
+    def test_list_shows_only_this_components_schedules(self):
+        when = datetime.now(timezone.utc) + timedelta(hours=1)
+        self.api.schedule("ring", at=when)
+        other = EventSchedulerInterface(bus=self.bus, skill_id="skill.b")
+        other.schedule("ring", at=when)
+        self.assertEqual(
+            [s["record"]["owner"] for s in self.api.list()], ["skill.a"])
+
+    def test_a_recurrence_can_be_created_from_a_local_rule(self):
+        schedule_id = self.api.schedule(
+            "wake", local={"time": "07:30", "zone": "Europe/Lisbon",
+                           "days": ["mon", "fri"]})
+        state = self.api.get(schedule_id)["state"]
+        self.assertIsNotNone(state["next"])
+
+    def test_a_relative_delay_is_accepted(self):
+        schedule_id = self.api.schedule("ring", in_seconds=300)
+        self.assertEqual(self.api.get(schedule_id)["record"]["in"],
+                         {"seconds": 300})
+
+    def test_a_timeout_is_surfaced_as_an_error(self):
+        self.service.shutdown()
+        with self.assertRaises(SchedulerError):
+            self.api._request("scheduler.list", {}, timeout=0.2)
+
+
+class TestLegacyClientMethods(TestCase):
+    """Today's usage patterns keep working, with a deprecation notice."""
+
+    def setUp(self):
+        self.bus = FakeBus()
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.service = ScheduledEventService(self.bus, store_path=self.store,
+                                             autostart=False)
+        self.api = EventSchedulerInterface(bus=self.bus, skill_id="skill.a")
+
+    def tearDown(self):
+        self.service.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
+
+    def test_schedule_event_with_a_delta_in_seconds(self):
+        with self.assertWarns(DeprecationWarning):
+            self.api.schedule_event(lambda m: None, when=3600, name="t")
+        self.assertIn(("skill.a", "skill.a:t"), self.service.schedules)
+
+    def test_schedule_event_with_a_datetime(self):
+        when = datetime.now(timezone.utc) + timedelta(hours=1)
+        with self.assertWarns(DeprecationWarning):
+            self.api.schedule_event(lambda m: None, when=when, name="t")
+        self.assertIn(("skill.a", "skill.a:t"), self.service.schedules)
+
+    def test_a_repeating_event_becomes_a_recurrence(self):
+        with self.assertWarns(DeprecationWarning):
+            self.api.schedule_repeating_event(lambda m: None, when=None,
+                                              interval=60, name="tick")
+        record = self.service.schedules["skill.a", "skill.a:tick"].record
+        self.assertEqual(record["every"]["seconds"], 60)
+
+    def test_cancel_scheduled_event_removes_the_schedule(self):
+        with self.assertWarns(DeprecationWarning):
+            self.api.schedule_event(lambda m: None, when=3600, name="t")
+            self.api.cancel_scheduled_event("t")
+        self.assertEqual(self.service.schedules, {})
+
+    def test_get_scheduled_event_status_returns_the_seconds_left(self):
+        with self.assertWarns(DeprecationWarning):
+            self.api.schedule_event(lambda m: None, when=3600, name="t")
+        left = self.api.get_scheduled_event_status("t")
+        self.assertGreater(left, 3500)
+
+    def test_a_scheduled_handler_still_runs_on_its_event(self):
+        seen = []
+        with self.assertWarns(DeprecationWarning):
+            self.api.schedule_event(seen.append, when=0, name="t")
+        self.service._evaluate()
+        self.assertEqual(len(seen), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_scheduler_conformance.py
+++ b/test/unittests/test_scheduler_conformance.py
@@ -1,0 +1,894 @@
+"""SCHEDULER-1 conformance suite — one test per MUST of §9."""
+import json
+import os
+import tempfile
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from ovos_utils.fakebus import FakeBus
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import (
+    LEGACY_REMOVAL_VERSION, MAX_DATA_BYTES, MAX_REPORTED, Schedule,
+    ScheduledEventService, format_instant, validate_record)
+
+
+def iso(when: datetime) -> str:
+    return when.isoformat()
+
+
+class Recorder:
+    """Captures every message the service emits, in order."""
+
+    def __init__(self, bus):
+        self.messages = []
+        bus.on("message", self._on)
+
+    def _on(self, message):
+        if isinstance(message, str):
+            message = Message.deserialize(message)
+        self.messages.append(message)
+
+    def types(self):
+        return [m.msg_type for m in self.messages]
+
+    def of(self, msg_type):
+        return [m for m in self.messages if m.msg_type == msg_type]
+
+    def last(self, msg_type):
+        found = self.of(msg_type)
+        return found[-1] if found else None
+
+
+class SchedulerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        self.recorder = Recorder(self.bus)
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.service = ScheduledEventService(self.bus, store_path=self.store,
+                                             autostart=False)
+
+    def tearDown(self):
+        self.service.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
+
+    def request(self, topic, data, context=None, service=None):
+        service = service or self.service
+        message = Message(topic, data, context or {})
+        getattr(service, f"handle_{topic.split('.')[1]}")(message)
+        return self.recorder.last(f"{topic}.response")
+
+    def schedule(self, **data):
+        data.setdefault("owner", "skill.a")
+        data.setdefault("id", "one")
+        data.setdefault("event", "skill.a.ring")
+        return self.request("scheduler.schedule", data)
+
+
+class TestValidationAndAnswers(SchedulerTestCase):
+    """§9.1 — validate every field and answer every request exactly once."""
+
+    def test_every_request_is_answered_once(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        self.assertEqual(len(self.recorder.of("scheduler.schedule.response")), 1)
+        self.request("scheduler.get", {"owner": "skill.a", "id": "one"})
+        self.assertEqual(len(self.recorder.of("scheduler.get.response")), 1)
+
+    def test_naive_instant_is_rejected(self):
+        response = self.schedule(at="2031-03-29T07:30:00")
+        self.assertFalse(response.data["ok"])
+        self.assertEqual(response.data["error"], "bad_instant")
+
+    def test_two_timing_fields_are_rejected(self):
+        response = self.schedule(at=iso(datetime.now(timezone.utc)),
+                                 every={"seconds": 10})
+        self.assertEqual(response.data["error"], "invalid_record")
+
+    def test_missing_timing_is_rejected(self):
+        self.assertEqual(self.schedule().data["error"], "invalid_record")
+
+    def test_an_event_with_a_colon_in_the_name_is_rejected(self):
+        response = self.schedule(event="skill.a.ring:now",
+                                 at=iso(datetime.now(timezone.utc)))
+        self.assertEqual(response.data["error"], "bad_event")
+
+    def test_an_event_that_is_only_the_owner_is_rejected(self):
+        response = self.schedule(event="skill.a.",
+                                 at=iso(datetime.now(timezone.utc)))
+        self.assertEqual(response.data["error"], "bad_event")
+
+    def test_bad_recurrence_is_rejected(self):
+        self.assertEqual(self.schedule(every={"seconds": 0}).data["error"],
+                         "bad_recurrence")
+        self.assertEqual(
+            self.schedule(local={"time": "07:30", "zone": "Mars/Olympus"}).data["error"],
+            "bad_recurrence")
+
+    def test_payload_cap(self):
+        response = self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)),
+                                 data={"blob": "x" * (MAX_DATA_BYTES + 100)})
+        self.assertEqual(response.data["error"], "payload_too_large")
+
+    def test_until_with_one_shot_is_rejected(self):
+        response = self.schedule(at=iso(datetime.now(timezone.utc)),
+                                 until=iso(datetime.now(timezone.utc)))
+        self.assertEqual(response.data["error"], "invalid_record")
+
+    def test_cancel_of_absent_schedule_is_not_an_error(self):
+        response = self.request("scheduler.cancel",
+                                {"owner": "skill.a", "id": "nope"})
+        self.assertTrue(response.data["ok"])
+        self.assertFalse(response.data["existed"])
+
+    def test_round_trip_schedule_get_list_cancel(self):
+        when = datetime.now(timezone.utc) + timedelta(hours=1)
+        created = self.schedule(at=iso(when))
+        self.assertTrue(created.data["ok"])
+        self.assertEqual(created.data["next"], iso(when))
+
+        got = self.request("scheduler.get", {"owner": "skill.a", "id": "one"})
+        self.assertEqual(got.data["record"]["event"], "skill.a.ring")
+        self.assertEqual(got.data["state"]["next"], iso(when))
+        self.assertIsNone(got.data["state"]["last_fired"])
+        self.assertEqual(got.data["state"]["missed"], [])
+
+        listed = self.request("scheduler.list", {"owner": "skill.a"})
+        self.assertEqual([s["record"]["id"] for s in listed.data["schedules"]],
+                         ["one"])
+
+        cancelled = self.request("scheduler.cancel",
+                                 {"owner": "skill.a", "id": "one"})
+        self.assertTrue(cancelled.data["existed"])
+        listed = self.request("scheduler.list", {"owner": "skill.a"})
+        self.assertEqual(listed.data["schedules"], [])
+
+
+class TestPersistence(SchedulerTestCase):
+    """§9.2 — persist before answering and before firing, atomically."""
+
+    def test_store_is_written_before_the_response(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        with open(self.store) as handle:
+            stored = json.load(handle)
+        self.assertEqual(stored["schedules"][0]["record"]["id"], "one")
+
+    def test_the_due_of_a_fired_occurrence_is_persisted_after_the_event(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self.schedule(id="tick", event="skill.a.tick", grace_s=600,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 1)
+        with open(self.store) as handle:
+            stored = json.load(handle)
+        self.assertEqual(stored["schedules"][0]["last_fired"], iso(start))
+
+    def test_an_occurrence_at_or_before_the_persisted_due_never_fires_again(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self.schedule(id="tick", event="skill.a.tick", grace_s=600,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        schedule = self.service.schedules["skill.a", "tick"]
+        # a replacement store handed a stale cursor must not replay the fire
+        schedule.cursor = start - timedelta(seconds=60)
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 1)
+
+    def test_a_crash_between_the_temp_write_and_the_replace_keeps_old_state(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        before = open(self.store).read()
+        with patch("os.replace", side_effect=OSError("power loss")):
+            response = self.schedule(id="two",
+                                     at=iso(datetime.now(timezone.utc) +
+                                            timedelta(hours=2)))
+        self.assertEqual(open(self.store).read(), before)
+        self.assertFalse(response.data["ok"])
+        self.assertEqual(response.data["error"], "internal")
+
+    def test_an_unwritable_store_still_answers_a_cancel(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        with patch("os.replace", side_effect=OSError("read-only")):
+            response = self.request("scheduler.cancel",
+                                    {"owner": "skill.a", "id": "one"})
+        self.assertEqual(response.data["error"], "internal")
+
+    def test_an_unstorable_creation_leaves_no_trace_in_memory(self):
+        with patch("os.replace", side_effect=OSError("read-only")):
+            response = self.schedule(
+                at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        self.assertEqual(response.data["error"], "internal")
+        # the running process agrees with the store it would restart from
+        self.assertEqual(self.service.schedules, {})
+
+    def test_an_unstorable_replacement_keeps_the_previous_schedule(self):
+        first = datetime.now(timezone.utc) + timedelta(hours=1)
+        self.schedule(at=iso(first))
+        with patch("os.replace", side_effect=OSError("read-only")):
+            response = self.schedule(
+                at=iso(datetime.now(timezone.utc) + timedelta(hours=5)))
+        self.assertEqual(response.data["error"], "internal")
+        self.assertEqual(
+            self.service.schedules["skill.a", "one"].record["at"], iso(first))
+
+    def test_an_unstorable_cancel_keeps_the_schedule(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(at=when)
+        with patch("os.replace", side_effect=OSError("read-only")):
+            response = self.request("scheduler.cancel",
+                                    {"owner": "skill.a", "id": "one"})
+        self.assertEqual(response.data["error"], "internal")
+        self.assertIn(("skill.a", "one"), self.service.schedules)
+        # and it is still cancellable once the store is writable again
+        self.assertTrue(self.request("scheduler.cancel",
+                                     {"owner": "skill.a", "id": "one"}
+                                     ).data["existed"])
+
+    def test_an_unstorable_wildcard_cancel_keeps_every_schedule(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        self.schedule(owner="skill.b", event="skill.b.ring", at=when)
+        self.service.admins = ["admin.panel"]
+        with patch("os.replace", side_effect=OSError("read-only")):
+            response = self.request("scheduler.cancel", {"owner": "*", "id": "one"},
+                                    context={"skill_id": "admin.panel"})
+        self.assertEqual(response.data["error"], "internal")
+        self.assertEqual(len(self.service.schedules), 2)
+
+    def test_a_corrupt_store_timestamp_does_not_stop_the_service(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        with open(self.store) as handle:
+            stored = json.load(handle)
+        stored["written_at"] = "nonsense"
+        with open(self.store, "w") as handle:
+            json.dump(stored, handle)
+        revived = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        self.addCleanup(revived.shutdown)
+        self.assertIn(("skill.a", "one"), revived.schedules)
+        self.assertTrue(revived._clock_synced)
+
+    def test_one_fire_is_persisted_before_the_next_is_emitted(self):
+        # a kill anywhere inside a backlog may repeat the occurrence that
+        # was in flight, and nothing earlier
+        start = datetime.now(timezone.utc) - timedelta(seconds=35)
+        self.schedule(id="tick", event="skill.a.tick", misfire="all",
+                      grace_s=0, every={"seconds": 10, "start": iso(start)})
+        # the store as it stands the instant after each event leaves the
+        # bus, which is where a kill can land
+        kill_points = []
+        real_fire = self.service._fire
+
+        def watched(schedule, due):
+            real_fire(schedule, due)
+            kill_points.append((format_instant(due), open(self.store).read()))
+
+        self.service._fire = watched
+        self.service._evaluate()
+        fired = [due for due, _ in kill_points]
+        self.assertEqual(len(fired), 4)
+
+        for position, (due, state) in enumerate(kill_points):
+            with open(self.store, "w") as handle:
+                handle.write(state)
+            bus = FakeBus()
+            recorder = Recorder(bus)
+            revived = ScheduledEventService(bus, store_path=self.store,
+                                            autostart=False)
+            revived.replay()
+            already = set(fired[:position + 1])
+            repeated = [m for m in recorder.of("skill.a.tick")
+                        if m.context["scheduler"]["due"] in already]
+            revived.shutdown()
+            self.assertLessEqual(
+                len(repeated), 1,
+                f"a kill just after the fire for {due} repeated "
+                f"{len(repeated)} already-emitted occurrences")
+
+    def test_ephemeral_schedules_are_never_persisted(self):
+        self.schedule(id="kept",
+                      at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        self.schedule(id="gone", ephemeral=True,
+                      at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        with open(self.store) as handle:
+            stored = json.load(handle)
+        self.assertEqual([s["record"]["id"] for s in stored["schedules"]], ["kept"])
+
+        revived = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        self.assertEqual([k[1] for k in revived.schedules], ["kept"])
+        revived.shutdown()
+
+
+class TestIdempotency(SchedulerTestCase):
+    """§9.3 — replace on identical identity, never duplicate."""
+
+    def test_rescheduling_the_same_identity_replaces(self):
+        first = datetime.now(timezone.utc) + timedelta(hours=1)
+        second = datetime.now(timezone.utc) + timedelta(hours=2)
+        self.assertFalse(self.schedule(at=iso(first)).data["replaced"])
+        response = self.schedule(at=iso(second))
+        self.assertTrue(response.data["replaced"])
+        self.assertEqual(response.data["next"], iso(second))
+        self.assertEqual(len(self.service.schedules), 1)
+
+    def test_two_owners_may_use_the_same_id(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        self.schedule(owner="skill.b", event="skill.b.ring", at=when)
+        self.assertEqual(len(self.service.schedules), 2)
+
+
+class TestReplay(SchedulerTestCase):
+    """§9.4 and §9.6 — restore, apply the misfire policy, announce ready."""
+
+    def _downtime(self, misfire, **extra):
+        """Persist a schedule due in the past, then start a fresh service."""
+        due = datetime.now(timezone.utc) - timedelta(minutes=30)
+        record = validate_record(dict(
+            {"id": "one", "owner": "skill.a", "event": "skill.a.ring",
+             "misfire": misfire, "at": iso(due)}, **extra))
+        service = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        service.schedules[record["owner"], record["id"]] = Schedule(record)
+        service._persist()
+        service.shutdown()
+        self.recorder.messages.clear()
+        revived = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        revived.replay()
+        return revived, due
+
+    def test_late_policy_fires_the_missed_one_shot_and_reports_it(self):
+        revived, due = self._downtime("late")
+        self.addCleanup(revived.shutdown)
+        missed = self.recorder.last("scheduler.missed")
+        self.assertEqual(missed.data["missed"], [iso(due)])
+        self.assertEqual(missed.data["fired_late"], [iso(due)])
+        fired = self.recorder.last("skill.a.ring")
+        self.assertEqual(fired.context["scheduler"]["due"], iso(due))
+        self.assertEqual(
+            self.recorder.types(),
+            ["scheduler.ready", "scheduler.missed", "skill.a.ring"])
+        ready = self.recorder.last("scheduler.ready")
+        # the count is what the store held, before replay consumed anything
+        self.assertEqual(ready.data, {"schedules": 1, "missed": 1,
+                                      "clock": "synchronized"})
+
+    def test_ready_counts_what_the_store_held_not_what_survives(self):
+        now = datetime.now(timezone.utc)
+        service = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        for name, when in (("overdue", now - timedelta(minutes=30)),
+                           ("later", now + timedelta(hours=1))):
+            record = validate_record({"id": name, "owner": "skill.a",
+                                      "event": "skill.a.ring", "at": iso(when)})
+            service.schedules["skill.a", name] = Schedule(record)
+        service._persist()
+        service.shutdown()
+        self.recorder.messages.clear()
+
+        revived = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        self.addCleanup(revived.shutdown)
+        revived.replay()
+        self.assertEqual(self.recorder.last("scheduler.ready").data["schedules"], 2)
+
+    def test_skip_policy_reports_but_does_not_fire(self):
+        revived, due = self._downtime("skip")
+        self.addCleanup(revived.shutdown)
+        self.assertEqual(self.recorder.of("skill.a.ring"), [])
+        self.assertEqual(self.recorder.last("scheduler.missed").data["fired_late"], [])
+        self.assertIn("scheduler.ready", self.recorder.types())
+
+    def test_all_policy_fires_every_missed_occurrence_oldest_first(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=50)
+        record = validate_record(
+            {"id": "tick", "owner": "skill.a", "event": "skill.a.tick",
+             "misfire": "all", "grace_s": 0, "count": 4,
+             "every": {"seconds": 10, "start": iso(start)}})
+        service = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        service.schedules[record["owner"], record["id"]] = Schedule(record)
+        service._persist()
+        service.shutdown()
+        self.recorder.messages.clear()
+
+        revived = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        self.addCleanup(revived.shutdown)
+        revived.replay()
+        dues = [m.context["scheduler"]["due"]
+                for m in self.recorder.of("skill.a.tick")]
+        self.assertEqual(dues, sorted(dues))
+        self.assertEqual(len(dues), 4)
+        self.assertEqual(dues[0], iso(start))
+
+    def test_one_shot_is_deleted_after_it_is_reported(self):
+        revived, _ = self._downtime("skip")
+        self.addCleanup(revived.shutdown)
+        self.assertEqual(revived.schedules, {})
+
+    def test_a_recurring_schedule_survives_a_restart(self):
+        self.schedule(id="tick", event="skill.a.tick",
+                      every={"seconds": 3600,
+                             "start": iso(datetime.now(timezone.utc) +
+                                          timedelta(hours=1))})
+        self.service.shutdown()
+        revived = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        self.addCleanup(revived.shutdown)
+        self.assertIn(("skill.a", "tick"), revived.schedules)
+
+
+class TestFiredMessage(SchedulerTestCase):
+    """§9.5 — a fresh context carrying the scheduler fields, no session."""
+
+    def test_fired_event_carries_only_scheduler_context(self):
+        due = datetime.now(timezone.utc) - timedelta(seconds=1)
+        self.schedule(at=iso(due), data={"key": "value"},
+                      context={"session": {"session_id": "abc"},
+                               "skill_id": "skill.a"})
+        self.service._evaluate()
+        fired = self.recorder.last("skill.a.ring")
+        self.assertEqual(fired.data, {"key": "value"})
+        self.assertNotEqual(
+            fired.context.get("session", {}).get("session_id"), "abc")
+        self.assertEqual(fired.context["scheduler"]["id"], "one")
+        self.assertEqual(fired.context["scheduler"]["owner"], "skill.a")
+        self.assertEqual(fired.context["scheduler"]["due"], iso(due))
+
+    def test_remaining_counts_down_across_a_late_batch(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self.schedule(id="tick", event="skill.a.tick", count=10, misfire="all",
+                      grace_s=0, every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        remaining = [m.context["scheduler"]["remaining"]
+                     for m in self.recorder.of("skill.a.tick")]
+        self.assertEqual(remaining, [9, 8, 7])
+
+
+class TestRecurrence(SchedulerTestCase):
+    """§9.7 — anchored periods, wall-clock recurrence with the DST rules."""
+
+    def test_a_late_fire_does_not_shift_the_following_occurrences(self):
+        start = datetime(2031, 1, 1, 0, 0, tzinfo=timezone.utc)
+        record = validate_record(
+            {"id": "tick", "owner": "skill.a", "event": "skill.a.tick",
+             "every": {"seconds": 600, "start": iso(start)}})
+        schedule = Schedule(record)
+        # the fire for 00:10 happens five minutes late; the next occurrence
+        # is still on the schedule's own phase, not five minutes behind it
+        late_fire = start + timedelta(minutes=15)
+        schedule.cursor = start + timedelta(minutes=10)
+        self.assertEqual(schedule.next_after(late_fire),
+                         start + timedelta(minutes=20))
+
+    def test_local_recurrence_across_a_spring_forward_gap(self):
+        # Europe/Lisbon jumps 01:00 -> 02:00 on 2031-03-30, so 01:30 does
+        # not exist and the occurrence is the first instant after the gap
+        record = validate_record(
+            {"id": "x", "owner": "skill.a", "event": "skill.a.x",
+             "local": {"time": "01:30", "zone": "Europe/Lisbon"}})
+        occurrence = Schedule(record).next_after(
+            datetime(2031, 3, 29, 12, tzinfo=timezone.utc))
+        lisbon = occurrence.astimezone(ZoneInfo("Europe/Lisbon"))
+        self.assertEqual(lisbon.date().isoformat(), "2031-03-30")
+        self.assertEqual(lisbon.strftime("%H:%M"), "02:00")
+
+    def test_local_recurrence_across_a_fall_back_overlap(self):
+        # America/New_York reads 01:30 twice on 2031-11-02; the occurrence
+        # is the first of the two, still on daylight time
+        record = validate_record(
+            {"id": "x", "owner": "skill.a", "event": "skill.a.x",
+             "local": {"time": "01:30", "zone": "America/New_York"}})
+        occurrence = Schedule(record).next_after(
+            datetime(2031, 11, 1, 12, tzinfo=timezone.utc))
+        self.assertEqual(occurrence.utcoffset(), timedelta(hours=-4))
+        self.assertEqual(
+            occurrence.astimezone(ZoneInfo("America/New_York")).strftime("%H:%M"),
+            "01:30")
+
+    def test_local_recurrence_honours_the_day_list(self):
+        record = validate_record(
+            {"id": "x", "owner": "skill.a", "event": "skill.a.x",
+             "local": {"time": "07:30", "zone": "Europe/Lisbon",
+                       "days": ["mon"]}})
+        schedule = Schedule(record)
+        # 2031-01-01 is a Wednesday; the next Monday is the 6th
+        occurrence = schedule.next_after(
+            datetime(2031, 1, 1, 12, tzinfo=timezone.utc))
+        self.assertEqual(
+            occurrence.astimezone(ZoneInfo("Europe/Lisbon")).date().isoformat(),
+            "2031-01-06")
+
+    def test_until_stops_the_recurrence(self):
+        start = datetime(2031, 1, 1, tzinfo=timezone.utc)
+        record = validate_record(
+            {"id": "x", "owner": "skill.a", "event": "skill.a.x",
+             "until": iso(start + timedelta(seconds=25)),
+             "every": {"seconds": 10, "start": iso(start)}})
+        schedule = Schedule(record)
+        schedule.cursor = start + timedelta(seconds=20)
+        self.assertIsNone(schedule.next_after(schedule.cursor))
+
+    def test_count_stops_the_recurrence(self):
+        start = datetime(2031, 1, 1, tzinfo=timezone.utc)
+        record = validate_record(
+            {"id": "x", "owner": "skill.a", "event": "skill.a.x", "count": 2,
+             "every": {"seconds": 10, "start": iso(start)}})
+        schedule = Schedule(record)
+        schedule.consumed = 2
+        self.assertIsNone(schedule.next_after(start))
+
+
+class TestOwnership(SchedulerTestCase):
+    """§9.8 — the event namespace and owner scoping."""
+
+    def test_an_event_outside_the_owner_namespace_is_rejected(self):
+        response = self.schedule(event="mycroft.stop",
+                                 at=iso(datetime.now(timezone.utc)))
+        self.assertEqual(response.data["error"], "bad_event")
+
+    def test_an_authenticated_identity_may_not_act_for_another_owner(self):
+        response = self.request(
+            "scheduler.schedule",
+            {"owner": "skill.a", "id": "one", "event": "skill.a.ring",
+             "at": iso(datetime.now(timezone.utc) + timedelta(hours=1))},
+            context={"skill_id": "skill.b"})
+        self.assertEqual(response.data["error"], "not_owner")
+
+    def test_cancel_and_get_are_scoped_by_owner(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        cancelled = self.request("scheduler.cancel",
+                                 {"owner": "skill.b", "id": "one"})
+        self.assertFalse(cancelled.data["existed"])
+        self.assertIn(("skill.a", "one"), self.service.schedules)
+        got = self.request("scheduler.get", {"owner": "skill.b", "id": "one"})
+        self.assertIsNone(got.data["record"])
+        self.assertFalse(got.data["existed"])
+
+    def test_list_shows_only_the_callers_schedules(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        self.schedule(owner="skill.b", event="skill.b.ring", at=when)
+        listed = self.request("scheduler.list", {"owner": "skill.b"})
+        self.assertEqual([s["record"]["owner"] for s in listed.data["schedules"]],
+                         ["skill.b"])
+
+
+class TestClock(SchedulerTestCase):
+    """§9.9 — clock steps never double-fire; an unsynchronized clock defers."""
+
+    def test_a_forward_step_fires_each_occurrence_once(self):
+        start = datetime.now(timezone.utc) + timedelta(seconds=10)
+        self.schedule(id="tick", event="skill.a.tick", misfire="all",
+                      grace_s=0, every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a.tick"), [])
+
+        jumped = start + timedelta(seconds=25)
+        with patch.object(ScheduledEventService, "_now", staticmethod(lambda: jumped)):
+            self.service._evaluate()
+            first = [m.context["scheduler"]["due"]
+                     for m in self.recorder.of("skill.a.tick")]
+            # a second evaluation at the same instant must add nothing
+            self.service._evaluate()
+        second = [m.context["scheduler"]["due"]
+                  for m in self.recorder.of("skill.a.tick")]
+        self.assertEqual(len(first), 3)
+        self.assertEqual(first, second)
+
+    def test_a_backward_step_does_not_refire_a_consumed_occurrence(self):
+        due = datetime.now(timezone.utc) - timedelta(seconds=1)
+        self.schedule(at=iso(due))
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+        rewound = due - timedelta(hours=2)
+        with patch.object(ScheduledEventService, "_now", staticmethod(lambda: rewound)):
+            self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+
+    def test_a_step_is_detected_against_the_monotonic_clock(self):
+        self.service._wall_reference = time.time() - 3600
+        self.service._mono_reference = time.monotonic()
+        self.assertGreater(abs(self.service._clock_stepped()), 2)
+        self.assertEqual(self.service._clock_stepped(), 0.0)
+
+    def test_an_unsynchronized_clock_defers_rather_than_drops(self):
+        # the wall clock reads before the newest instant a past run wrote
+        self.service._written_at = datetime.now(timezone.utc) + timedelta(days=400)
+        self.service._clock_synced = False
+        due = datetime.now(timezone.utc) - timedelta(seconds=1)
+        response = self.schedule(at=iso(due))
+        self.assertTrue(response.data["ok"])
+        self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a.ring"), [])
+
+        self.service.handle_clock_synced(Message("system.clock.synced"))
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+        ready = self.recorder.last("scheduler.ready")
+        self.assertEqual(ready.data["clock"], "synchronized")
+
+    def test_the_clock_syncs_when_the_wall_clock_passes_the_stored_instant(self):
+        self.service._written_at = datetime.now(timezone.utc) - timedelta(days=1)
+        self.service._clock_synced = False
+        self.service.tick()
+        self.assertTrue(self.service._clock_synced)
+        self.assertIn("scheduler.ready", self.recorder.types())
+
+
+class TestLegacyAdapter(SchedulerTestCase):
+    """The pre-specification protocol keeps working for one stable cycle."""
+
+    def emit_legacy(self, **data):
+        self.bus.emit(Message("mycroft.scheduler.schedule_event", data))
+
+    def test_schedule_and_fire_through_the_legacy_topic(self):
+        self.emit_legacy(event="skill.a:ring", time=time.time() - 1,
+                         data={"k": 1})
+        self.service._evaluate()
+        self.assertEqual(self.recorder.last("skill.a:ring").data, {"k": 1})
+
+    def test_legacy_one_shot_with_an_existing_name_replaces(self):
+        for _ in range(3):
+            self.emit_legacy(event="skill.a:ring", time=time.time() + 3600)
+        self.assertEqual(len(self.service.schedules), 1)
+        self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a:ring"), [])
+
+    def test_legacy_remove_event(self):
+        self.emit_legacy(event="skill.a:ring", time=time.time() + 3600)
+        self.bus.emit(Message("mycroft.scheduler.remove_event",
+                              {"event": "skill.a:ring"}))
+        self.assertEqual(self.service.schedules, {})
+
+    def test_legacy_update_event_replaces_the_data(self):
+        self.emit_legacy(event="skill.a:ring", time=time.time() + 3600,
+                         data={"k": 1})
+        self.bus.emit(Message("mycroft.scheduler.update_event",
+                              {"event": "skill.a:ring", "data": {"k": 2}}))
+        self.assertEqual(
+            self.service.schedules["skill.a", "skill.a:ring"].record["data"],
+            {"k": 2})
+
+    def test_legacy_get_event_answers_on_its_callback_topic(self):
+        when = time.time() + 3600
+        self.emit_legacy(event="skill.a:ring", time=when)
+        self.service.handle_legacy_get(
+            Message("mycroft.scheduler.get_event", {"name": "skill.a:ring"}))
+        reply = self.recorder.last("mycroft.event_status.callback.skill.a:ring")
+        self.assertAlmostEqual(reply.data["schedule"][0], when, places=0)
+
+    def test_legacy_list_events_keeps_its_reply_shape(self):
+        self.emit_legacy(event="skill.a:ring", time=time.time() + 3600)
+        self.service.handle_legacy_list(
+            Message("mycroft.scheduler.list_events", {},
+                    {"source": ["x"], "destination": ["y"]}))
+        listed = [m for m in self.recorder.messages if "scheduled_events" in m.data]
+        self.assertIn("skill.a:ring", listed[-1].data["scheduled_events"])
+
+    def test_a_legacy_repeat_becomes_a_fixed_period_recurrence(self):
+        self.emit_legacy(event="skill.a:tick", time=time.time() + 60, repeat=30)
+        record = self.service.schedules["skill.a", "skill.a:tick"].record
+        self.assertEqual(record["every"]["seconds"], 30)
+
+    def test_an_unnamespaced_legacy_event_is_owned_by_legacy(self):
+        self.emit_legacy(event="bare", time=time.time() + 60)
+        self.assertIn(("legacy", "bare"), self.service.schedules)
+
+    def test_the_deprecation_notice_names_the_removal_version(self):
+        with patch("ovos_bus_client.util.scheduled_events.LOG") as log:
+            self.emit_legacy(event="skill.a:ring", time=time.time() + 60)
+            self.emit_legacy(event="skill.a:other", time=time.time() + 60)
+        notices = [c.args[0] for c in log.warning.call_args_list]
+        # warned once for the topic, naming the release that drops it
+        self.assertEqual(len(notices), 1)
+        self.assertIn(LEGACY_REMOVAL_VERSION, notices[0])
+
+    def test_the_store_moves_out_of_the_configuration_directory(self):
+        with tempfile.TemporaryDirectory() as config_dir:
+            old = os.path.join(config_dir, "schedule.json")
+            with open(old, "w") as handle:
+                json.dump({"skill.a:ring": [[time.time() + 3600, None, {}, {}]]},
+                          handle)
+            if os.path.isfile(self.store):
+                os.unlink(self.store)
+            with patch("ovos_bus_client.util.scheduled_events."
+                       "get_xdg_config_save_path", return_value=config_dir):
+                migrated = ScheduledEventService(self.bus, store_path=self.store,
+                                                 autostart=False)
+            self.addCleanup(migrated.shutdown)
+            self.assertIn(("skill.a", "skill.a:ring"), migrated.schedules)
+            self.assertTrue(os.path.isfile(self.store))
+            # the original stays put so a downgrade still finds it
+            self.assertTrue(os.path.isfile(old))
+            self.assertTrue(os.path.isfile(f"{old}.migrated"))
+
+            again = ScheduledEventService(self.bus, store_path=self.store,
+                                          autostart=False)
+            self.addCleanup(again.shutdown)
+            self.assertEqual(len(again.schedules), 1)
+
+
+class TestRelativeDelay(SchedulerTestCase):
+    """``in`` runs off the monotonic clock, so a wall step cannot move it."""
+
+    def test_a_wall_clock_step_does_not_fire_a_relative_delay_early(self):
+        self.schedule(**{"in": {"seconds": 300}})
+        jumped = datetime.now(timezone.utc) + timedelta(hours=5)
+        with patch.object(ScheduledEventService, "_now", staticmethod(lambda: jumped)):
+            self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a.ring"), [])
+
+    def test_a_relative_delay_fires_when_the_monotonic_deadline_passes(self):
+        self.schedule(**{"in": {"seconds": 300}})
+        schedule = self.service.schedules["skill.a", "one"]
+        schedule.deadline = time.monotonic() - 1
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+        self.assertEqual(self.service.schedules, {})
+
+    def test_a_relative_delay_is_persisted_as_a_wall_clock_estimate(self):
+        self.schedule(**{"in": {"seconds": 300}})
+        with open(self.store) as handle:
+            stored = json.load(handle)
+        self.assertIsNotNone(stored["schedules"][0]["estimate"])
+        self.assertEqual(stored["schedules"][0]["record"]["in"], {"seconds": 300})
+
+    def test_until_and_count_are_refused_for_a_relative_delay(self):
+        response = self.schedule(count=2, **{"in": {"seconds": 300}})
+        self.assertEqual(response.data["error"], "invalid_record")
+
+
+class TestBounds(SchedulerTestCase):
+    """Occurrences the misfire policy drops still count against ``count``."""
+
+    def test_skipped_occurrences_are_consumed_against_count(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      grace_s=0, count=3,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a.tick"), [])
+        # three occurrences passed; the bound is spent and the record is gone
+        self.assertEqual(self.service.schedules, {})
+
+    def test_all_respects_until(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=55)
+        self.schedule(id="tick", event="skill.a.tick", misfire="all", grace_s=0,
+                      until=iso(start + timedelta(seconds=25)),
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 3)
+
+    def test_a_long_downtime_caps_and_flags_the_missed_report(self):
+        backlog = 5 * MAX_REPORTED
+        start = datetime.now(timezone.utc) - timedelta(seconds=backlog)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      grace_s=0, every={"seconds": 1, "start": iso(start)})
+        self.service._evaluate()
+        missed = self.recorder.last("scheduler.missed")
+        self.assertEqual(len(missed.data["missed"]), MAX_REPORTED)
+        self.assertTrue(missed.data["truncated"])
+        # the whole backlog was consumed even though only part was reported
+        self.assertGreaterEqual(
+            self.service.schedules["skill.a", "tick"].consumed, backlog)
+
+    def test_a_backlog_inside_the_cap_is_not_flagged(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      grace_s=0, every={"seconds": 1, "start": iso(start)})
+        self.service._evaluate()
+        self.assertFalse(self.recorder.last("scheduler.missed").data["truncated"])
+
+    def test_missed_dues_show_up_in_the_computed_state(self):
+        due = datetime.now(timezone.utc) - timedelta(hours=2)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      every={"seconds": 86400, "start": iso(due)})
+        self.service._evaluate()
+        got = self.request("scheduler.get", {"owner": "skill.a", "id": "tick"})
+        self.assertEqual(got.data["state"]["missed"], [iso(due)])
+
+    def test_a_fire_clears_the_missed_dues_that_precede_it(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self.schedule(id="tick", event="skill.a.tick", misfire="late",
+                      grace_s=0, every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        got = self.request("scheduler.get", {"owner": "skill.a", "id": "tick"})
+        self.assertEqual(got.data["state"]["missed"], [])
+        self.assertEqual(got.data["state"]["last_fired"],
+                         iso(start + timedelta(seconds=20)))
+
+    def test_replay_reports_every_occurrence_it_produces(self):
+        # an occurrence emitted just before a crash may have lost its
+        # record, so replay reports it even when it is inside the grace
+        start = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self.schedule(id="tick", event="skill.a.tick", grace_s=600,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service.replay()
+        missed = self.recorder.last("scheduler.missed")
+        self.assertEqual(missed.data["missed"], [iso(start)])
+        self.assertEqual(missed.data["fired_late"], [])
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 1)
+
+
+class TestAdministrativeOwner(SchedulerTestCase):
+    """``*`` reaches every owner, and only for a configured administrator."""
+
+    def populate(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        self.schedule(owner="skill.b", event="skill.b.ring", at=when)
+
+    def test_an_anonymous_caller_may_not_use_the_wildcard(self):
+        self.populate()
+        listed = self.request("scheduler.list", {"owner": "*"})
+        self.assertEqual(listed.data["error"], "not_owner")
+        cancelled = self.request("scheduler.cancel", {"owner": "*", "id": "one"})
+        self.assertEqual(cancelled.data["error"], "not_owner")
+        self.assertEqual(len(self.service.schedules), 2)
+
+    def test_an_identified_caller_outside_the_allowlist_may_not_either(self):
+        self.populate()
+        listed = self.request("scheduler.list", {"owner": "*"},
+                              context={"skill_id": "skill.a"})
+        self.assertEqual(listed.data["error"], "not_owner")
+
+    def test_an_allowlisted_administrator_lists_and_cancels_everything(self):
+        self.populate()
+        self.service.admins = ["admin.panel"]
+        listed = self.request("scheduler.list", {"owner": "*"},
+                              context={"skill_id": "admin.panel"})
+        self.assertEqual(len(listed.data["schedules"]), 2)
+        self.request("scheduler.cancel", {"owner": "*", "id": "one"},
+                     context={"skill_id": "admin.panel"})
+        self.assertEqual(self.service.schedules, {})
+
+    def test_the_allowlist_is_empty_unless_configured(self):
+        self.assertEqual(self.service.admins, [])
+
+    def test_no_schedule_may_be_created_under_the_wildcard(self):
+        response = self.schedule(owner="*", event="*.ring",
+                                 at=iso(datetime.now(timezone.utc)))
+        self.assertEqual(response.data["error"], "not_owner")
+
+    def test_an_administrator_may_not_create_under_the_wildcard_either(self):
+        self.service.admins = ["admin.panel"]
+        response = self.request(
+            "scheduler.schedule",
+            {"owner": "*", "id": "one", "event": "*.ring",
+             "at": iso(datetime.now(timezone.utc) + timedelta(hours=1))},
+            context={"skill_id": "admin.panel"})
+        self.assertEqual(response.data["error"], "not_owner")
+
+
+class TestListeners(SchedulerTestCase):
+    def test_shutdown_leaves_an_unrelated_observer_subscribed(self):
+        seen = []
+        self.bus.on("scheduler.schedule", seen.append)
+        self.service.shutdown()
+        self.bus.emit(Message("scheduler.schedule", {}))
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(self.recorder.of("scheduler.schedule.response"), [])
+
+
+class TestInstants(unittest.TestCase):
+    def test_format_round_trips(self):
+        when = datetime(2031, 3, 29, 7, 30, tzinfo=timezone.utc)
+        self.assertEqual(format_instant(when), "2031-03-29T07:30:00+00:00")
+
+    def test_zulu_suffix_is_accepted(self):
+        record = validate_record({"id": "x", "owner": "s", "event": "s.e",
+                                  "at": "2031-03-29T07:30:00Z"})
+        self.assertEqual(record["at"], "2031-03-29T07:30:00+00:00")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_scheduler_extra.py
+++ b/test/unittests/test_scheduler_extra.py
@@ -1,181 +1,108 @@
-"""Coverage tests for ovos_bus_client.util.scheduler — EventScheduler."""
+"""Bus-level coverage of the legacy scheduler surface."""
 import os
 import tempfile
 import time
 import unittest
 from unittest import TestCase
-from unittest.mock import MagicMock
 
-from ovos_bus_client.message import Message
-from ovos_bus_client.util.scheduler import EventScheduler, repeat_time
 from ovos_utils.fakebus import FakeBus
 
-
-class TestRepeatTime(TestCase):
-    def test_repeat_time_advances_until_future(self):
-        past = time.time() - 100
-        future = repeat_time(past, 30)
-        self.assertGreaterEqual(future, time.time())
-
-    def test_repeat_time_negative_returns_future(self):
-        next_time = repeat_time(time.time(), -30)
-        self.assertGreaterEqual(next_time, time.time())
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduler import EventScheduler
 
 
-class TestEventScheduler(TestCase):
+class TestLegacyBusSurface(TestCase):
     def setUp(self):
         self.bus = FakeBus()
-        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
-        self.tmpfile.close()
-        os.unlink(self.tmpfile.name)
-        self.sched = EventScheduler(self.bus, schedule_file=self.tmpfile.name,
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.sched = EventScheduler(self.bus, schedule_file=self.store,
                                     autostart=False)
 
     def tearDown(self):
-        self.sched._stopping.set()
-        try:
-            self.sched.shutdown()
-        except Exception:
-            pass
-        try:
-            os.unlink(self.tmpfile.name)
-        except OSError:
-            pass
+        self.sched.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
 
     def test_initial_state(self):
-        self.assertEqual(self.sched.events, {})
+        self.assertEqual(self.sched.schedules, {})
         self.assertFalse(self.sched.is_running)
 
     def test_schedule_event_one_shot(self):
-        # ensure clock-sync check passes
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        future = time.time() + 60
-        self.sched.schedule_event("ev", future, data={"x": 1})
-        self.assertIn("ev", self.sched.events)
+        self.sched.schedule_event("skill:ev", time.time() + 60, data={"x": 1})
+        self.assertIn(("skill", "skill:ev"), self.sched.schedules)
 
-    def test_schedule_event_clock_in_past_drops(self):
-        # leave _last_sync at its initial past value
-        from ovos_utils.time import now_local
-        from datetime import timedelta
-        self.sched._last_sync = now_local() - timedelta(days=800)
-        self.sched.schedule_event("ev", time.time() + 60)
-        self.assertNotIn("ev", self.sched.events)
-        self.assertEqual(self.sched._dropped_events, 1)
+    def test_a_request_made_while_the_clock_is_behind_is_kept(self):
+        # a board that boots before its time source is reached must not
+        # lose the schedules made in that window
+        self.sched._clock_synced = False
+        self.sched.schedule_event("skill:ev", time.time() + 60)
+        self.assertIn(("skill", "skill:ev"), self.sched.schedules)
+        self.assertTrue(os.path.isfile(self.store))
 
-    def test_schedule_repeating_event_dedupes(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
+    def test_scheduling_a_repeat_twice_keeps_one_record(self):
         future = time.time() + 60
-        self.sched.schedule_event("ev", future, repeat=10)
-        # second schedule should be ignored
-        self.sched.schedule_event("ev", future, repeat=10)
-        self.assertEqual(len(self.sched.events["ev"]), 1)
+        self.sched.schedule_event("skill:ev", future, repeat=10)
+        self.sched.schedule_event("skill:ev", future, repeat=10)
+        self.assertEqual(len(self.sched.schedules), 1)
 
     def test_handle_schedule_event_via_bus_message(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        future = time.time() + 60
-        msg = Message("mycroft.scheduler.schedule_event",
-                      {"event": "fromBus", "time": future, "data": {}})
-        self.sched.handle_schedule_event(msg)
-        self.assertIn("fromBus", self.sched.events)
+        self.bus.emit(Message("mycroft.scheduler.schedule_event",
+                              {"event": "skill:fromBus",
+                               "time": time.time() + 60, "data": {}}))
+        self.assertIn(("skill", "skill:fromBus"), self.sched.schedules)
 
-    def test_handle_schedule_event_missing_event_logs(self):
-        # missing event name → logged error, no addition
-        msg = Message("e", {"time": time.time() + 60})
-        self.sched.handle_schedule_event(msg)
-        self.assertEqual(self.sched.events, {})
+    def test_handle_schedule_event_missing_event(self):
+        self.bus.emit(Message("mycroft.scheduler.schedule_event",
+                              {"time": time.time() + 60}))
+        self.assertEqual(self.sched.schedules, {})
 
     def test_handle_schedule_event_missing_time(self):
-        msg = Message("e", {"event": "x"})
-        self.sched.handle_schedule_event(msg)
-        self.assertNotIn("x", self.sched.events)
+        self.bus.emit(Message("mycroft.scheduler.schedule_event",
+                              {"event": "skill:x"}))
+        self.assertEqual(self.sched.schedules, {})
 
     def test_remove_event_present(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60)
-        self.sched.remove_event("ev")
-        self.assertNotIn("ev", self.sched.events)
+        self.sched.schedule_event("skill:ev", time.time() + 60)
+        self.sched.remove_event("skill:ev")
+        self.assertNotIn(("skill", "skill:ev"), self.sched.schedules)
 
     def test_remove_event_absent_noop(self):
-        self.sched.remove_event("missing")  # no error
+        self.sched.remove_event("skill:missing")
 
     def test_handle_remove_event(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60)
-        self.sched.handle_remove_event(Message("e", {"event": "ev"}))
-        self.assertNotIn("ev", self.sched.events)
-
-    def test_update_event_present(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60, data={"x": 1})
-        self.sched.update_event("ev", {"x": 2})
-        new_data = self.sched.events["ev"][0][2]
-        self.assertEqual(new_data["x"], 2)
+        self.sched.schedule_event("skill:ev", time.time() + 60)
+        self.bus.emit(Message("mycroft.scheduler.remove_event",
+                              {"event": "skill:ev"}))
+        self.assertNotIn(("skill", "skill:ev"), self.sched.schedules)
 
     def test_update_event_absent_noop(self):
-        self.sched.update_event("missing", {"x": 1})
+        self.sched.update_event("skill:missing", {"x": 1})
 
     def test_handle_update_event(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60, data={"x": 1})
-        self.sched.handle_update_event(
-            Message("u", {"event": "ev", "data": {"x": 2}})
-        )
+        self.sched.schedule_event("skill:ev", time.time() + 60, data={"x": 1})
+        self.bus.emit(Message("mycroft.scheduler.update_event",
+                              {"event": "skill:ev", "data": {"x": 2}}))
+        self.assertEqual(
+            self.sched.schedules["skill", "skill:ev"].record["data"], {"x": 2})
 
-    def test_handle_get_event_for_unknown_emits_none(self):
-        # for an unknown event name the handler still hits the emitter;
-        # an internal assertion errors on non-dict data, so just verify it doesn't crash
-        # the lookup path
-        try:
-            self.sched.handle_get_event(Message("g", {"name": "never-scheduled"}))
-        except AssertionError:
-            pass  # Message.reply enforces dict-data; not our concern here
-
-    def test_clear_empty_removes_empty_entries(self):
-        self.sched.events["empty"] = []
-        self.sched.events["full"] = [(time.time() + 60, None, {}, {})]
-        self.sched.clear_empty()
-        self.assertNotIn("empty", self.sched.events)
-        self.assertIn("full", self.sched.events)
-
-    def test_clear_repeating_filters_repeats_in_place(self):
-        # clear_repeating filters the tuple list per event key to drop
-        # repeats (tup[1] is None means one-shot)
-        self.sched.events["mixed"] = [
-            (time.time() + 60, 30, {}, {}),    # repeat
-            (time.time() + 60, None, {}, {}),  # one-shot
-        ]
-        self.sched.clear_repeating()
-        # one-shot survives
-        self.assertEqual(len(self.sched.events["mixed"]), 1)
-        self.assertIsNone(self.sched.events["mixed"][0][1])
+    def test_handle_get_event_for_an_unknown_name(self):
+        answers = []
+        self.bus.on("mycroft.event_status.callback.never-scheduled",
+                    answers.append)
+        self.bus.emit(Message("mycroft.scheduler.get_event",
+                              {"name": "never-scheduled"}))
+        self.assertIsNone(answers[-1].data["schedule"])
 
     def test_store_and_reload(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60)
+        self.sched.schedule_event("skill:ev", time.time() + 60)
         self.sched.store()
-        # constructing a new scheduler should reload from disk
-        new = EventScheduler(self.bus, schedule_file=self.tmpfile.name,
-                             autostart=False)
-        try:
-            self.assertIn("ev", new.events)
-        finally:
-            new._stopping.set()
+        revived = EventScheduler(self.bus, schedule_file=self.store,
+                                 autostart=False)
+        self.addCleanup(revived.shutdown)
+        self.assertIn(("skill", "skill:ev"), revived.schedules)
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_util.py
+++ b/test/unittests/test_util.py
@@ -26,8 +26,8 @@ class TestEventScheduler(unittest.TestCase):
         cls.scheduler = EventScheduler(cls.bus, cls.test_schedule_name, False)
 
     def test_00_init(self):
-        self.assertEqual(self.scheduler.events, dict())
-        self.assertIsNotNone(self.scheduler.event_lock)
+        self.assertEqual(self.scheduler.schedules, dict())
+        self.assertIsNotNone(self.scheduler.lock)
         self.assertEqual(self.scheduler.bus, self.bus)
         self.assertFalse(isfile(self.scheduler.schedule_file))
         self.assertEqual(


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This implements SCHEDULER-1 (OpenVoiceOS/architecture#169) as a service in this repository. `ScheduledEventService` speaks the `scheduler.schedule` / `.cancel` / `.get` / `.list` request-and-response protocol, takes RFC 3339 instants with an offset and refuses naive ones, supports fixed-period, wall-clock and relative-delay timing with `until` and `count` bounds, applies the `late` / `skip` / `all` misfire policies and reports on `scheduler.missed`, replays its store on start and announces `scheduler.ready`, enforces the event namespace and owner scoping, and detects wall-clock steps against a monotonic reference. Wall-clock recurrences are evaluated with `zoneinfo` in the zone the owner chose: across a spring-forward gap the occurrence is the first instant after the gap, across a fall-back overlap it is the first of the two readings. A fired event is a new message carrying only `context["scheduler"]`, so the session captured when the schedule was created is never replayed hours later.

Planning and delivery are separate: working out what is due consumes nothing, and each occurrence is emitted and then its consumption written to the store before the next one leaves. Delivery is therefore at least once with a one-occurrence bound — a kill in the window between an event reaching the bus and its due reaching the store repeats that occurrence on the next start and nothing earlier. `remaining` decrements across a late batch, `scheduler.ready` reports the count the store held before replay consumed anything, and `scheduler.missed` caps its arrays at 100 while counting the full backlog, so `truncated` is set when there is more than it can carry.

`EventScheduler` is that service under its historical name, so `ovos-core` starts it unchanged. It also answers the `mycroft.scheduler.*` topics for one stable cycle, mapping an epoch float to an instant, `repeat` to a fixed period and the `skill_id:` prefix of the event name to an owner, and logging a deprecation notice once per topic that names the release which drops them. A legacy one-shot registered twice under one name now replaces rather than appends, which is the duplicate-on-boot bug. On the client side `EventSchedulerInterface` gains `schedule`, `cancel`, `get` and `list`, each awaiting the response and raising `SchedulerError` on a refusal; the default `schedule_id` comes from the event name alone, so a component keeps one schedule per event and re-scheduling replaces it rather than orphaning the old record. The old methods keep working behind a `DeprecationWarning` carrying the computed removal version.

The store moved to the XDG state directory. An existing `schedule.json` in the configuration directory is copied there on first start and the original left in place, so a downgrade still finds it. Writes go through a temporary file and an atomic replace; when that write fails the request is still answered, with `ok: false` and `error: "internal"`, rather than leaving the caller on its timeout. A corrupt store timestamp is logged and ignored instead of stopping the constructor. `shutdown` deregisters only this service's own handlers, so an unrelated observer on the same topic stays subscribed. The pseudo-owner `*` is refused outright on `schedule` and honoured on `cancel` and `list` only for a component id in the `scheduler.admins` allowlist, which is empty by default — an anonymous wildcard cancel is impossible.

The conformance suite has one test per MUST of §9 plus the client and legacy-adapter surfaces: request round trips, replace-on-identity, owner isolation and `not_owner`, namespace rejection, the payload cap, anchoring after a late fire, the daylight-saving gap in Europe/Lisbon and the overlap in America/New_York on concrete dates, `until` and `count`, all three misfire policies after a simulated downtime with the ready/missed/fire ordering asserted, a kill at every point inside a four-fire backlog proving at most one repeat, a failed atomic replace leaving the old state, forward and backward clock steps with no double fire, ephemeral records staying out of the store, the fresh fired context, and the relative delay surviving a wall-clock jump. Each regression was proven against the code it fixes first — the original service for the five field bugs, and a patch-revert of each fix for the rest. The suite goes from 832 passed / 6 skipped on `dev` to 928 passed / 6 skipped here.

Clauses I had to interpret, for the spec review. `count` needed a counting origin for `local` recurrences, which have no `start`, so it counts occurrences the scheduler produces rather than indexing a series. Nothing says which of `scheduler.missed` and the late fires comes first within one schedule, so the report precedes the events. The legacy `get_event` reply could not keep its list-shaped `data` because the message spec refuses a non-dict payload — the old shape was already unconstructible on `dev` — so it answers `{"event": ..., "schedule": [...]}` and the client reads that. Legacy records keep colon-separated names and therefore bypass the `<owner>.<name>` namespace rule, which otherwise would reject every existing skill. `internal` is a new error code for a store that cannot be written, and needs adding to the spec's error table. One evaluation works through at most ten thousand occurrences so that a years-long backlog under `all` drains across ticks rather than in one burst; the reported arrays are capped at a hundred independently of that.
