### PR TITLE
feat: scheduled events service and client (SCHEDULER-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Full developer docs live in [`docs/`](docs/):
 - [Configuration](docs/configuration.md) — host, port, route, ssl
 - [Sessions](docs/session.md) — `Session`, `SessionManager`, `IntentContextManager`
 - [Waiters and collectors](docs/waiter_and_collector.md) — request/response and multi-reply patterns
-- [High-level APIs](docs/apis.md) — `GUIInterface`, `OCPInterface`, `EnclosureAPI`, scheduler
+- [High-level APIs](docs/apis.md) — `GUIInterface`, `OCPInterface`, `EnclosureAPI`
+- [Scheduled events](docs/scheduler.md) — firing an event at a wall-clock instant, once or on a recurrence
 - [CLI tools](docs/scripts.md) — `ovos-speak`, `ovos-listen`, `ovos-say-to`, `ovos-simple-cli`
 - [Common patterns](docs/patterns.md) — recipes for everyday use
 - [Testing](docs/testing.md) — `FakeBus`, isolating tests

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,8 @@ agent backends, or anything else that talks to an OVOS messagebus.
 ### Intermediate
 
 7. [Waiters and collectors](waiter_and_collector.md) — request/response and multi-reply patterns.
-8. [High-level APIs](apis.md) — `GUIInterface`, `OCPInterface`, `EnclosureAPI`, `EventSchedulerInterface`.
+8. [High-level APIs](apis.md) — `GUIInterface`, `OCPInterface`, `EnclosureAPI`.
+8. [Scheduled events](scheduler.md) — `ScheduledEventService`, `SchedulerClient`.
 9. [CLI tools](scripts.md) — `ovos-listen`, `ovos-speak`, `ovos-say-to`, `ovos-simple-cli`.
 10. [Common patterns](patterns.md) — request/reply, broadcast, session scoping, reconnect.
 11. [Testing](testing.md) — `FakeBus`, isolating tests, asserting bus traffic.

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -96,37 +96,26 @@ The class is a thin emitter — every method maps one-to-one to a Mycroft
 enclosure message type. Read the source for the full method list; it is more
 exhaustive than this doc would be useful at.
 
-## `EventSchedulerInterface` — `ovos_bus_client/apis/events.py:12`
+## `EventSchedulerInterface` — `ovos_bus_client/apis/events.py`
 
-Schedule one-shot and repeating events through the OVOS event scheduler.
+Fire a named event on the bus at a wall-clock instant, once or on a
+recurrence.
 
 ```python
+from datetime import datetime, timedelta, timezone
 from ovos_bus_client.apis.events import EventSchedulerInterface
-from datetime import datetime, timedelta
 
-es = EventSchedulerInterface(bus=bus, skill_id="my.skill")
-
-es.schedule_event(
-    handler=my_callback,
-    when=datetime.now() + timedelta(minutes=5),
-    data={"reason": "wake up"},
-    name="wakeup_timer",
-)
-
-es.schedule_repeating_event(
-    handler=heartbeat,
-    when=datetime.now(),
-    frequency=60,           # seconds
-    name="heartbeat",
-)
+events = EventSchedulerInterface(bus=bus, skill_id="my.skill")
+events.schedule("wakeup", handler=my_callback,
+                at=datetime.now(timezone.utc) + timedelta(minutes=5),
+                data={"reason": "wake up"})
 ```
 
-Cancel with `cancel_scheduled_event(name)`. Inspect with
-`get_scheduled_event_status(name)` (`events.py:185`). Tear everything down
-with `shutdown()` (`events.py:224`).
-
-Names are namespaced by `skill_id` internally (`events.py:44`) so two skills
-can use the same logical name without colliding.
+Read them back with `get(id)` and `list()`, change one with
+`reschedule(id, **changes)`, drop one with `cancel(id)`, and tear the
+interface down with `shutdown()`. Timing forms, recurrence rules,
+the misfire policy and the store are covered in
+[Scheduled events](scheduler.md).
 
 ## Pattern: passing `source_message`
 

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,41 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `1.5.0 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## 2.11.0a1
+
+The event scheduler was rewritten against SCHEDULER-1 and now speaks an
+`ovos.scheduler.*` request/response protocol alongside the
+`mycroft.scheduler.*` topics, which keep working for one stable cycle and log
+a deprecation notice naming the release that drops them. `EventScheduler` is
+the new service under its old name, so nothing that starts it needs to
+change.
+
+Four behaviour changes are worth knowing about before you upgrade. The store
+moved from the XDG configuration directory to the XDG state directory, where
+it belongs; an existing `schedule.json` is copied there on first start and the
+original left in place. Recurring schedules now survive a restart instead of
+being deleted on shutdown. A one-shot that was due while the service was down
+now fires late within its grace period, or is reported on
+`ovos.scheduler.missed`, rather than being dropped silently. And scheduling
+the same name twice replaces rather than appends, so a skill that re-creates
+its schedules on boot no longer doubles them.
+
+The client derives a schedule's id from the event name alone when you do not
+pass one, so a component keeps one schedule per event and re-scheduling
+replaces it. Give explicit ids when one event needs several schedules. The
+client also owns the handler it registers: cancelling a schedule removes it,
+and replacing a schedule replaces it.
+
+Two smaller changes can surface as a behaviour difference. A fired event
+carries the context of the request that created the schedule, unchanged, plus
+a `context["scheduler"]` block describing the occurrence — on both protocols,
+including the session, which is what the scheduler this replaced did. A
+request made with no context still fires with none. And
+`mycroft.scheduler.get_event` answers with
+`{"event": ..., "schedule": [...]}` instead of a bare list, because the
+message spec refuses a list-shaped payload and the old reply could not be
+constructed at all.
+
 ## 2.10.0a2
 
 A clean `close()` could still surface `RuntimeError: cannot schedule new

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,222 @@
+# Scheduled events
+
+The scheduler fires a named event on the bus at a wall-clock instant, once or
+on a recurrence, on behalf of a component. It is the clock that alarms,
+timers, reminders and housekeeping jobs run on: the component that owns the
+schedule owns the meaning of the event, and the scheduler owns only the
+timing.
+
+The service is `ovos_bus_client.util.scheduled_events.ScheduledEventService`,
+also importable as `EventScheduler` from `ovos_bus_client.util.scheduler`,
+which is the name `ovos-core` starts it by. The component-facing client is
+`SchedulerClient` in `ovos_bus_client.apis.scheduler`, which skills reach
+through `EventSchedulerInterface`. Both implement SCHEDULER-1; this page is
+the practical guide and the specification is the contract.
+
+## Scheduling from a component
+
+```python
+from datetime import datetime, timedelta, timezone
+from ovos_bus_client.apis.events import EventSchedulerInterface
+
+events = EventSchedulerInterface(bus=bus, skill_id="my.skill")
+
+schedule_id = events.schedule(
+    "wakeup",
+    handler=self.handle_wakeup,
+    at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    data={"alarm": "kitchen"},
+)
+```
+
+`schedule` namespaces the event to the component, so the message that
+eventually reaches the bus is `my.skill.wakeup`. It registers the handler
+before it sends the request, so an occurrence due immediately is not lost,
+and it waits for the scheduler's answer: a refusal is raised as
+`SchedulerError` carrying the wire error code, never swallowed.
+
+`at` must be a time-zone-aware datetime. A naive one is refused unless you
+pass `zone="Europe/Lisbon"` to say which zone to read it in — the process's
+local zone is never assumed on your behalf, because that is how an alarm ends
+up an hour out after a daylight-saving change.
+
+The other three timing forms are a fixed period, a wall-clock recurrence, and
+a relative delay:
+
+```python
+events.schedule("sync", every={"seconds": 3600})
+events.schedule("wake", local={"time": "07:30", "zone": "Europe/Lisbon",
+                               "days": ["mon", "tue", "wed", "thu", "fri"]})
+events.schedule("timer", in_seconds=300)
+```
+
+A fixed period is anchored on the schedule, not on the last fire, so a late
+fire does not make the whole series drift. A `local` recurrence is evaluated
+in the zone you named: when a spring-forward gap means the wall clock never
+reads your time, the occurrence is the first instant after the gap; when a
+fall-back overlap means it reads it twice, the occurrence is the first of the
+two. A relative delay runs off the monotonic clock while the service is up,
+so a clock correction cannot make it fire early or late.
+
+Bound a recurrence with `until` (an instant) or `count` (a number of
+occurrences). `misfire` and `grace_s` decide what happens to an occurrence
+that came due while nothing was running, and `ephemeral=True` marks a
+schedule that is meaningless outside your process; anything else outlives
+your restarts and the scheduler's.
+
+## Identity and replacement
+
+A schedule is identified by the pair (owner, id). Scheduling the same
+identity again replaces it atomically — there is no update request, and there
+are no duplicates. If you do not pass `schedule_id`, the client derives one
+from the event name alone. That means a component keeps one schedule per
+event: calling `schedule` again for the same event replaces it whatever the
+new timing is, so re-creating your schedules on start is the intended pattern
+and costs nothing. When one event genuinely needs several schedules — three
+alarms all firing `my.skill.alarm` — give each an explicit `schedule_id`, or
+the second will replace the first.
+
+A replacement is not a new schedule. What the schedule has already fired
+comes across with it, so re-creating your schedules on start cannot ring this
+morning's alarm a second time, and changing a payload cannot hand a bounded
+schedule a fresh `count` budget. Changing the timing does not hand it one
+either: a schedule that has spent three of its five occurrences has two left
+whatever you reschedule it to. Cancel and create again when you do want to
+start over.
+
+A handler may schedule from inside the event it is handling, including under
+the same id. Arming the next occurrence when this one fires is how a chain of
+one-shots is built, and the schedule the handler creates stands: only the
+schedule that actually fired is retired afterwards.
+
+The client owns the handler it registers. `cancel(schedule_id)` removes the
+handler that `schedule` put in place, and re-scheduling the same id with a
+handler replaces the old one instead of leaving a second subscription behind.
+
+An administrative component can read or cancel across every owner by sending
+`owner: "*"`, but only when its component id appears in the
+`scheduler.admins` allowlist in the configuration, which is empty by default.
+No schedule can be created under `*`. The allowlist is a misconfiguration
+guard, not a security boundary: on an unauthenticated bus any process can
+claim any component id, so it stops an honest component reaching across
+owners by accident and nothing more.
+
+Read schedules back with `events.get(schedule_id)` and `events.list()`. Both
+return the stored record alongside computed state: the next occurrence, the
+due instant of the last fire, the dues missed since that fire, and how many
+occurrences are left. Cancel with `events.cancel(schedule_id)`, which tells
+you whether the schedule existed.
+
+Pass `context=` to say which context the occurrence belongs to instead of
+inheriting the one being handled; it is stored with the schedule and survives
+a restart with it.
+
+`events.is_available()` says whether there is a scheduler on the bus at all.
+A component that may be running against a core older than this protocol asks
+once, before it spends a request timeout finding out the hard way, and falls
+back to whatever it did before. The answer is remembered.
+
+To change one part of a schedule and leave the rest, use `reschedule`:
+
+```python
+events.reschedule("morning-brief", data={"topics": ["weather", "news"]})
+```
+
+It reads the schedule back, applies what you passed, and sends the
+replacement. Whatever you leave out stays as it was — including the phase, so
+changing the payload of an hourly job does not move the hour, and changing
+the payload of a countdown does not start the countdown over. Pass a timing
+to move the schedule, or a handler to swap the one that is subscribed.
+
+## The fired event
+
+The message the scheduler emits carries the record's `data`, and the context
+of the request that created the schedule, unchanged, with one block added:
+
+```python
+message.context["scheduler"]  # {"id", "owner", "due", "fired", "remaining"}
+```
+
+The context comes back whole because it is routing you already wrote — where
+the request came from, where its answers go, which session it belongs to. A
+handler that speaks when the alarm rings speaks to the right device without
+doing anything, and a schedule made outside any request fires with nothing
+but its owner and the scheduler block: nothing is invented for it.
+
+Whether that routing is still good is your business, not the scheduler's. A
+session captured when the alarm was set may be long finished by the time it
+rings, and what a consumer does with a session it no longer recognises is
+what SESSION-2 already says it does.
+
+Anything else you need at fire time goes in `data`, which is the part meant
+to be read. Context is stored and rewritten with the schedule like `data` is,
+and is held to the same 16 KB limit.
+
+## What happens when an occurrence is missed
+
+An occurrence is missed when the scheduler fires it later than `grace_s`
+after its due instant, or cannot fire it at all. `grace_s` therefore decides
+where the backlog after an outage stops being ordinary lateness and starts
+being a misfire: everything due within the last `grace_s` seconds simply
+fires, one message per occurrence, and only what is older than that is
+subject to the policy.
+
+The record's `misfire` field decides what happens to that older part: `late`
+(the default) fires the most recent of them and drops the rest, `skip` fires
+none, and `all` fires every one oldest first.
+
+So a ten-second recurrence coming back from a hundred-and-fifty-second outage
+with the default sixty-second grace emits seven messages under `late`: the
+six occurrences inside the grace window, and one for the most recent
+occurrence older than it.
+
+`all` drains its whole backlog in one evaluation, up to ten thousand
+occurrences, each one emitted and then written to the store. A deployment that
+expects days of downtime on a short recurrence should expect that tick to be
+a busy one, and should reach for `late` unless every single occurrence
+genuinely matters.
+
+Either way the scheduler emits `ovos.scheduler.missed` for the schedule,
+listing the dues that were missed and the ones it fired late. Treat it as the
+signal that something did not happen on time and decide what to tell the
+user. After a restart the scheduler reports every occurrence it produces,
+including one that may already have reached the bus in the instant before a
+crash, so deduplicate on the pair (id, due).
+
+When replay finishes the scheduler emits `ovos.scheduler.ready` with the
+number of schedules it restored, the number that had missed occurrences, and
+whether the clock is trusted yet. A device without a battery-backed clock
+starts with a wall clock behind the newest instant its store recorded as
+already past; in that state the scheduler still accepts and persists requests
+but does not evaluate them, and it replays once the clock catches up or
+`system.clock.synced` arrives.
+
+## The store
+
+Schedules live in `schedule.json` in the XDG state directory. Every accepted
+change is written with an atomic replace before the response goes out, and
+the due of each fired occurrence is written immediately after that event and
+before the next one leaves, so a crash leaves either the old state or the new
+one. Delivery is therefore at least once: a kill in the window between an
+event reaching the bus and its due reaching the store repeats that one
+occurrence on the next start, and nothing earlier. Handlers for a schedule
+that matters should be idempotent on the pair (id, due).
+
+A store left in the configuration directory by an older release is copied to
+the state directory on first start. The original is left where it is, so a
+downgrade still finds it; the copy is marked so it is not repeated.
+
+## The legacy protocol
+
+The `mycroft.scheduler.*` topics and the `schedule_event`,
+`schedule_repeating_event`, `update_scheduled_event`,
+`cancel_scheduled_event` and `get_scheduled_event_status` client methods
+still work and are answered by the same service, which maps an epoch float to
+an instant, `repeat` to a fixed period, and the `skill_id:` prefix of the
+event name to an owner. They emit a deprecation notice naming the release
+that drops them. New code uses the methods above.
+
+A schedule created this way fires with the context its request carried, whole
+and including its session — which is what the old scheduler did, and now also
+what a schedule created through `ovos.scheduler.*` does. There is nothing
+different about context on this path.

--- a/ovos_bus_client/apis/events.py
+++ b/ovos_bus_client/apis/events.py
@@ -1,45 +1,43 @@
+"""The event-scheduler interface a skill or plugin uses.
+
+:class:`EventSchedulerInterface` is the SCHEDULER-1 client of
+:class:`~ovos_bus_client.apis.scheduler.SchedulerClient` — ``schedule``,
+``cancel``, ``get`` and ``list`` — plus the ``*_scheduled_event`` methods
+that speak the pre-specification protocol. The older methods keep their
+behaviour for one stable cycle and warn, naming their replacement.
+"""
 import time
+import warnings
 from datetime import datetime, timedelta
 from typing import Callable, Optional, Union
 
-from ovos_utils.events import EventContainer, create_basic_wrapper
-from ovos_bus_client.message import Message, dig_for_message
+from ovos_utils.events import create_basic_wrapper
 from ovos_utils.log import LOG
 from ovos_config.locale import get_config_tz
 from ovos_utils.time import now_local
 
+from ovos_bus_client.apis.scheduler import SchedulerClient, SchedulerError
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import topics
+from ovos_bus_client.util.scheduled_events.legacy import LEGACY_REMOVAL_VERSION
 
-class EventSchedulerInterface:
-    """Interface for accessing the event scheduler over the message bus."""
+__all__ = ["EventSchedulerInterface", "SchedulerClient", "SchedulerError"]
+
+
+def _warn_legacy(method: str, replacement: str):
+    warnings.warn(
+        f"EventSchedulerInterface.{method} speaks the pre-specification "
+        f"mycroft.scheduler.* protocol; use {replacement} instead. It will "
+        f"be removed in ovos-bus-client {LEGACY_REMOVAL_VERSION}.",
+        DeprecationWarning, stacklevel=3)
+
+
+class EventSchedulerInterface(SchedulerClient):
+    """Schedules work for a skill or plugin over the message bus."""
 
     def __init__(self, bus=None, skill_id=None):
-        self.skill_id = skill_id or self.__class__.__name__.lower()
-        self.bus = bus
-        self.events = EventContainer(bus)
+        super().__init__(bus, skill_id)
         self.scheduled_repeats = []
-
-    def set_bus(self, bus):
-        """Attach the messagebus of the parent skill
-
-        Args:
-            bus (MessageBusClient): websocket connection to the messagebus
-        """
-        self.bus = bus
-        self.events.set_bus(bus)
-
-    def set_id(self, skill_id: str):
-        """
-        Attach the skill_id of the parent skill
-
-        Args:
-            skill_id (str): skill_id of the parent skill
-        """
-        self.skill_id = skill_id
-
-    def _get_source_message(self):
-        message = dig_for_message() or Message("")
-        message.context['skill_id'] = self.skill_id
-        return message
 
     def _create_unique_name(self, name: str) -> str:
         """
@@ -102,7 +100,7 @@ class EventSchedulerInterface:
         message = self._get_source_message()
         context = context or message.context
         context["skill_id"] = self.skill_id
-        self.bus.emit(Message('mycroft.scheduler.schedule_event',
+        self.bus.emit(Message(topics.LEGACY_SCHEDULE,
                               data=event_data, context=context))
 
     def schedule_event(self, handler: Callable[..., None],
@@ -119,6 +117,7 @@ class EventSchedulerInterface:
         @param name: Event name, must be unique in the context of this object
         @param context: Message context to send to `handler`
         """
+        _warn_legacy("schedule_event", "schedule()")
         self._schedule_event(handler, when, data, name, context=context)
 
     def schedule_repeating_event(self,
@@ -138,6 +137,7 @@ class EventSchedulerInterface:
         @param interval:  time in seconds between calls
         @param context: Message context to send to `handler`
         """
+        _warn_legacy("schedule_repeating_event", "schedule()")
         # Ensure name is defined to avoid re-scheduling
         name = name or self.skill_id + handler.__name__
 
@@ -160,12 +160,13 @@ class EventSchedulerInterface:
             name (str): reference name of event (from original scheduling)
             data (dict): new data to update event with
         """
+        _warn_legacy("update_scheduled_event", "schedule()")
         data = {
             'event': self._create_unique_name(name),
             'data': data or {}
         }
         message = self._get_source_message()
-        self.bus.emit(message.forward('mycroft.scheduler.update_event', data))
+        self.bus.emit(message.forward(topics.LEGACY_UPDATE, data))
 
     def cancel_scheduled_event(self, name: str):
         """
@@ -174,13 +175,14 @@ class EventSchedulerInterface:
         Args:
             name (str): reference name of event (from original scheduling)
         """
+        _warn_legacy("cancel_scheduled_event", "cancel()")
         unique_name = self._create_unique_name(name)
         data = {'event': unique_name}
         if name in self.scheduled_repeats:
             self.scheduled_repeats.remove(name)
         if self.events.remove(unique_name):
             message = self._get_source_message()
-            self.bus.emit(message.forward('mycroft.scheduler.remove_event', data))
+            self.bus.emit(message.forward(topics.LEGACY_REMOVE, data))
 
     def get_scheduled_event_status(self, name: str) -> int:
         """
@@ -195,22 +197,20 @@ class EventSchedulerInterface:
         Raises:
             Exception: Raised if event is not found
         """
+        _warn_legacy("get_scheduled_event_status", "get()")
         event_name = self._create_unique_name(name)
-        data = {'name': event_name}
-
-        reply_name = f'mycroft.event_status.callback.{event_name}'
+        reply_name = f"{topics.LEGACY_GET_REPLY_PREFIX}{event_name}"
         message = self._get_source_message()
-        msg = message.forward('mycroft.scheduler.get_event', data)
-        status = self.bus.wait_for_response(msg, reply_type=reply_name)
+        status = self.bus.wait_for_response(
+            message.forward(topics.LEGACY_GET, {"name": event_name}),
+            reply_type=reply_name)
 
-        if status:
-            event_time = int(status.data[0][0])
-            current_time = int(time.time())
-            time_left_in_seconds = event_time - current_time
-            LOG.info(time_left_in_seconds)
-            return time_left_in_seconds
-        else:
+        if not status or not status.data.get("schedule"):
             raise Exception("Event Status Messagebus Timeout")
+        # the reply carries the schedule under a key: the wire refuses a
+        # list-shaped payload, which is what this used to answer with
+        event_time = int(status.data["schedule"][0])
+        return event_time - int(time.time())
 
     def cancel_all_repeating_events(self):
         """

--- a/ovos_bus_client/apis/scheduler.py
+++ b/ovos_bus_client/apis/scheduler.py
@@ -1,0 +1,336 @@
+"""The component-facing half of the scheduler protocol (SCHEDULER-1 §8).
+
+A component creates a schedule, subscribes to the event it fires, and later
+changes, cancels or reads it back. The client owns the subscription:
+cancelling a schedule removes the handler it registered, and re-scheduling
+the same id replaces that handler rather than leaving a second one behind.
+
+``schedule`` says what a schedule is from scratch; ``reschedule`` changes one
+part of an existing schedule and leaves the rest, including its phase, where
+it was.
+"""
+from datetime import datetime
+from typing import Callable, Optional
+from zoneinfo import ZoneInfo
+
+from ovos_utils.events import EventContainer, create_basic_wrapper
+from ovos_utils.log import LOG
+
+from ovos_bus_client.message import Message, dig_for_message
+from ovos_bus_client.util.scheduled_events import topics
+
+#: seconds to wait for the scheduler's answer to a request
+DEFAULT_TIMEOUT = 3.0
+
+#: seconds to wait when only asking whether a scheduler is there at all
+PRESENCE_TIMEOUT = 0.5
+
+
+class SchedulerError(RuntimeError):
+    """A scheduler request that was refused, or that went unanswered.
+
+    ``error`` is the wire code of SCHEDULER-1 §4, or ``"timeout"`` when no
+    answer arrived.
+    """
+
+    def __init__(self, error: str, reason: str):
+        super().__init__(f"{error}: {reason}")
+        self.error = error
+        self.reason = reason
+
+
+class SchedulerClient:
+    """Creates, cancels and reads this component's schedules.
+
+    Every method sends one request and waits for its answer, raising
+    :class:`SchedulerError` when the scheduler refuses. The component id is
+    the owner of everything the client creates, so a client can neither see
+    nor touch another component's schedules.
+
+    ``is_available`` asks whether there is a scheduler to talk to at all,
+    which a component running against an older core needs to know before it
+    spends a timeout finding out the hard way.
+    """
+
+    def __init__(self, bus=None, skill_id: Optional[str] = None):
+        self.skill_id = skill_id or self.__class__.__name__.lower()
+        self.bus = bus
+        self.events = EventContainer(bus)
+        #: the event each schedule this client created is subscribed on, so
+        #: that cancelling or replacing one can take its handler with it
+        self._handled_events = {}
+        self._presence = None
+
+    def set_bus(self, bus):
+        """Attach the message bus of the parent component."""
+        self.bus = bus
+        self.events.set_bus(bus)
+
+    def set_id(self, skill_id: str):
+        """Attach the component id of the parent component."""
+        self.skill_id = skill_id
+
+    def is_available(self, timeout: float = PRESENCE_TIMEOUT) -> bool:
+        """Whether a scheduler is answering on this bus.
+
+        A component can be running against a core older than the protocol,
+        where every request would cost a full timeout and then raise. Asking
+        first costs one short request, and the answer is remembered: a
+        scheduler that is there when a component starts does not go away and
+        leave the component talking to nothing.
+
+        A refusal counts as present — something answered.
+        """
+        if self._presence is None:
+            try:
+                self._request(topics.SCHEDULER_LIST, {}, timeout=timeout)
+                self._presence = True
+            except SchedulerError as refusal:
+                self._presence = refusal.error != "timeout"
+        return self._presence
+
+    def schedule(self, event: str, handler: Optional[Callable[..., None]] = None,
+                 at: Optional[datetime] = None,
+                 in_seconds: Optional[float] = None,
+                 every: Optional[dict] = None,
+                 local: Optional[dict] = None,
+                 data: Optional[dict] = None,
+                 schedule_id: Optional[str] = None,
+                 zone: Optional[str] = None,
+                 until: Optional[datetime] = None,
+                 count: Optional[int] = None,
+                 misfire: str = "late",
+                 grace_s: Optional[float] = None,
+                 ephemeral: bool = False,
+                 context: Optional[dict] = None) -> str:
+        """Create or replace a schedule and return its id.
+
+        Give exactly one timing: ``at`` a datetime, ``in_seconds`` from now,
+        ``every`` a fixed period, or ``local`` a wall-clock rule. ``at`` and
+        ``until`` must be time-zone-aware datetimes unless ``zone`` names the
+        IANA zone to read them in; the process's own zone is never assumed.
+
+        ``handler`` is subscribed to ``event`` before the request goes out, so
+        an occurrence due immediately is not lost. When the same
+        ``schedule_id`` is scheduled again with a handler, the previous
+        handler is dropped instead of accumulating.
+
+        Without ``schedule_id`` the component keeps one schedule per event,
+        derived from the event name and never from the handler, so scheduling
+        the same event again replaces it. A handler renamed while the id is
+        derived from the handler's own name would orphan the old schedule,
+        which is why it is not.
+
+        The occurrence fires with ``context``, or with the context of the
+        message being handled when none is given. It is stored with the
+        schedule and replayed on every fire (§3.5), so it survives a restart
+        along with it. It travels as the request message's context, never in
+        the request body, which §8 forbids.
+
+        ``misfire`` decides what happens to occurrences that came due while
+        the scheduler was down: ``"late"`` fires the most recent one,
+        ``"skip"`` fires none, ``"all"`` fires every one. ``grace_s`` is how
+        late a fire may be before it counts as missed. ``ephemeral``
+        schedules are held in memory and die with the scheduler.
+        """
+        event = self._namespaced(event)
+        timing = self._timing(at=at, in_seconds=in_seconds, every=every,
+                              local=local, zone=zone)
+        schedule_id = schedule_id or self._default_id(event)
+
+        if handler is not None:
+            self._take_over_handler(schedule_id, event, handler,
+                                    once=("at" in timing or "in" in timing))
+
+        request = {"id": schedule_id, "event": event, "data": data or {},
+                   "misfire": misfire, "ephemeral": ephemeral}
+        request.update(timing)
+        if grace_s is not None:
+            request["grace_s"] = grace_s
+        if until is not None:
+            request["until"] = self._instant(until, zone, "until")
+        if count is not None:
+            request["count"] = count
+
+        self._request(topics.SCHEDULER_SCHEDULE, request, context=context)
+        return schedule_id
+
+    def reschedule(self, schedule_id: str, **changes) -> str:
+        """Change one of this component's schedules, keeping the rest of it.
+
+        Any keyword :meth:`schedule` takes may be given; what is not given is
+        read back from the stored schedule. Changing only the payload leaves
+        the schedule's phase alone — a period keeps the anchor it was created
+        with (§3.4.1), and a one-shot keeps the instant it was already
+        counting down to rather than starting the delay over.
+
+        Replacing a schedule is how the protocol changes one: a request whose
+        identity matches a stored schedule replaces it (§5.2). There is no
+        separate update on the wire, and this is that replacement, filled in
+        from what is already there.
+
+        The handler stays subscribed unless a new one is given.
+        """
+        stored = self.get(schedule_id)
+        if stored is None:
+            raise SchedulerError("not_found",
+                                 f"no schedule {schedule_id} to reschedule")
+        arguments = self._as_arguments(stored["record"], stored["state"])
+        if any(field in changes for field in ("at", "in_seconds", "every", "local")):
+            for field in ("at", "in_seconds", "every", "local"):
+                arguments.pop(field, None)
+        arguments.update(changes)
+        return self.schedule(**arguments)
+
+    def _as_arguments(self, record: dict, state: dict) -> dict:
+        """A stored schedule as the arguments that would create it again."""
+        arguments = {"event": record["event"], "schedule_id": record["id"],
+                     "data": record["data"], "misfire": record["misfire"],
+                     "grace_s": record["grace_s"],
+                     "ephemeral": record["ephemeral"],
+                     "context": record.get("context", {})}
+        arguments.update(self._kept_timing(record, state))
+        if "until" in record:
+            arguments["until"] = datetime.fromisoformat(record["until"])
+        if "count" in record:
+            arguments["count"] = record["count"]
+        return arguments
+
+    @staticmethod
+    def _kept_timing(record: dict, state: dict) -> dict:
+        """The stored timing, in the form that keeps the schedule's phase.
+
+        A recurrence goes back unchanged, anchor and all. A one-shot goes
+        back as the instant it is still waiting for, which is the same
+        instant whether it was asked for as a time or as a delay.
+        """
+        if "every" in record:
+            return {"every": record["every"]}
+        if "local" in record:
+            return {"local": record["local"]}
+        upcoming = state["next"] or record.get("at")
+        if upcoming is None:
+            raise SchedulerError("bad_instant",
+                                 f"{record['id']} has no occurrence left to "
+                                 f"keep; give a new timing")
+        return {"at": datetime.fromisoformat(upcoming)}
+
+    def cancel(self, schedule_id: str) -> bool:
+        """Delete a schedule and drop the handler it registered.
+
+        Returns whether the schedule existed; cancelling one that does not is
+        not an error.
+        """
+        self._release_handler(schedule_id)
+        answer = self._request(topics.SCHEDULER_CANCEL, {"id": schedule_id})
+        return answer["existed"]
+
+    def get(self, schedule_id: str) -> Optional[dict]:
+        """One of this component's schedules as ``record`` and ``state``, or
+        None when it does not exist."""
+        answer = self._request(topics.SCHEDULER_GET, {"id": schedule_id})
+        if not answer["existed"]:
+            return None
+        return {"record": answer["record"], "state": answer["state"]}
+
+    def list(self) -> list:
+        """Every schedule this component owns, as ``record`` and ``state``.
+
+        A component reconciles its own state against this after it starts;
+        schedules outlive the process that created them.
+        """
+        return self._request(topics.SCHEDULER_LIST, {})["schedules"]
+
+    # --- request plumbing -------------------------------------------------
+
+    def _request(self, topic: str, data: dict,
+                 timeout: float = DEFAULT_TIMEOUT,
+                 context: Optional[dict] = None) -> dict:
+        message = self._get_source_message(context).forward(
+            topic, dict(data, owner=self.skill_id))
+        answer = self.bus.wait_for_response(message,
+                                            reply_type=f"{topic}.response",
+                                            timeout=timeout)
+        if answer is None:
+            raise SchedulerError("timeout", f"no answer to {topic}")
+        if not answer.data.get("ok"):
+            raise SchedulerError(answer.data.get("error", "unknown"),
+                                 answer.data.get("reason", ""))
+        return answer.data
+
+    def _get_source_message(self,
+                            context: Optional[dict] = None) -> Message:
+        """A message to derive the request from, carrying this component's id.
+
+        Its context is the caller's if one was given, else the context of the
+        message being handled. The scheduler reads ``skill_id`` from it as
+        the caller's identity, and keeps the rest to fire the occurrence
+        with.
+
+        The dug message is not stamped in place: that would leave our
+        ``skill_id`` on everything the surrounding handler forwards
+        afterwards.
+        """
+        if context is not None:
+            return Message("", context=dict(context,
+                                            skill_id=self.skill_id))
+        source = dig_for_message()
+        if source is None:
+            return Message("", context={"skill_id": self.skill_id})
+        return Message(source.msg_type, source.data,
+                       dict(source.context, skill_id=self.skill_id))
+
+    # --- naming -----------------------------------------------------------
+
+    def _namespaced(self, event: str) -> str:
+        """A fired event always belongs to its owner's namespace (§6.1)."""
+        if event.startswith(f"{self.skill_id}."):
+            return event
+        return f"{self.skill_id}.{event}"
+
+    def _default_id(self, event: str) -> str:
+        return event[len(self.skill_id) + 1:] or "schedule"
+
+    # --- timing -----------------------------------------------------------
+
+    def _timing(self, at, in_seconds, every, local, zone) -> dict:
+        given = {}
+        if at is not None:
+            given["at"] = self._instant(at, zone, "at")
+        if in_seconds is not None:
+            given["in"] = {"seconds": in_seconds}
+        if every is not None:
+            given["every"] = every
+        if local is not None:
+            given["local"] = local
+        if len(given) != 1:
+            raise ValueError("exactly one of at, in_seconds, every, local "
+                             "is required")
+        return given
+
+    @staticmethod
+    def _instant(when: datetime, zone: Optional[str], field: str) -> str:
+        if not isinstance(when, datetime):
+            raise TypeError(f"{field} must be a datetime, got {when!r}")
+        if when.tzinfo is None:
+            if zone is None:
+                raise ValueError(f"{field} is a naive datetime and no zone "
+                                 f"was given; pass an aware datetime or zone=")
+            when = when.replace(tzinfo=ZoneInfo(zone))
+        return when.isoformat()
+
+    # --- handler ownership ------------------------------------------------
+
+    def _take_over_handler(self, schedule_id: str, event: str,
+                           handler: Callable[..., None], once: bool):
+        self._release_handler(schedule_id)
+        wrapped = create_basic_wrapper(
+            handler,
+            lambda err: LOG.exception(f"error in scheduled event handler: {err}"))
+        self.events.add(event, wrapped, once=once)
+        self._handled_events[schedule_id] = event
+
+    def _release_handler(self, schedule_id: str):
+        event = self._handled_events.pop(schedule_id, None)
+        if event:
+            self.events.remove(event)

--- a/ovos_bus_client/util/scheduled_events/__init__.py
+++ b/ovos_bus_client/util/scheduled_events/__init__.py
@@ -1,0 +1,45 @@
+"""The scheduler: fires a named event on the bus at a wall-clock instant.
+
+A component asks for an event to be emitted once, or on a recurrence, and the
+scheduler emits it — surviving restarts, clock steps and daylight saving on
+the component's behalf. The protocol is SCHEDULER-1; the specification's
+section numbers appear in the docstrings that implement them.
+
+The implementation is split by concern, and a reader looking for one thing
+finds it in one place:
+
+``topics``
+    the bus topic names, mirroring the platform's message registry.
+``records``
+    the vocabulary a record is written in: instants, wall-clock times, and
+    the error a refused request carries.
+``validation``
+    what a request must contain to become a stored record.
+``timing``
+    occurrence arithmetic for the four timing forms, including the
+    daylight-saving rules.
+``schedules``
+    a stored record plus the state the scheduler keeps beside it, and the
+    bounds (``count``, ``until``, the last fire) that state imposes.
+``store``
+    the file schedules survive a restart in, written atomically.
+``service``
+    the service itself: requests, answers, evaluation, firing.
+``legacy``
+    the pre-specification ``mycroft.scheduler.*`` protocol, translated.
+"""
+from ovos_bus_client.util.scheduled_events import topics
+from ovos_bus_client.util.scheduled_events.legacy import (
+    LEGACY_REMOVAL_VERSION, LegacyAdapter)
+from ovos_bus_client.util.scheduled_events.records import (
+    MAX_DATA_BYTES, ScheduleError, format_instant, parse_instant)
+from ovos_bus_client.util.scheduled_events.schedules import MAX_REPORTED, Schedule
+from ovos_bus_client.util.scheduled_events.service import ScheduledEventService
+from ovos_bus_client.util.scheduled_events.store import (
+    ScheduleStore, default_store_path)
+from ovos_bus_client.util.scheduled_events.validation import validate_record
+
+__all__ = ["LEGACY_REMOVAL_VERSION", "LegacyAdapter", "MAX_DATA_BYTES",
+           "MAX_REPORTED", "Schedule", "ScheduleError", "ScheduleStore",
+           "ScheduledEventService", "default_store_path", "format_instant",
+           "parse_instant", "topics", "validate_record"]

--- a/ovos_bus_client/util/scheduled_events/legacy.py
+++ b/ovos_bus_client/util/scheduled_events/legacy.py
@@ -1,0 +1,190 @@
+"""The pre-specification scheduling protocol, kept for one stable cycle.
+
+Before SCHEDULER-1 a component scheduled work by emitting
+``mycroft.scheduler.schedule_event`` with an epoch float and a name, and the
+scheduler kept its store in the configuration directory. Both are still
+served here, translated into records the specification understands, so that
+components can move over one at a time.
+
+Two behaviours differ from the protocol as it used to be implemented, because
+the old ones cannot be expressed in a record:
+
+* scheduling a name that already exists replaces it instead of appending a
+  second entry, which is what stops a component that re-creates its schedules
+  on every start from doubling them;
+* ``mycroft.scheduler.get_event`` answers with an object rather than a bare
+  list, because the wire refuses a list-shaped payload.
+
+Everything else these owners relied on is kept, including the context they
+scheduled with: the old scheduler stored it and emitted the fired event with
+it, and components written against that still expect it. It is kept whole,
+session included, which is what §3.5 asks of any schedule — so context is
+the one thing this adapter does not have to translate.
+"""
+import json
+import os
+from datetime import datetime, timezone
+from typing import Dict, Optional, Tuple
+
+from ovos_config.locations import get_xdg_config_save_path
+from ovos_utils.log import LOG
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import topics
+from ovos_bus_client.util.scheduled_events.records import (
+    ScheduleError, format_instant)
+from ovos_bus_client.util.scheduled_events.validation import validate_record
+from ovos_bus_client.util.scheduled_events.schedules import Schedule
+from ovos_bus_client.version import VERSION_MAJOR
+
+#: the release these topics and their epoch-float API disappear in
+LEGACY_REMOVAL_VERSION = f"{VERSION_MAJOR + 1}.0.0"
+
+#: the owner of a legacy event name that carries no component id
+UNNAMESPACED_OWNER = "legacy"
+
+
+def legacy_owner(name: str) -> str:
+    """The owner of a legacy event name.
+
+    Legacy names are ``<skill_id>:<name>``; anything without the colon
+    predates even that and belongs to no component in particular.
+    """
+    return name.split(":", 1)[0] if ":" in name else UNNAMESPACED_OWNER
+
+
+def legacy_record(name: str, when: float, repeat: Optional[float],
+                  data: Optional[dict],
+                  context: Optional[dict] = None) -> dict:
+    """Turn an epoch float and a name into a record.
+
+    A repeat becomes a fixed-period recurrence anchored on the first
+    occurrence. The event name is stored as it arrived: it predates the
+    ``<owner>.<name>`` rule and rejecting it would break the components this
+    adapter exists for.
+
+    The context the request carried is stored with the record and replayed
+    on every fire (§3.5), exactly as for a schedule made through the
+    specified protocol.
+    """
+    instant = format_instant(datetime.fromtimestamp(when, timezone.utc))
+    record = {"id": name, "owner": legacy_owner(name), "event": name,
+              "data": data or {}}
+    if repeat:
+        record["every"] = {"seconds": repeat, "start": instant}
+    else:
+        record["at"] = instant
+    record["context"] = context or {}
+    return validate_record(record, namespaced=False)
+
+
+def pending_migration_path() -> Optional[str]:
+    """The configuration-directory store that has not been migrated yet."""
+    path = os.path.join(get_xdg_config_save_path(), "schedule.json")
+    if not os.path.isfile(path) or os.path.isfile(f"{path}.migrated"):
+        return None
+    return path
+
+
+def read_migration_source(path: str) -> Dict[Tuple[str, str], Schedule]:
+    """Read the configuration-directory store as schedules."""
+    with open(path) as handle:
+        content = json.load(handle)
+    schedules = {}
+    for name, entries in content.items():
+        for entry in entries:
+            payload = entry[2] if len(entry) > 2 else {}
+            context = entry[3] if len(entry) > 3 else None
+            record = legacy_record(name, entry[0], entry[1], payload, context)
+            schedule = Schedule(record)
+            schedules[schedule.key] = schedule
+    return schedules
+
+
+def mark_migrated(path: str):
+    """Leave the original where it is, so a downgrade still finds it."""
+    open(f"{path}.migrated", "w").close()
+
+
+class LegacyAdapter:
+    """Serves the ``mycroft.scheduler.*`` topics from the same schedules.
+
+    It reaches into the scheduler for the store lock and the persistence it
+    guards; everything it adds is translation.
+    """
+
+    def __init__(self, service):
+        self.service = service
+        self._warned_about = set()
+
+    def subscriptions(self):
+        """The topic and handler pairs the scheduler subscribes for us."""
+        return ((topics.LEGACY_SCHEDULE, self.handle_schedule),
+                (topics.LEGACY_REMOVE, self.handle_remove),
+                (topics.LEGACY_UPDATE, self.handle_update),
+                (topics.LEGACY_GET, self.handle_get),
+                (topics.LEGACY_LIST, self.handle_list))
+
+    def handle_schedule(self, message: Message):
+        self._warn_once(message.msg_type)
+        name = message.data.get("event")
+        when = message.data.get("time")
+        if not name or when is None:
+            LOG.error("legacy schedule request is missing event or time")
+            return
+        try:
+            record = legacy_record(name, when, message.data.get("repeat"),
+                                   message.data.get("data"),
+                                   message.context)
+        except ScheduleError as err:
+            LOG.error(f"legacy schedule request refused: {err.reason}")
+            return
+        self.service.replace_schedule(record)
+
+    def handle_remove(self, message: Message):
+        self._warn_once(message.msg_type)
+        name = message.data.get("event")
+        if name:
+            self.service.drop_schedule(self._key(name))
+
+    def handle_update(self, message: Message):
+        self._warn_once(message.msg_type)
+        name = message.data.get("event")
+        if name:
+            self.service.replace_payload(self._key(name),
+                                         message.data.get("data") or {})
+
+    def handle_get(self, message: Message):
+        self._warn_once(message.msg_type)
+        name = message.data.get("name")
+        schedule = self.service.find_schedule(self._key(name or ""))
+        entry = self._entry(schedule) if schedule else None
+        self.service.bus.emit(message.reply(
+            f"{topics.LEGACY_GET_REPLY_PREFIX}{name}",
+            data={"event": name, "schedule": entry}))
+
+    def handle_list(self, message: Message):
+        self._warn_once(message.msg_type)
+        listing = {schedule.record["id"]: [self._entry(schedule)]
+                   for schedule in self.service.all_schedules()}
+        self.service.bus.emit(
+            message.response(data={"scheduled_events": listing}))
+
+    def _key(self, name: str) -> Tuple[str, str]:
+        return legacy_owner(name), name
+
+    def _entry(self, schedule: Schedule) -> list:
+        """One schedule in the shape the legacy protocol reads: next epoch
+        time, repeat period, data, context."""
+        upcoming = schedule.next_from_now(self.service.now())
+        return [upcoming.timestamp() if upcoming else 0,
+                schedule.record.get("every", {}).get("seconds"),
+                schedule.record["data"], schedule.record.get("context") or {}]
+
+    def _warn_once(self, topic: str):
+        if topic not in self._warned_about:
+            self._warned_about.add(topic)
+            LOG.warning(f"{topic} is deprecated in favour of the "
+                        f"{topics.SCHEDULER_SCHEDULE.rsplit('.', 1)[0]}.* "
+                        f"topics and will be removed in ovos-bus-client "
+                        f"{LEGACY_REMOVAL_VERSION}")

--- a/ovos_bus_client/util/scheduled_events/records.py
+++ b/ovos_bus_client/util/scheduled_events/records.py
@@ -1,0 +1,74 @@
+"""The vocabulary a schedule record is written in.
+
+Instants, wall-clock times, the field names, and the error a refused request
+leaves through — :class:`ScheduleError`, whose ``code`` is one of the wire
+errors of SCHEDULER-1 §4.
+"""
+from datetime import datetime
+from typing import Tuple
+
+#: compact UTF-8 JSON bytes allowed in a record's ``data`` (§3.1)
+MAX_DATA_BYTES = 16384
+
+WEEKDAYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+TIMING_FIELDS = ("at", "in", "every", "local")
+
+
+class ScheduleError(ValueError):
+    """A request the scheduler refuses, carrying its wire error code."""
+
+    def __init__(self, code: str, reason: str):
+        super().__init__(reason)
+        self.code = code
+        self.reason = reason
+
+
+def parse_instant(value, field: str) -> datetime:
+    """Read an RFC 3339 instant.
+
+    An instant without a UTC offset is refused: without one the string does
+    not name a point on the time line (§3.2).
+    """
+    if not isinstance(value, str):
+        raise ScheduleError("bad_instant", f"{field} must be an RFC 3339 string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise ScheduleError("bad_instant", f"{field} is not RFC 3339: {value}")
+    if parsed.tzinfo is None:
+        raise ScheduleError("bad_instant", f"{field} has no UTC offset: {value}")
+    return parsed
+
+
+def format_instant(when: datetime) -> str:
+    """Write an instant in the form :func:`parse_instant` reads back."""
+    return when.isoformat()
+
+
+def timing_of(record: dict) -> Tuple[str, dict]:
+    """The one timing a record carries, as (field name, value).
+
+    Two records describe the same series when this is equal for both.
+    """
+    for field in TIMING_FIELDS:
+        if field in record:
+            return field, record[field]
+    raise ScheduleError("invalid_record", "record carries no timing")
+
+
+def parse_wall_clock(value) -> Tuple[int, int, int]:
+    """Read the ``HH:MM`` or ``HH:MM:SS`` of a wall-clock recurrence."""
+    if not isinstance(value, str):
+        raise ScheduleError("bad_recurrence", "local.time must be HH:MM or HH:MM:SS")
+    parts = value.split(":")
+    if len(parts) not in (2, 3):
+        raise ScheduleError("bad_recurrence", f"local.time is not HH:MM[:SS]: {value}")
+    try:
+        hour, minute = int(parts[0]), int(parts[1])
+        second = int(parts[2]) if len(parts) == 3 else 0
+    except ValueError:
+        raise ScheduleError("bad_recurrence", f"local.time is not HH:MM[:SS]: {value}")
+    if not (0 <= hour < 24 and 0 <= minute < 60 and 0 <= second < 60):
+        raise ScheduleError("bad_recurrence", f"local.time out of range: {value}")
+    return hour, minute, second

--- a/ovos_bus_client/util/scheduled_events/schedules.py
+++ b/ovos_bus_client/util/scheduled_events/schedules.py
@@ -1,0 +1,187 @@
+"""A stored record plus the state the scheduler keeps alongside it."""
+import time
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Tuple
+
+from ovos_bus_client.util.scheduled_events.records import (
+    format_instant, parse_instant)
+from ovos_bus_client.util.scheduled_events.timing import next_occurrence
+
+#: instants reported in one missed message, and the length of the missed
+#: list a schedule carries in its state (§4.3)
+MAX_REPORTED = 100
+
+
+class Schedule:
+    """One schedule as the scheduler holds it.
+
+    ``cursor`` is the instant up to and including which occurrences have been
+    consumed, and ``last_fired`` the due instant of the most recent occurrence
+    that reached the bus. Together they are the whole of the no-double-fire
+    guarantee of §5.1: an occurrence is only ever produced strictly after the
+    cursor, and never at or before ``last_fired``.
+
+    ``consumed`` counts occurrences as they are produced or dropped, which is
+    what ``count`` bounds; a misfire the policy discards is consumed all the
+    same (§4.3).
+    """
+
+    def __init__(self, record: dict, cursor: Optional[datetime] = None,
+                 consumed: int = 0, anchored: bool = True,
+                 last_fired: Optional[datetime] = None,
+                 missed: Optional[List[str]] = None,
+                 estimate: Optional[datetime] = None,
+                 deadline: Optional[float] = None):
+        self.record = record
+        self.consumed = consumed
+        self.anchored = anchored
+        self.last_fired = last_fired
+        self.missed = list(missed or [])
+        #: a relative delay runs off the monotonic ``deadline`` while the
+        #: service is up; ``estimate`` is the wall-clock projection that
+        #: survives a restart (§3.4.3)
+        self.estimate = estimate
+        self.deadline = deadline
+        if "in" in record and self.estimate is None:
+            seconds = record["in"]["seconds"]
+            self.estimate = datetime.now(timezone.utc) + timedelta(seconds=seconds)
+            self.deadline = time.monotonic() + seconds
+        self.cursor = cursor if cursor is not None else self._first_cursor()
+
+    @property
+    def key(self) -> Tuple[str, str]:
+        """The (owner, id) pair a schedule is identified by (§3.3)."""
+        return self.record["owner"], self.record["id"]
+
+    @property
+    def is_one_shot(self) -> bool:
+        return "at" in self.record or "in" in self.record
+
+    def _first_cursor(self) -> datetime:
+        """Where a brand new schedule starts looking.
+
+        One second before its first possible occurrence, so that an
+        occurrence due at that very instant is still ahead of the cursor.
+        """
+        margin = timedelta(seconds=1)
+        if "at" in self.record:
+            return parse_instant(self.record["at"], "at") - margin
+        if "in" in self.record:
+            return datetime.now(timezone.utc) - margin
+        if "every" in self.record:
+            return parse_instant(self.record["every"]["start"], "every.start") - margin
+        return datetime.now(timezone.utc)
+
+    def anchor(self, now: datetime):
+        """Pin a recurrence that was created while the clock was unset.
+
+        A period created before the device knew the time was anchored on a
+        meaningless instant; once the clock is trustworthy the anchor is the
+        moment of the first evaluation instead (§7.2).
+        """
+        if self.anchored:
+            return
+        self.anchored = True
+        if "local" in self.record:
+            self.cursor = now
+        elif "every" in self.record:
+            seconds = self.record["every"]["seconds"]
+            self.record["every"]["start"] = format_instant(
+                now + timedelta(seconds=seconds))
+            self.cursor = now
+
+    def retime(self, now: datetime):
+        """Project a relative delay onto the wall clock.
+
+        A step of the wall clock moves the estimate, never the delay the
+        owner asked for (§3.4.3).
+        """
+        if self.deadline is None:
+            return
+        left = self.deadline - time.monotonic()
+        self.estimate = now + timedelta(seconds=max(left, 0.0))
+
+    def next_after(self, after: datetime,
+                   consumed: Optional[int] = None) -> Optional[datetime]:
+        """The next occurrence strictly after ``after``, or None.
+
+        ``consumed`` overrides the schedule's own tally, so that a caller can
+        walk a backlog of occurrences without spending them.
+        """
+        if consumed is None:
+            consumed = self.consumed
+        if "count" in self.record and consumed >= self.record["count"]:
+            return None
+        if self.last_fired is not None and after < self.last_fired:
+            after = self.last_fired
+        occurrence = next_occurrence(self.record, after, self.estimate)
+        if occurrence is None:
+            return None
+        if "until" in self.record and \
+                occurrence > parse_instant(self.record["until"], "until"):
+            return None
+        return occurrence
+
+    def next_from_now(self, now: datetime) -> Optional[datetime]:
+        """The next occurrence a reader of this schedule should expect."""
+        return self.next_after(max(self.cursor, now))
+
+    def remaining(self) -> Optional[int]:
+        """Occurrences left when the schedule is bounded, else None."""
+        if self.is_one_shot:
+            return 0
+        if "count" in self.record:
+            return max(0, self.record["count"] - self.consumed)
+        return None
+
+    def record_fire(self, due: datetime):
+        """Note that the occurrence ``due`` reached the bus."""
+        if self.last_fired is None or due > self.last_fired:
+            self.last_fired = due
+
+    def remember_missed(self, dues: List[datetime], since: Optional[datetime]):
+        """Keep the missed instants a reader still needs to know about.
+
+        ``since`` is the due instant of the fire that just happened, if there
+        was one: everything it covers is no longer outstanding (§4.1).
+        """
+        if since is None:
+            self.missed.extend(format_instant(due) for due in dues)
+        else:
+            self.missed = [format_instant(due) for due in dues if due > since]
+        del self.missed[:-MAX_REPORTED]
+
+    def state(self, now: datetime) -> dict:
+        """The computed state a get or list answer carries (§4.1)."""
+        upcoming = self.next_from_now(now)
+        return {"next": format_instant(upcoming) if upcoming else None,
+                "last_fired": format_instant(self.last_fired) if self.last_fired else None,
+                "missed": list(self.missed),
+                "remaining": self.remaining()}
+
+    def as_stored(self) -> dict:
+        """This schedule as one entry of the store file."""
+        return {"record": self.record,
+                "cursor": format_instant(self.cursor),
+                "consumed": self.consumed,
+                "anchored": self.anchored,
+                "missed": list(self.missed),
+                "estimate": format_instant(self.estimate) if self.estimate else None,
+                "last_fired": format_instant(self.last_fired) if self.last_fired else None}
+
+    @classmethod
+    def from_stored(cls, entry: dict) -> "Schedule":
+        """Rebuild a schedule from one entry of the store file.
+
+        A relative delay comes back without its monotonic deadline: across a
+        restart it is an ``at`` on the estimate that was written (§3.4.3).
+        """
+        last_fired = entry.get("last_fired")
+        estimate = entry.get("estimate")
+        return cls(entry["record"],
+                   cursor=parse_instant(entry["cursor"], "cursor"),
+                   consumed=entry.get("consumed", 0),
+                   anchored=entry.get("anchored", True),
+                   last_fired=parse_instant(last_fired, "last_fired") if last_fired else None,
+                   missed=entry.get("missed"),
+                   estimate=parse_instant(estimate, "estimate") if estimate else None)

--- a/ovos_bus_client/util/scheduled_events/service.py
+++ b/ovos_bus_client/util/scheduled_events/service.py
@@ -1,0 +1,654 @@
+"""The scheduler service (SCHEDULER-1).
+
+Requests arrive on the four ``ovos.scheduler.*`` request topics and each is
+answered exactly once on the matching response topic. Accepted state reaches
+the store before the answer goes out, and the due instant of a fired
+occurrence reaches it immediately after the event, so an occurrence is
+delivered at least once and repeated at most once.
+"""
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import Event, RLock, Thread
+from typing import Dict, List, Optional, Tuple
+
+from ovos_config.config import Configuration
+from ovos_utils.log import LOG
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import topics
+from ovos_bus_client.util.scheduled_events.legacy import (
+    LegacyAdapter, mark_migrated, pending_migration_path, read_migration_source)
+from ovos_bus_client.util.scheduled_events.records import (
+    ScheduleError, format_instant, timing_of)
+from ovos_bus_client.util.scheduled_events.schedules import MAX_REPORTED, Schedule
+from ovos_bus_client.util.scheduled_events.store import (
+    ScheduleStore, default_store_path)
+from ovos_bus_client.util.scheduled_events.validation import validate_record
+
+#: seconds between evaluations
+TICK_SECONDS = 0.5
+#: occurrences one evaluation works through; a longer backlog drains over the
+#: ticks that follow
+MAX_BACKLOG = 10000
+#: a wall-clock/monotonic divergence above this is a step, not drift
+CLOCK_STEP_THRESHOLD = 2.0
+
+ScheduleKey = Tuple[str, str]
+
+
+@dataclass
+class DueBatch:
+    """What one schedule owes the bus in one evaluation.
+
+    Nothing here is consumed yet: consumption belongs next to the emission it
+    pays for, so that a crash mid-batch loses at most one occurrence's record.
+    """
+
+    schedule: Schedule
+    #: every occurrence at or before the evaluation instant, oldest first
+    due: List[datetime]
+    #: the occurrences that reach the bus, oldest first, each with its
+    #: position in ``due`` — which is what it consumes when it fires
+    to_fire: List[Tuple[int, datetime]]
+    #: the occurrences the missed message names
+    to_report: List[datetime]
+    #: the subset of ``to_fire`` that is firing after its grace period
+    fired_late: List[datetime] = field(default_factory=list)
+
+
+class ScheduledEventService(Thread):
+    """Keeps schedules and fires their events.
+
+    Construct it with a bus; it subscribes, restores its store and, unless
+    ``autostart`` is false, starts evaluating on its own thread.
+    """
+
+    def __init__(self, bus, store_path: Optional[str] = None,
+                 autostart: bool = True, admins: Optional[list] = None):
+        super().__init__(daemon=True)
+        self.bus = bus
+        self.schedule_store = ScheduleStore(store_path or default_store_path())
+        self.schedules: Dict[ScheduleKey, Schedule] = {}
+        self.lock = RLock()
+        self.legacy = LegacyAdapter(self)
+        self.admins = self._configured_admins(admins)
+
+        self._wall_reference = time.time()
+        self._mono_reference = time.monotonic()
+        #: newest instant a past run recorded as already past; a wall clock
+        #: behind it belongs to a device that has not found a time source yet
+        self.newest_past_instant: Optional[datetime] = None
+        self.clock_synced = True
+
+        self._restore()
+        self._subscriptions = self._subscribe()
+
+        self._running = Event()
+        self._stopping = Event()
+        if autostart:
+            self.start()
+            self._running.wait(10)
+        else:
+            # nothing is evaluating, so is_running must read False; a caller
+            # that wants a pass drives tick() or replay() by hand
+            self._stopping.set()
+
+    @property
+    def store_path(self) -> str:
+        return self.schedule_store.path
+
+    @staticmethod
+    def _configured_admins(admins: Optional[list]) -> list:
+        """Component ids allowed to act under the pseudo-owner ``*`` (§6.2).
+
+        An empty allowlist, which is the default, means no caller can.
+        """
+        if admins is None:
+            admins = Configuration().get("scheduler", {}).get("admins") or []
+        return list(admins)
+
+    def _subscribe(self):
+        subscriptions = (
+            (topics.SCHEDULER_SCHEDULE, self.handle_schedule),
+            (topics.SCHEDULER_CANCEL, self.handle_cancel),
+            (topics.SCHEDULER_GET, self.handle_get),
+            (topics.SCHEDULER_LIST, self.handle_list),
+            (topics.CLOCK_SYNCED, self.handle_clock_synced),
+        ) + self.legacy.subscriptions()
+        for topic, handler in subscriptions:
+            self.bus.on(topic, handler)
+        return subscriptions
+
+    # --- start-up ---------------------------------------------------------
+
+    def _restore(self):
+        """Load the store and work out whether the clock can be trusted."""
+        self._migrate_config_directory_store()
+        self.schedules.update(self.schedule_store.load())
+        self.newest_past_instant = self._newest_past_instant()
+        self.clock_synced = (self.newest_past_instant is None or
+                             self.now() >= self.newest_past_instant)
+
+    def _newest_past_instant(self) -> Optional[datetime]:
+        """The newest instant this scheduler has recorded as already past.
+
+        That is the wall-clock time of the most recent store write or the due
+        instant of the most recent fire, whichever is later. Only instants
+        that were already in the past when they were written count: a
+        schedule due next week says nothing about whether the device knows
+        what time it is (§7.2).
+        """
+        newest = self.schedule_store.written_at
+        for schedule in self.schedules.values():
+            if schedule.last_fired and (newest is None or
+                                        schedule.last_fired > newest):
+                newest = schedule.last_fired
+        return newest
+
+    def _migrate_config_directory_store(self):
+        """Adopt the store the previous scheduler kept in the configuration
+        directory, once, leaving the original in place."""
+        if os.path.isfile(self.schedule_store.path):
+            return
+        source = pending_migration_path()
+        if source is None:
+            return
+        try:
+            adopted = read_migration_source(source)
+            self.schedule_store.save(adopted.values())
+        except Exception as err:
+            LOG.error(f"could not migrate the legacy schedule store: {err}")
+            return
+        mark_migrated(source)
+        LOG.info(f"migrated {len(adopted)} schedules to {self.schedule_store.path}")
+
+    # --- clock ------------------------------------------------------------
+
+    @staticmethod
+    def now() -> datetime:
+        """The wall clock, which is what due-ness is measured against."""
+        return datetime.now(timezone.utc)
+
+    def _clock_step(self) -> float:
+        """Seconds by which the wall clock moved beyond the passage of time
+        since the last reading, or zero when the two clocks agree (§7.1)."""
+        wall, mono = time.time(), time.monotonic()
+        drift = (wall - self._wall_reference) - (mono - self._mono_reference)
+        self._wall_reference, self._mono_reference = wall, mono
+        return drift if abs(drift) > CLOCK_STEP_THRESHOLD else 0.0
+
+    def handle_clock_synced(self, message: Message):
+        """A deployment signalling that the device reached a time source."""
+        if not self.clock_synced:
+            LOG.info("clock synchronized, replaying deferred schedules")
+        self.clock_synced = True
+        self._clock_step()
+        self.replay()
+
+    # --- requests ---------------------------------------------------------
+
+    def handle_schedule(self, message: Message):
+        """Create or replace a schedule (§4.1)."""
+        try:
+            owner = self._authorized_owner(message, message.data.get("owner"))
+            with self.lock:
+                previous = self.schedules.get((owner, message.data.get("id")))
+                record = validate_record(
+                    dict(message.data, context=message.context),
+                    previous=previous.record if previous else None)
+                schedule = self._continuing(record, previous)
+                self._put_schedule(schedule, previous)
+                upcoming = schedule.next_from_now(self.now())
+        except ScheduleError as err:
+            return self._refuse(message, err)
+        except OSError as err:
+            return self._refuse(message, _unwritable_store(err))
+        self._answer(message, {"ok": True, "id": record["id"], "owner": owner,
+                               "next": format_instant(upcoming) if upcoming else None,
+                               "replaced": previous is not None})
+
+    def handle_cancel(self, message: Message):
+        """Delete a schedule. Cancelling one that does not exist is not an
+        error; the answer simply says it did not exist (§4.1)."""
+        try:
+            owner = self._authorized_owner(message, message.data.get("owner"),
+                                           wildcard=True)
+            schedule_id = _required_id(message)
+            with self.lock:
+                existed = self._drop_matching(owner, schedule_id)
+        except ScheduleError as err:
+            return self._refuse(message, err)
+        except OSError as err:
+            return self._refuse(message, _unwritable_store(err))
+        self._answer(message, {"ok": True, "id": schedule_id, "owner": owner,
+                               "existed": existed})
+
+    def handle_get(self, message: Message):
+        """Read one schedule as stored, plus its computed state (§4.1)."""
+        try:
+            owner = self._authorized_owner(message, message.data.get("owner"))
+            schedule_id = _required_id(message)
+            with self.lock:
+                schedule = self.schedules.get((owner, schedule_id))
+                view = self._view(schedule) if schedule else None
+        except ScheduleError as err:
+            return self._refuse(message, err)
+        self._answer(message, {"ok": True, "id": schedule_id, "owner": owner,
+                               "existed": view is not None,
+                               "record": view["record"] if view else None,
+                               "state": view["state"] if view else None})
+
+    def handle_list(self, message: Message):
+        """Read the caller's schedules, or every schedule under ``*``."""
+        try:
+            owner = self._authorized_owner(message, message.data.get("owner"),
+                                           wildcard=True)
+            with self.lock:
+                views = [self._view(schedule)
+                         for key, schedule in self.schedules.items()
+                         if owner == "*" or key[0] == owner]
+        except ScheduleError as err:
+            return self._refuse(message, err)
+        self._answer(message, {"ok": True, "owner": owner, "schedules": views})
+
+    def _view(self, schedule: Schedule) -> dict:
+        return {"record": dict(schedule.record),
+                "state": schedule.state(self.now())}
+
+    def _answer(self, message: Message, data: dict):
+        self.bus.emit(message.response(data))
+
+    def _refuse(self, message: Message, err: ScheduleError):
+        LOG.warning(f"{message.msg_type} refused: {err.reason}")
+        self._answer(message, {"ok": False, "error": err.code,
+                               "reason": err.reason})
+
+    # --- ownership --------------------------------------------------------
+
+    def _authorized_owner(self, message: Message, owner,
+                          wildcard: bool = False) -> str:
+        """The owner a request may act as, or a refusal (§6.2).
+
+        Where the bus carries an authenticated component identity, it must
+        match the request's owner. Where it does not, the owner field still
+        scopes the request, so that a component cannot reach another
+        component's schedules by omission.
+        """
+        if not isinstance(owner, str) or not owner:
+            raise ScheduleError("invalid_record", "owner is required")
+        identity = message.context.get("skill_id")
+        if owner == "*":
+            return self._authorized_administrator(identity, wildcard)
+        if identity and identity != owner:
+            raise ScheduleError("not_owner",
+                                f"{identity} may not act on schedules of {owner}")
+        return owner
+
+    def _authorized_administrator(self, identity, wildcard: bool) -> str:
+        if not wildcard:
+            raise ScheduleError("not_owner",
+                                "* is not an owner a schedule can belong to")
+        if not identity or identity not in self.admins:
+            raise ScheduleError(
+                "not_owner",
+                f"{identity or 'an anonymous caller'} is not allowed to act "
+                f"across every owner")
+        return "*"
+
+    # --- the schedules the scheduler holds --------------------------------
+
+    def all_schedules(self) -> List[Schedule]:
+        with self.lock:
+            return list(self.schedules.values())
+
+    def find_schedule(self, key: ScheduleKey) -> Optional[Schedule]:
+        with self.lock:
+            return self.schedules.get(key)
+
+    def replace_schedule(self, record: dict) -> Schedule:
+        """Put a validated record in place of whatever shares its identity."""
+        with self.lock:
+            previous = self.schedules.get((record["owner"], record["id"]))
+            schedule = self._continuing(record, previous)
+            self._put_schedule(schedule, previous)
+            return schedule
+
+    def _continuing(self, record: dict,
+                    previous: Optional[Schedule]) -> Schedule:
+        """A replacement, carrying what the schedule it replaces has done.
+
+        A replacement is not a new schedule. §5.2 makes sending the same
+        request twice the same as sending it once, which it is not if the
+        replacement arrives with an empty history and fires the morning
+        again.
+
+        ``last_fired`` comes across whatever else changed: §5.1 and §9.9 say
+        without exception that an occurrence at or before the most recent
+        fire is never fired again, and a replacement is not a way to ask for
+        one. ``consumed`` comes across too. Nothing in §4.3 or §5.2 grants a
+        replacement a fresh ``count`` budget, and an owner that wants one
+        cancels the schedule and creates it again (§5.4) — where the spec is
+        silent, the reading that cannot ring an alarm twice is the one to
+        take.
+
+        The cursor and the missed list are positions in a series. They mean
+        nothing once the timing describes a different one, so they come
+        across only when the timing is unchanged; ``last_fired`` still floors
+        everything the new series can produce.
+        """
+        if previous is None:
+            return Schedule(record, anchored=self.clock_synced)
+        same_series = timing_of(previous.record) == timing_of(record)
+        return Schedule(record, anchored=self.clock_synced,
+                        last_fired=previous.last_fired,
+                        consumed=previous.consumed,
+                        cursor=previous.cursor if same_series else None,
+                        missed=previous.missed if same_series else None)
+
+    def drop_schedule(self, key: ScheduleKey) -> bool:
+        """Delete one schedule. Returns whether it existed."""
+        with self.lock:
+            return self._drop_matching(key[0], key[1])
+
+    def replace_payload(self, key: ScheduleKey, data: dict):
+        """Change the data a schedule's occurrences fire with."""
+        with self.lock:
+            schedule = self.schedules.get(key)
+            if schedule is None:
+                return
+            schedule.record["data"] = data
+            self._persist()
+
+    def _put_schedule(self, schedule: Schedule, previous: Optional[Schedule]):
+        """Store a schedule, rolling the memory back if the write fails.
+
+        A request that could not be persisted did not happen: the running
+        process must not disagree with the store it will restart from (§5.1).
+        """
+        key = schedule.key
+        self.schedules[key] = schedule
+        try:
+            self._persist()
+        except OSError:
+            if previous is not None:
+                self.schedules[key] = previous
+            else:
+                self.schedules.pop(key, None)
+            raise
+
+    def _drop_matching(self, owner: str, schedule_id: str) -> bool:
+        """Remove the schedules an owner and id name, rolling back on a failed
+        write. Under ``*`` that is the id under every owner."""
+        if owner == "*":
+            keys = [key for key in self.schedules if key[1] == schedule_id]
+        else:
+            keys = [(owner, schedule_id)] if (owner, schedule_id) in self.schedules else []
+        if not keys:
+            return False
+        dropped = {key: self.schedules.pop(key) for key in keys}
+        try:
+            self._persist()
+        except OSError:
+            self.schedules.update(dropped)
+            raise
+        return True
+
+    def _persist(self):
+        with self.lock:
+            self.schedule_store.save(self.schedules.values())
+
+    # --- evaluation -------------------------------------------------------
+
+    def run(self):
+        LOG.info("ScheduledEventService started")
+        self._stopping.clear()
+        self._running.set()
+        self.replay()
+        while not self._stopping.wait(TICK_SECONDS):
+            try:
+                self.tick()
+            except Exception as err:
+                LOG.exception(err)
+        LOG.info("ScheduledEventService stopped")
+
+    def tick(self):
+        """One pass: notice a clock step, then fire whatever is due."""
+        step = self._clock_step()
+        if not self.clock_synced:
+            self._recheck_the_clock()
+            return
+        if step:
+            LOG.info(f"wall clock stepped by {step:.0f}s, re-evaluating schedules")
+        self._evaluate()
+
+    def _recheck_the_clock(self):
+        """While the clock is unsynchronized the scheduler accepts and stores
+        requests but evaluates nothing. It starts evaluating when the wall
+        clock passes the newest instant it recorded as past (§7.2)."""
+        if self.newest_past_instant is None or self.now() >= self.newest_past_instant:
+            LOG.info("wall clock reached a plausible reading, replaying")
+            self.clock_synced = True
+            self.replay()
+
+    def replay(self):
+        """Announce readiness, then apply the misfire policy to everything
+        that came due while the scheduler was not evaluating.
+
+        Readiness goes out first so that an owner subscribed to it still hears
+        its own late fires (§5.4).
+        """
+        restored = len(self.schedules)
+        batches = self._plan(replaying=True)
+        self.bus.emit(Message(topics.SCHEDULER_READY, {
+            "schedules": restored,
+            "missed": len(batches),
+            "clock": "synchronized" if self.clock_synced else "unsynchronized"}))
+        self._run(batches)
+
+    def _evaluate(self):
+        self._run(self._plan())
+
+    def _run(self, batches: List[DueBatch]):
+        for batch in batches:
+            if batch.to_report:
+                # the report precedes any late fire of the same batch (§4.3)
+                self._report_missed(batch)
+            self._fire_batch(batch)
+
+    def _plan(self, replaying: bool = False) -> List[DueBatch]:
+        """Work out what every schedule owes the bus, consuming nothing."""
+        if not self.clock_synced:
+            return []
+        now = self.now()
+        batches = []
+        with self.lock:
+            for schedule in list(self.schedules.values()):
+                schedule.anchor(now)
+                schedule.retime(now)
+                batch = self._batch_for(schedule, now, replaying)
+                if batch is not None:
+                    batches.append(batch)
+        return batches
+
+    def _batch_for(self, schedule: Schedule, now: datetime,
+                   replaying: bool) -> Optional[DueBatch]:
+        due = self._occurrences_through(schedule, now)
+        if not due:
+            return None
+        grace = schedule.record["grace_s"]
+        late = [when for when in due if (now - when).total_seconds() > grace]
+        fired_late = _late_fires(schedule.record["misfire"], late)
+
+        to_fire = []
+        for position, occurrence in enumerate(due):
+            if occurrence not in late or occurrence in fired_late:
+                to_fire.append((position, occurrence))
+
+        # after a restart an occurrence may have reached the bus and lost its
+        # record to the crash window, so replay reports everything it
+        # produces; owners deduplicate on (id, due) (§5.1)
+        return DueBatch(schedule=schedule, due=due, to_fire=to_fire,
+                        to_report=due if replaying else late,
+                        fired_late=fired_late)
+
+    @staticmethod
+    def _occurrences_through(schedule: Schedule,
+                             now: datetime) -> List[datetime]:
+        """Every occurrence at or before ``now`` that has not been consumed,
+        oldest first, up to one evaluation's worth."""
+        due = []
+        cursor = schedule.cursor
+        consumed = schedule.consumed
+        while len(due) < MAX_BACKLOG:
+            occurrence = schedule.next_after(cursor, consumed)
+            if occurrence is None or occurrence > now:
+                break
+            due.append(occurrence)
+            cursor = occurrence
+            consumed += 1
+        return due
+
+    def _report_missed(self, batch: DueBatch):
+        """Name every missed occurrence of one schedule, once (§4.3)."""
+        schedule = batch.schedule
+        truncated = (len(batch.to_report) > MAX_REPORTED or
+                     len(batch.fired_late) > MAX_REPORTED)
+        upcoming = self._next_occurrence_after(batch)
+        self.bus.emit(Message(topics.SCHEDULER_MISSED, {
+            "id": schedule.record["id"],
+            "owner": schedule.record["owner"],
+            "missed": [format_instant(when)
+                       for when in batch.to_report[:MAX_REPORTED]],
+            "fired_late": [format_instant(when)
+                           for when in batch.fired_late[:MAX_REPORTED]],
+            "truncated": truncated,
+            "next": format_instant(upcoming) if upcoming else None}))
+
+    def _next_occurrence_after(self, batch: DueBatch) -> Optional[datetime]:
+        """The next occurrence once this batch has been consumed.
+
+        The report goes out before the fires it announces (§4.3), so the
+        schedule still carries the tally from before the batch. Reporting
+        ``next`` from that tally would name an occurrence a spent ``count``
+        can no longer produce.
+        """
+        schedule = batch.schedule
+        return schedule.next_after(max(schedule.cursor, batch.due[-1], self.now()),
+                                   schedule.consumed + len(batch.due))
+
+    def _fire_batch(self, batch: DueBatch):
+        """Emit one occurrence, persist the consumption it represents, then
+        the next. A crash anywhere in here repeats at most the occurrence
+        that was in flight (§5.1)."""
+        schedule = batch.schedule
+        already_consumed = schedule.consumed
+        for position, occurrence in batch.to_fire:
+            schedule.cursor = occurrence
+            schedule.consumed = already_consumed + position + 1
+            self._fire(schedule, occurrence)
+            self._persist()
+
+        # occurrences the policy dropped are consumed all the same (§4.3)
+        schedule.cursor = max(schedule.cursor, batch.due[-1])
+        schedule.consumed = already_consumed + len(batch.due)
+        schedule.remember_missed(
+            batch.to_report,
+            since=batch.to_fire[-1][1] if batch.to_fire else None)
+        self._retire_if_spent(schedule)
+        self._persist()
+
+    def _fire(self, schedule: Schedule, due: datetime):
+        """Emit one occurrence, with the context the schedule was made with.
+
+        §4.2: the fired message's context is the stored context of §3.5,
+        unchanged but for the added ``scheduler`` key. Every other key is
+        left exactly as it arrived, and none is dropped or rewritten, so a
+        request that carried no context fires with the ``scheduler`` key
+        alone.
+
+        That context is the routing identity of whoever asked — ``source``,
+        ``destination`` and the session carrier — and replaying it verbatim
+        is what makes an alarm asked for on a remote device ring on that
+        device rather than wherever the scheduler runs.
+
+        Whether a session snapshot inside it is still current is a
+        consumer's question, answered under the session lifecycle
+        (SESSION-2 §2.5, §4.1) and not here.
+        """
+        record = schedule.record
+        context = dict(record.get("context") or {})
+        context["scheduler"] = {"id": record["id"],
+                                "owner": record["owner"],
+                                "due": format_instant(due),
+                                "fired": format_instant(self.now()),
+                                "remaining": schedule.remaining()}
+        LOG.debug(f"scheduled event fired: {record['id']}")
+        self.bus.emit(Message(record["event"], dict(record["data"]), context))
+        schedule.record_fire(due)
+
+    def _retire_if_spent(self, schedule: Schedule):
+        """A one-shot is deleted once its occurrence has fired or been
+        reported missed, and a recurrence once it has none left (§4.3).
+
+        Only the schedule that fired is retired, which is why this compares
+        the stored schedule and not just its identity. A handler that arms
+        the next occurrence from inside the event it just received — ring,
+        then set tomorrow's — has already put a different schedule under this
+        identity by the time the batch ends, and so has a replacement that
+        arrived from another thread while it ran. Retiring by identity alone
+        deletes that schedule silently, and the owner has no way to learn
+        that the request it made was undone.
+        """
+        if not (schedule.is_one_shot or
+                schedule.next_after(schedule.cursor) is None):
+            return
+        with self.lock:
+            if self.schedules.get(schedule.key) is schedule:
+                del self.schedules[schedule.key]
+
+    # --- lifecycle --------------------------------------------------------
+
+    @property
+    def is_running(self) -> bool:
+        return not self._stopping.is_set()
+
+    @is_running.setter
+    def is_running(self, value: bool):
+        if value:
+            self._stopping.clear()
+        else:
+            self._stopping.set()
+
+    def shutdown(self):
+        self._stopping.set()
+        # only this scheduler's own subscriptions go; an unrelated observer on
+        # the same topic is none of our business
+        for topic, handler in self._subscriptions:
+            self.bus.remove(topic, handler)
+        if self.is_alive():
+            self.join(30)
+        self._persist()
+        self._running.clear()
+
+
+def _late_fires(policy: str, late: List[datetime]) -> List[datetime]:
+    """Which missed occurrences the misfire policy puts on the bus (§4.3)."""
+    if policy == "all":
+        return list(late)
+    if policy == "late":
+        return late[-1:]
+    return []
+
+
+def _required_id(message: Message) -> str:
+    schedule_id = message.data.get("id")
+    if not isinstance(schedule_id, str) or not schedule_id:
+        raise ScheduleError("invalid_record", "id is required")
+    return schedule_id
+
+
+def _unwritable_store(err: OSError) -> ScheduleError:
+    return ScheduleError("internal",
+                         f"the schedule store could not be written: {err}")

--- a/ovos_bus_client/util/scheduled_events/store.py
+++ b/ovos_bus_client/util/scheduled_events/store.py
@@ -1,0 +1,170 @@
+"""The schedule store: the file schedules survive a restart in (§5).
+
+The store lives in the assistant's state directory, not its configuration
+directory. Its format is not part of the wire contract, but it carries the
+records of §3.1 unchanged so that a replacement scheduler can read them.
+"""
+import json
+import os
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from ovos_utils.log import LOG
+from ovos_utils.xdg_utils import xdg_state_home
+from ovos_config.meta import get_xdg_base
+
+from ovos_bus_client.util.scheduled_events.records import (
+    ScheduleError, format_instant, parse_instant)
+from ovos_bus_client.util.scheduled_events.schedules import Schedule
+
+#: bumped when the on-disk shape changes in a way a reader must know about.
+#: A file written by a newer scheduler is not read: this one cannot know what
+#: its entries mean. An older one is read, because every version so far only
+#: added a field an older record simply does not have.
+STORE_VERSION = 2
+
+#: the oldest version whose records this scheduler still understands
+OLDEST_READABLE_VERSION = 1
+
+
+def default_store_path(filename: str = "schedule.json") -> str:
+    """Where the store lives unless a deployment says otherwise."""
+    return os.path.join(xdg_state_home(), get_xdg_base(), filename)
+
+
+class ScheduleStore:
+    """Reads and writes the schedule file.
+
+    Every write is an atomic replace, so a crash at any point leaves either
+    the previous file or the new one and never a partial write (§5.1).
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+        #: the wall-clock time of the most recent write, which is one half of
+        #: the newest-already-past instant of §7.2
+        self.written_at: Optional[datetime] = None
+
+    def load(self) -> Dict[Tuple[str, str], Schedule]:
+        """Every schedule the file holds, keyed by identity.
+
+        An unreadable entry is reported and skipped: a scheduler that refuses
+        to start because one record went bad is worse than one that starts
+        without it. A whole file this scheduler cannot use — damaged, or
+        written by a version it does not read — is moved aside instead, so
+        that starting without it does not destroy it.
+        """
+        content = self._read()
+        if content is None:
+            return {}
+        version = content.get("version")
+        if not self._readable(version):
+            self._set_aside(version)
+            return {}
+        self.written_at = self._stored_write_time(content.get("written_at"))
+        schedules = {}
+        for entry in content.get("schedules", []):
+            try:
+                schedule = Schedule.from_stored(entry)
+            except (ScheduleError, KeyError, TypeError) as err:
+                LOG.error(f"dropping unreadable schedule: {err}")
+                continue
+            schedules[schedule.key] = schedule
+        return schedules
+
+    def save(self, schedules: Iterable[Schedule]):
+        """Write every non-ephemeral schedule, atomically.
+
+        Raises OSError when the store could not be written; the caller is
+        expected to roll back rather than run on state the file disagrees
+        with (§5.1).
+        """
+        directory = os.path.dirname(self.path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        written_at = datetime.now(timezone.utc)
+        content = {"version": STORE_VERSION,
+                   "written_at": format_instant(written_at),
+                   "schedules": self._persistable(schedules)}
+        temporary = f"{self.path}.tmp"
+        with open(temporary, "w") as handle:
+            json.dump(content, handle)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, self.path)
+        self.written_at = written_at
+
+    @staticmethod
+    def _persistable(schedules: Iterable[Schedule]) -> List[dict]:
+        """Ephemeral schedules are held in memory only (§5.3)."""
+        entries = []
+        for schedule in schedules:
+            if not schedule.record["ephemeral"]:
+                entries.append(schedule.as_stored())
+        return entries
+
+    def _read(self) -> Optional[dict]:
+        if not os.path.isfile(self.path):
+            return None
+        try:
+            with open(self.path) as handle:
+                return json.load(handle)
+        except Exception as err:
+            self._quarantine(err)
+            return None
+
+    def _quarantine(self, err: Exception):
+        """Move a store that will not parse out of the way.
+
+        Starting empty means the next write replaces the file, and the
+        damaged bytes are the only account of what the scheduler was holding.
+        They are kept beside it under a name of their own, so that whoever
+        comes to ask why the alarms are gone has something to read.
+        """
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+        quarantined = f"{self.path}.corrupt.{stamp}.bak"
+        try:
+            os.replace(self.path, quarantined)
+        except OSError as unmovable:
+            LOG.error(f"unreadable schedule store {self.path}: {err}; it could "
+                      f"not be set aside either ({unmovable}), so the next "
+                      f"write will replace it")
+            return
+        LOG.error(f"unreadable schedule store {self.path}: {err}; it was moved "
+                  f"to {quarantined} and this scheduler starts with no "
+                  f"schedules")
+
+    @staticmethod
+    def _readable(version) -> bool:
+        """Whether a store of this version can be read.
+
+        Older stores are read as they are. Every version so far has only
+        added a field, so a record from an older one is a record with that
+        field missing, and the next write brings the file up to date.
+        """
+        return (isinstance(version, int) and not isinstance(version, bool) and
+                OLDEST_READABLE_VERSION <= version <= STORE_VERSION)
+
+    def _set_aside(self, version):
+        """Move a store this scheduler cannot read out of the way.
+
+        Starting empty means the next write replaces the file, so a store from
+        a version we do not understand is preserved beside it first: a
+        downgrade must not cost the schedules the newer scheduler held.
+        """
+        backup = f"{self.path}.v{version}.bak"
+        os.replace(self.path, backup)
+        LOG.warning(f"schedule store {self.path} is version {version} and this "
+                    f"scheduler reads versions {OLDEST_READABLE_VERSION} to "
+                    f"{STORE_VERSION}; it was moved to {backup} and this "
+                    f"scheduler starts with no schedules")
+
+    @staticmethod
+    def _stored_write_time(value) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            return parse_instant(value, "written_at")
+        except ScheduleError as err:
+            LOG.warning(f"ignoring unreadable store timestamp: {err}")
+            return None

--- a/ovos_bus_client/util/scheduled_events/timing.py
+++ b/ovos_bus_client/util/scheduled_events/timing.py
@@ -1,0 +1,110 @@
+"""When a record's occurrences fall (SCHEDULER-1 §3.4).
+
+These functions answer one question — the first occurrence strictly after a
+given instant — for each of the four timing forms. They know nothing about
+``count``, ``until`` or what has already fired; those bounds belong to the
+schedule (see :mod:`.schedules`).
+"""
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from ovos_bus_client.util.scheduled_events.records import (
+    WEEKDAYS, parse_instant, parse_wall_clock)
+
+#: how far ahead a wall-clock rule looks before giving up; a rule listing a
+#: single weekday needs a week, and a year of slack costs nothing
+_LOOKAHEAD_DAYS = 400
+
+
+def next_occurrence(record: dict, after: datetime,
+                    estimate: Optional[datetime] = None) -> Optional[datetime]:
+    """The first occurrence of ``record`` strictly after ``after``.
+
+    ``estimate`` is the wall-clock instant a relative delay is projected
+    onto; it is the only timing form whose answer is not a function of the
+    record alone (§3.4.3).
+    """
+    if "at" in record:
+        at = parse_instant(record["at"], "at")
+        return at if at > after else None
+    if "in" in record:
+        return estimate if estimate is not None and estimate > after else None
+    if "every" in record:
+        return _next_period_occurrence(record["every"], after)
+    return next_wall_clock_occurrence(record["local"], after)
+
+
+def _next_period_occurrence(every: dict, after: datetime) -> datetime:
+    """Occurrence *n* is ``start + n x seconds``.
+
+    The series is anchored on the schedule and never on the previous fire, so
+    a late fire does not shift the occurrences that follow it (§3.4.1).
+    """
+    start = parse_instant(every["start"], "every.start")
+    seconds = every["seconds"]
+    if after < start:
+        return start
+    elapsed = (after - start).total_seconds()
+    periods = int(elapsed // seconds) + 1
+    return start + timedelta(seconds=periods * seconds)
+
+
+def next_wall_clock_occurrence(local: dict, after: datetime) -> Optional[datetime]:
+    """The next instant at which the wall clock in ``local.zone`` reads
+    ``local.time`` on one of ``local.days`` (§3.4.2)."""
+    zone = ZoneInfo(local["zone"])
+    hour, minute, second = parse_wall_clock(local["time"])
+    days = local.get("days") or list(WEEKDAYS)
+
+    day = after.astimezone(zone).date()
+    for _ in range(_LOOKAHEAD_DAYS):
+        if WEEKDAYS[day.weekday()] in days:
+            occurrence = wall_clock_instant(day, hour, minute, second, zone)
+            # a spring-forward gap can push the reading onto the next day,
+            # which the owner did not ask for
+            landed_on = occurrence.astimezone(zone)
+            if occurrence > after and WEEKDAYS[landed_on.weekday()] in days:
+                return occurrence
+        day += timedelta(days=1)
+    return None
+
+
+def wall_clock_instant(day: date, hour: int, minute: int, second: int,
+                       zone: ZoneInfo) -> datetime:
+    """The instant at which the wall clock in ``zone`` reads the given time
+    on ``day``.
+
+    A daylight-saving change makes two readings ambiguous. Across a
+    spring-forward gap the wall clock never reads the time at all, and the
+    occurrence is the first instant after the gap; across a fall-back overlap
+    it reads it twice, and the occurrence is the first of the two (§3.4.2).
+    """
+    wanted = datetime(day.year, day.month, day.day, hour, minute, second)
+    earlier = wanted.replace(tzinfo=zone, fold=0)
+    if _reading_in(earlier, zone) == wanted:
+        return earlier
+    return _first_instant_reading_at_or_past(wanted, zone)
+
+
+def _reading_in(moment: datetime, zone: ZoneInfo) -> datetime:
+    """What the wall clock in ``zone`` reads at ``moment``, as a naive time."""
+    return moment.astimezone(timezone.utc).astimezone(zone).replace(tzinfo=None)
+
+
+def _first_instant_reading_at_or_past(wanted: datetime,
+                                      zone: ZoneInfo) -> datetime:
+    """Bisect the day around a gap for the instant the clock resumes at.
+
+    The wall clock is monotonic across a gap, so the boundary is found by
+    halving a window that starts inside the gap's own day.
+    """
+    before = (wanted - timedelta(hours=6)).replace(tzinfo=zone).astimezone(timezone.utc)
+    after = (wanted + timedelta(hours=6)).replace(tzinfo=zone).astimezone(timezone.utc)
+    while after - before > timedelta(seconds=1):
+        middle = before + (after - before) / 2
+        if _reading_in(middle, zone) < wanted:
+            before = middle
+        else:
+            after = middle
+    return after.astimezone(zone)

--- a/ovos_bus_client/util/scheduled_events/topics.py
+++ b/ovos_bus_client/util/scheduled_events/topics.py
@@ -1,0 +1,30 @@
+"""Bus topics of the scheduler protocol (SCHEDULER-1 §4).
+
+These names mirror the ``SCHEDULER_*`` constants of
+``ovos_spec_tools.messages.SpecMessage``, which is where the platform keeps
+its message registry. They are defined here only until that registry ships
+them; when it does, this module becomes a re-export and no call site has to
+change, because nothing outside this module writes a topic literal.
+"""
+
+SCHEDULER_SCHEDULE = "ovos.scheduler.schedule"
+SCHEDULER_SCHEDULE_RESPONSE = "ovos.scheduler.schedule.response"
+SCHEDULER_CANCEL = "ovos.scheduler.cancel"
+SCHEDULER_CANCEL_RESPONSE = "ovos.scheduler.cancel.response"
+SCHEDULER_GET = "ovos.scheduler.get"
+SCHEDULER_GET_RESPONSE = "ovos.scheduler.get.response"
+SCHEDULER_LIST = "ovos.scheduler.list"
+SCHEDULER_LIST_RESPONSE = "ovos.scheduler.list.response"
+SCHEDULER_READY = "ovos.scheduler.ready"
+SCHEDULER_MISSED = "ovos.scheduler.missed"
+
+#: emitted by the platform when the device reaches a time source
+CLOCK_SYNCED = "system.clock.synced"
+
+#: the pre-specification protocol, kept for one stable cycle
+LEGACY_SCHEDULE = "mycroft.scheduler.schedule_event"
+LEGACY_REMOVE = "mycroft.scheduler.remove_event"
+LEGACY_UPDATE = "mycroft.scheduler.update_event"
+LEGACY_GET = "mycroft.scheduler.get_event"
+LEGACY_LIST = "mycroft.scheduler.list_events"
+LEGACY_GET_REPLY_PREFIX = "mycroft.event_status.callback."

--- a/ovos_bus_client/util/scheduled_events/validation.py
+++ b/ovos_bus_client/util/scheduled_events/validation.py
@@ -1,0 +1,248 @@
+"""What a request must contain to become a stored record (SCHEDULER-1 §3.1).
+
+A refused request leaves through :class:`.ScheduleError` carrying the wire
+error code the answer will name.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from ovos_bus_client.util.scheduled_events.records import (
+    MAX_DATA_BYTES, TIMING_FIELDS, WEEKDAYS, ScheduleError, format_instant,
+    parse_instant, parse_wall_clock)
+from ovos_bus_client.util.scheduled_events.timing import next_occurrence
+
+
+def validate_record(request: dict, namespaced: bool = True,
+                    previous: Optional[dict] = None) -> dict:
+    """Check a request against §3.1 and return the record to store.
+
+    ``namespaced`` is false only for the legacy adapter, whose event names
+    predate the ``<owner>.<name>`` rule. ``previous`` is the stored record of
+    the same identity, if any; it is what lets an unchanged recurrence keep
+    its anchor.
+
+    The requesting message's ``context`` is kept as it arrived (§3.5), so
+    that the occurrence can be emitted with it. It is not part of the
+    identity: two requests that differ only in context are the same schedule,
+    and the later one's context is the one that fires.
+    """
+    if not isinstance(request, dict):
+        raise ScheduleError("invalid_record", "request data must be an object")
+
+    owner = _required_name(request.get("owner"), "owner")
+    record = {"id": _required_name(request.get("id"), "id"),
+              "owner": owner,
+              "event": _validated_event(request.get("event"), owner, namespaced),
+              "data": _validated_payload(request.get("data"))}
+
+    context = _validated_context(request.get("context"))
+    if context:
+        record["context"] = context
+
+    timing = _sole_timing_field(request)
+    record[timing] = _validated_timing(timing, request, previous)
+    record.update(_validated_bounds(timing, request))
+    record.update(_validated_policies(request))
+    _reject_a_recurrence_that_can_never_fire(record)
+    return record
+
+
+def _reject_a_recurrence_that_can_never_fire(record: dict):
+    """§4 makes "describes no occurrence" a ``bad_recurrence``.
+
+    A recurrence bounded before its own first occurrence would otherwise be
+    stored forever: only a fire retires a schedule, and this one never fires.
+    """
+    if "at" in record or "in" in record:
+        return
+    if "every" in record:
+        first = parse_instant(record["every"]["start"], "every.start")
+    else:
+        first = next_occurrence(record, datetime.now(timezone.utc))
+    if first is None:
+        raise ScheduleError("bad_recurrence",
+                            "the recurrence describes no occurrence")
+    until = record.get("until")
+    if until is not None and first > parse_instant(until, "until"):
+        raise ScheduleError(
+            "bad_recurrence",
+            f"the recurrence's first occurrence {format_instant(first)} is "
+            f"after until {until}")
+
+
+def _required_name(value, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ScheduleError("invalid_record", f"{field} is required")
+    return value
+
+
+def _validated_event(event, owner: str, namespaced: bool) -> str:
+    """The message type each occurrence fires (§6.1).
+
+    The ``<owner>.<name>`` shape makes a fired event attributable to its
+    owner, and the ban on ``:`` keeps it clear of the dispatch shape of
+    MSG-1 §2.1.1, so a schedule can never address another component's
+    registered handler.
+    """
+    if not isinstance(event, str) or not event:
+        raise ScheduleError("bad_event", "event is required")
+    if not namespaced:
+        return event
+    prefix = f"{owner}."
+    name = event[len(prefix):] if event.startswith(prefix) else ""
+    if not name or ":" in name:
+        raise ScheduleError(
+            "bad_event",
+            f"event must be <owner>.<name> for owner {owner}, with a "
+            f"non-empty name free of ':'; got {event}")
+    return event
+
+
+def _validated_payload(data) -> dict:
+    payload = data or {}
+    if not isinstance(payload, dict):
+        raise ScheduleError("invalid_record", "data must be an object")
+    try:
+        size = len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    except (TypeError, ValueError):
+        raise ScheduleError("invalid_record", "data is not JSON serializable")
+    if size > MAX_DATA_BYTES:
+        raise ScheduleError("payload_too_large",
+                            f"data is {size} bytes, the limit is {MAX_DATA_BYTES}")
+    return payload
+
+
+def _validated_context(context) -> dict:
+    """The message context to fire the occurrence with, as it arrived.
+
+    §3.5 forbids adding to it, removing from it or rewriting it, and the
+    caller takes it from the request message rather than from the request
+    body, so a component can only schedule a fire into a context it reached
+    the scheduler from. Nothing here reads it; it is only checked for shape
+    and for size, which it shares with the payload because it is stored and
+    replayed exactly as the payload is.
+    """
+    if context is None:
+        return {}
+    if not isinstance(context, dict):
+        raise ScheduleError("invalid_record", "context must be an object")
+    try:
+        size = len(json.dumps(context, separators=(",", ":")).encode("utf-8"))
+    except (TypeError, ValueError):
+        raise ScheduleError("invalid_record", "context is not JSON serializable")
+    if size > MAX_DATA_BYTES:
+        raise ScheduleError("payload_too_large",
+                            f"context is {size} bytes, the limit is "
+                            f"{MAX_DATA_BYTES}")
+    return context
+
+
+def _sole_timing_field(request: dict) -> str:
+    present = [field for field in TIMING_FIELDS
+               if request.get(field) is not None]
+    if len(present) != 1:
+        raise ScheduleError("invalid_record",
+                            "exactly one of at, in, every, local is required")
+    return present[0]
+
+
+def _validated_timing(timing: str, request: dict, previous: Optional[dict]):
+    if timing == "at":
+        return format_instant(parse_instant(request["at"], "at"))
+    if timing == "in":
+        return _validated_delay(request["in"])
+    if timing == "every":
+        return _validated_period(request["every"], previous)
+    return _validated_wall_clock_rule(request["local"])
+
+
+def _validated_delay(delay) -> dict:
+    if not isinstance(delay, dict):
+        raise ScheduleError("invalid_record", "in must be an object")
+    return {"seconds": _positive_number(delay.get("seconds"), "in.seconds",
+                                        "invalid_record")}
+
+
+def _validated_period(every, previous: Optional[dict]) -> dict:
+    if not isinstance(every, dict):
+        raise ScheduleError("bad_recurrence", "every must be an object")
+    seconds = _positive_number(every.get("seconds"), "every.seconds",
+                               "bad_recurrence")
+    start = every.get("start")
+    if start is not None:
+        start = format_instant(parse_instant(start, "every.start"))
+    elif previous and previous.get("every", {}).get("seconds") == seconds:
+        # an owner re-creating an unchanged recurrence keeps its phase (§3.4.1)
+        start = previous["every"]["start"]
+    else:
+        start = format_instant(datetime.now(timezone.utc) +
+                               timedelta(seconds=seconds))
+    return {"seconds": seconds, "start": start}
+
+
+def _validated_wall_clock_rule(local) -> dict:
+    if not isinstance(local, dict):
+        raise ScheduleError("bad_recurrence", "local must be an object")
+    parse_wall_clock(local.get("time"))
+    zone = local.get("zone")
+    if not isinstance(zone, str) or not zone:
+        raise ScheduleError("bad_recurrence", "local.zone is required")
+    try:
+        ZoneInfo(zone)
+    except (ZoneInfoNotFoundError, ValueError):
+        raise ScheduleError("bad_recurrence", f"unknown time zone: {zone}")
+    rule = {"time": local["time"], "zone": zone}
+    days = local.get("days")
+    if days is not None:
+        if not isinstance(days, list) or not days or \
+                any(day not in WEEKDAYS for day in days):
+            raise ScheduleError("bad_recurrence",
+                                "local.days must be a non-empty list of mon..sun")
+        rule["days"] = list(days)
+    return rule
+
+
+def _validated_bounds(timing: str, request: dict) -> dict:
+    """``until`` and ``count`` bound a recurrence and mean nothing to a
+    one-shot, which has exactly one occurrence to begin with (§3.1)."""
+    given = {field for field in ("until", "count")
+             if request.get(field) is not None}
+    if timing in ("at", "in"):
+        if given:
+            raise ScheduleError("invalid_record",
+                                "until and count are for recurring schedules")
+        return {}
+
+    bounds = {}
+    if "until" in given:
+        bounds["until"] = format_instant(parse_instant(request["until"], "until"))
+    if "count" in given:
+        count = request["count"]
+        if not isinstance(count, int) or isinstance(count, bool) or count < 1:
+            raise ScheduleError("invalid_record", "count must be an integer >= 1")
+        bounds["count"] = count
+    return bounds
+
+
+def _validated_policies(request: dict) -> dict:
+    misfire = request.get("misfire", "late")
+    if misfire not in ("late", "skip", "all"):
+        raise ScheduleError("invalid_record", "misfire must be late, skip or all")
+
+    grace = request.get("grace_s", 60)
+    if not isinstance(grace, (int, float)) or isinstance(grace, bool) or grace < 0:
+        raise ScheduleError("invalid_record", "grace_s must be a number >= 0")
+
+    ephemeral = request.get("ephemeral", False)
+    if not isinstance(ephemeral, bool):
+        raise ScheduleError("invalid_record", "ephemeral must be a boolean")
+
+    return {"misfire": misfire, "grace_s": grace, "ephemeral": ephemeral}
+
+
+def _positive_number(value, field: str, code: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        raise ScheduleError(code, f"{field} must be a number > 0")
+    return value

--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -12,367 +12,90 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""
-The scheduler module allows setting up scheduled messages.
+"""The scheduler under the name the rest of the stack starts it by.
 
-A scheduled message will be kept and not sent until the system clock time
-criteria is met.
+:class:`EventScheduler` is :class:`~ovos_bus_client.util.scheduled_events.
+ScheduledEventService` with the epoch-float methods the pre-specification
+service offered. New code talks the SCHEDULER-1 protocol instead, through
+:class:`~ovos_bus_client.apis.events.SchedulerClient`.
 """
-import datetime
-import json
-import shutil
+import os
 import time
-from os.path import isfile, join, expanduser
-from threading import Event
-from threading import Thread, Lock
 from typing import Optional
 
-from ovos_config.config import Configuration
-from ovos_config.locations import get_xdg_data_save_path, get_xdg_config_save_path
-from ovos_utils.log import LOG
-from ovos_utils.time import now_local
 from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import topics
+from ovos_bus_client.util.scheduled_events.service import ScheduledEventService
+from ovos_bus_client.util.scheduled_events.store import default_store_path
 
 
 def repeat_time(sched_time: float, repeat: float) -> float:
-    """
-    Next scheduled time for repeating event. Guarantees that the
-    time is not in the past (but could skip interim events)
+    """Next occurrence of a repeating event, anchored on the schedule.
 
     Args:
-        sched_time (float): Scheduled unix time for the event
-        repeat (float):     Repeat period in seconds
+        sched_time: unix time of the occurrence that just passed
+        repeat: period in seconds
 
-    Returns: (float) time for next event
+    Returns: unix time of the next occurrence
     """
-    next_time = sched_time + repeat
-    while next_time < time.time():
-        # Schedule at an offset to assure no doubles
-        next_time = time.time() + abs(repeat)
+    period = abs(repeat)
+    next_time = sched_time + period
+    now = time.time()
+    if next_time < now:
+        # stay on the schedule's own phase rather than re-anchoring on the miss
+        periods = (now - sched_time) // period + 1
+        next_time = sched_time + periods * period
     return next_time
 
 
-class EventScheduler(Thread):
-    """
-    Create an event scheduler thread. Will send messages at a
-    predetermined time to the registered targets.
+class EventScheduler(ScheduledEventService):
+    """The scheduler service, reachable under its historical name.
 
-    Arguments:
-        bus:            Mycroft messagebus client
-        schedule_file:  filename used to store pending events to on
-                        shutdown. File is created in XDG_DATA_HOME
-        autostart: if True, start scheduler on init
+    Args:
+        bus: message bus client
+        schedule_file: store file name, resolved inside the XDG state
+            directory unless an absolute path is given
+        autostart: start the thread on construction
     """
 
-    def __init__(self, bus, schedule_file: str = 'schedule.json', autostart: bool = True):
-        super().__init__()
-
-        self.events = {}
-        self.event_lock = Lock()
-
-        # to check if its our first connection to the internet via clock_skew
-        self._last_sync: datetime.datetime = now_local()
-        self._dropped_events = 0
-        self._past_date = datetime.datetime(day=1, month=12, year=2024, tzinfo=self._last_sync.tzinfo)
-        LOG.debug(f"Boot time clock: {self._last_sync}")
-
-        self.bus = bus
-
-        core_conf = Configuration()
-        data_dir = core_conf.get('data_dir') or get_xdg_data_save_path()
-        old_schedule_path = join(expanduser(data_dir), schedule_file)
-
-        self.schedule_file = join(get_xdg_config_save_path(), schedule_file)
-        if isfile(old_schedule_path):
-            shutil.move(old_schedule_path, self.schedule_file)
-
-        if self.schedule_file:
-            self.load()
-
-        self.bus.on('mycroft.scheduler.schedule_event', self.handle_schedule_event)
-        self.bus.on('mycroft.scheduler.remove_event', self.handle_remove_event)
-        self.bus.on('mycroft.scheduler.update_event', self.handle_update_event)
-        self.bus.on('mycroft.scheduler.get_event', self.handle_get_event)
-        self.bus.on('mycroft.scheduler.list_events', self.handle_list_events)
-        self.bus.on('system.clock.synced', self.handle_system_clock_sync)  # emitted by raspOVOS
-
-        self._running = Event()
-        self._stopping = Event()
-        if autostart:
-            self.start()
-            self._running.wait(10)
-        else:
-            # Explicitly define event states
-            self._stopping.set()
-            self._running.clear()
+    def __init__(self, bus, schedule_file: str = "schedule.json",
+                 autostart: bool = True):
+        store = schedule_file if os.path.isabs(schedule_file) \
+            else default_store_path(schedule_file)
+        super().__init__(bus, store_path=store, autostart=autostart)
 
     @property
-    def is_running(self) -> bool:
-        """
-        Return True while scheduler is running
-        """
-        return not self._stopping.is_set()
-
-    @is_running.setter
-    def is_running(self, value: bool):
-        if value is True:
-            self._stopping.clear()
-        elif value is False:
-            self._stopping.set()
-
-    def load(self):
-        """
-        Load json data with active events from json file.
-        """
-        if isfile(self.schedule_file):
-            json_data = {}
-            with open(self.schedule_file) as schedule_file:
-                try:
-                    json_data = json.load(schedule_file)
-                except Exception as exc:
-                    LOG.error(exc)
-            current_time = time.time()
-            with self.event_lock:
-                for key in json_data:
-                    event_list = json_data[key]
-                    # discard non repeating events that has already happened
-                    self.events[key] = [tuple(evt) for evt in event_list
-                                        if evt[0] > current_time or evt[1]]
-
-    def run(self):
-        """
-        Check events periodically until stopped
-        """
-        LOG.info("EventScheduler Started")
-        self._stopping.clear()
-        self._running.set()
-        while not self._stopping.wait(0.5):
-            try:
-                self.check_state()
-            except Exception as e:
-                LOG.exception(e)
-        LOG.info("EventScheduler Stopped")
-
-    def check_state(self):
-        """
-        Check if any event should be triggered.
-        """
-        with self.event_lock:
-            # Check all events
-            pending_messages = []
-            for event in self.events:
-                current_time = time.time()
-                e = self.events[event]
-                # Get scheduled times that has passed
-                passed = ((t, r, d, c) for
-                          (t, r, d, c) in e if t <= current_time)
-                # and remaining times that we're still waiting for
-                remaining = [(t, r, d, c) for
-                             t, r, d, c in e if t > current_time]
-                # Trigger registered methods
-                for sched_time, repeat, data, context in passed:
-                    pending_messages.append(Message(event, data, context))
-                    # if this is a repeated event add a new trigger time
-                    if repeat:
-                        next_time = repeat_time(sched_time, repeat)
-                        remaining.append((next_time, repeat, data, context))
-                # update list of events
-                self.events[event] = remaining
-
-        # Remove events that are now completed
-        self.clear_empty()
-
-        # Finally, emit the queued up events that triggered
-        for msg in pending_messages:
-            LOG.debug(f"Call scheduled event: {msg.msg_type}")
-            self.bus.emit(msg)
+    def schedule_file(self) -> str:
+        return self.store_path
 
     def schedule_event(self, event: str, sched_time: float,
                        repeat: Optional[float] = None,
                        data: Optional[dict] = None,
                        context: Optional[dict] = None):
-        """
-        Add event to pending event schedule.
+        """Add an event to the schedule using the epoch-float API.
 
-        Arguments:
-            event (str): Handler for the event
-            sched_time (float): epoch time of event
-            repeat ([type], optional): Defaults to None. [description]
-            data ([type], optional): Defaults to None. [description]
-            context (dict, optional): context (dict, optional): message
-                                      context to send when the
-                                      handler is called
+        ``context`` is accepted and ignored: a fired event carries a fresh
+        context of its own.
         """
-        if self._last_sync < self._past_date:
-            # this works around problems in raspOVOS images and other
-            # systems without RTC that didnt sync clock with the internet yet
-            # eg. issue demonstration without this:
-            #   date time skill schedulling the hour change sound N times (+1hour every time until present)
-            LOG.error("Refusing to schedule event, system clock is in the past!")
-            self._dropped_events += 1
-            return
-        
-        data = data or {}
-        with self.event_lock:
-            # get current list of scheduled times for event, [] if missing
-            event_list = self.events.get(event, [])
-
-            # Don't schedule if the event is repeating and already scheduled
-            if repeat and event in self.events:
-                LOG.debug(f'Repeating event {event} is already scheduled, '
-                          f'discarding')
-            else:
-                LOG.debug(f"Scheduled event: {event} for time {sched_time}")
-                # add received event and time
-                event_list.append((sched_time, repeat, data, context))
-                self.events[event] = event_list
-                if sched_time < time.time():
-                    LOG.warning(f"Added event is scheduled in the past and "
-                                f"will be called immediately: {event}")
-
-    def handle_schedule_event(self, message: Message):
-        """
-        Messagebus interface to the schedule_event method.
-        Required data in the message envelope is
-            event: event to emit
-            time:  time to emit the event
-
-        Optional data is
-            repeat: repeat interval
-            data:   data to send along with the event
-        """
-        event = message.data.get('event')
-        sched_time = message.data.get('time')
-        repeat = message.data.get('repeat')
-        data = message.data.get('data')
-        context = message.context
-        if event and sched_time:
-            self.schedule_event(event, sched_time, repeat, data, context)
-        elif not event:
-            LOG.error('Scheduled event msg_type not provided')
-        else:
-            LOG.error('Scheduled event time not provided')
+        self.legacy.handle_schedule(
+            Message(topics.LEGACY_SCHEDULE,
+                    {"event": event, "time": sched_time, "repeat": repeat,
+                     "data": data}))
 
     def remove_event(self, event: str):
-        """
-        Remove an event from the list of scheduled events.
-
-        Arguments:
-            event (str): event identifier
-        """
-        with self.event_lock:
-            if event in self.events:
-                self.events.pop(event)
-
-    def handle_system_clock_sync(self, message: Message):
-        # clock sync, are we in the past?
-        if self._last_sync < self._past_date:
-            LOG.warning(f"Clock was in the past!!! {self._dropped_events} scheduled events have been dropped")
-        self._last_sync = now_local()
-        LOG.info(f"clock sync: {self._last_sync}")
-
-    def handle_remove_event(self, message: Message):
-        """
-        Messagebus interface to the remove_event method.
-        """
-        event = message.data.get('event')
-        self.remove_event(event)
+        """Remove an event from the schedule."""
+        self.legacy.handle_remove(
+            Message(topics.LEGACY_REMOVE, {"event": event}))
 
     def update_event(self, event: str, data: dict):
-        """
-        Change an existing event's data.
+        """Change the data an existing event fires with."""
+        self.legacy.handle_update(
+            Message(topics.LEGACY_UPDATE, {"event": event, "data": data}))
 
-        This will only update the first call if multiple calls are registered
-        to the same event identifier.
-
-        Arguments:
-            event (str): event identifier
-            data (dict): new data
-        """
-        with self.event_lock:
-            # if there is an active event with this name
-            if len(self.events.get(event, [])) > 0:
-                event_time, repeat, _, context = self.events[event][0]
-                self.events[event][0] = (event_time, repeat, data, context)
-
-    def handle_update_event(self, message: Message):
-        """
-        Messagebus interface to the update_event method.
-        """
-        event = message.data.get('event')
-        data = message.data.get('data')
-        self.update_event(event, data)
-
-    def handle_list_events(self, message: Message):
-        """
-        Messagebus interface to the list_events method.
-        """
-        with self.event_lock:
-            events_snapshot = dict(self.events)
-        self.bus.emit(message.response(data={"scheduled_events": events_snapshot}))
-
-    def handle_get_event(self, message: Message):
-        """
-        Messagebus interface to get_event.
-
-        Emits another event sending event status.
-        """
-        event_name = message.data.get("name")
-        event = None
-        with self.event_lock:
-            if event_name in self.events:
-                event = self.events[event_name]
-        emitter_name = f'mycroft.event_status.callback.{event_name}'
-        self.bus.emit(message.reply(emitter_name, data=event))
+    def check_state(self):
+        """Fire every occurrence that is due."""
+        self._evaluate()
 
     def store(self):
-        """
-        Write current schedule to disk.
-        """
-        with self.event_lock:
-            with open(self.schedule_file, 'w') as schedule_file:
-                json.dump(self.events, schedule_file)
-
-    def clear_repeating(self):
-        """
-        Remove repeating events from events dict.
-        """
-        with self.event_lock:
-            for evt in self.events:
-                self.events[evt] = [tup for tup in self.events[evt]
-                                    if tup[1] is None]
-
-    def clear_empty(self):
-        """
-        Remove empty event entries from events dict.
-        """
-        with self.event_lock:
-            self.events = {k: self.events[k] for k in self.events
-                           if self.events[k] != []}
-
-    def shutdown(self):
-        """
-        Stop the running thread.
-        """
-        try:
-            self._stopping.set()
-            # Remove listeners
-            self.bus.remove_all_listeners('mycroft.scheduler.get_event')
-            self.bus.remove_all_listeners('mycroft.scheduler.list_events')
-            self.bus.remove_all_listeners('mycroft.scheduler.remove_event')
-            self.bus.remove_all_listeners('mycroft.scheduler.schedule_event')
-            self.bus.remove_all_listeners('mycroft.scheduler.update_event')
-            self.bus.remove_all_listeners('system.clock.synced')
-            # Wait for thread to finish
-            self.join(30)
-            # Prune event list in preparation for saving
-            self.clear_repeating()
-            self.clear_empty()
-            # Store all pending scheduled events
-            self.store()
-            self._running.clear()
-        except Exception as e:
-            self._running.clear()
-            if not isinstance(e, OSError):
-                self.store()
-            raise e
+        """Write the schedule to disk."""
+        self._persist()

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -1,144 +1,114 @@
-"""
-Test cases regarding the event scheduler.
-"""
+"""The scheduler under its historical name, ``EventScheduler``.
 
-import unittest
+These exercise the epoch-float API and the ``mycroft.scheduler.*`` topics the
+rest of the stack still speaks.
+"""
+import os
+import tempfile
 import time
+import unittest
 
-try:
-    from pyee import ExecutorEventEmitter
-except (ImportError, ModuleNotFoundError):
-    from pyee.executor import ExecutorEventEmitter
-
-
-from unittest.mock import MagicMock, patch
 from ovos_utils.fakebus import FakeBus
-from ovos_bus_client.util.scheduler import EventScheduler
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import topics
+from ovos_bus_client.util.scheduler import EventScheduler, repeat_time
+
+
+class TestRepeatTime(unittest.TestCase):
+    def test_next_occurrence_is_in_the_future(self):
+        past = time.time() - 100
+        self.assertGreaterEqual(repeat_time(past, 30), time.time())
+
+    def test_a_missed_period_keeps_the_schedule_phase(self):
+        start = time.time() - 95
+        self.assertAlmostEqual((repeat_time(start, 30) - start) % 30, 0, places=3)
+
+    def test_a_negative_period_is_read_as_its_magnitude(self):
+        self.assertGreaterEqual(repeat_time(time.time(), -30), time.time())
 
 
 class TestEventScheduler(unittest.TestCase):
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_create(self, mock_open, mock_json_dump, mock_load, mock_thread):
-        """
-        Test creating and shutting down event_scheduler.
-        """
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
-        es.shutdown()
-        self.assertEqual(mock_json_dump.call_args[0][0], {})
+    def setUp(self):
+        self.bus = FakeBus()
+        self.emitted = []
+        self.bus.on("message", self._record)
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.scheduler = EventScheduler(self.bus, self.store, autostart=False)
 
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_add_remove(self, mock_open, mock_json_dump, mock_load, mock_thread):
-        """
-        Test add an event and then remove it.
-        """
-        # Thread start is mocked so will not actually run the thread loop
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
+    def tearDown(self):
+        self.scheduler.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
 
-        # 900000000000 should be in the future for a long time
-        es.schedule_event("test", 90000000000, None)
-        es.schedule_event("test-2", 90000000000, None)
+    def _record(self, message):
+        if isinstance(message, str):
+            message = Message.deserialize(message)
+        self.emitted.append(message)
 
-        es.check_state()  # run one cycle
-        self.assertTrue("test" in es.events)
-        self.assertTrue("test-2" in es.events)
+    def test_an_absolute_path_is_used_as_the_store(self):
+        self.assertEqual(self.scheduler.schedule_file, self.store)
+        self.assertFalse(self.scheduler.is_running)
 
-        es.remove_event("test")
-        es.check_state()  # run one cycle
-        self.assertTrue("test" not in es.events)
-        self.assertTrue("test-2" in es.events)
-        es.shutdown()
+    def test_add_and_remove(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        self.scheduler.schedule_event("skill:test-2", time.time() + 3600)
+        self.assertIn(("skill", "skill:test"), self.scheduler.schedules)
 
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_save(self, mock_open, mock_dump, mock_load, mock_thread):
-        """
-        Test save functionality.
-        """
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
+        self.scheduler.remove_event("skill:test")
+        self.assertNotIn(("skill", "skill:test"), self.scheduler.schedules)
+        self.assertIn(("skill", "skill:test-2"), self.scheduler.schedules)
 
-        # 900000000000 should be in the future for a long time
-        es.schedule_event("test", 900000000000, None)
-        es.schedule_event("test-repeat", 910000000000, 60)
-        es.check_state()
+    def test_a_due_event_is_emitted_with_its_data(self):
+        self.scheduler.schedule_event("skill:test", time.time(), data={"a": 1})
+        self.scheduler.check_state()
+        fired = [m for m in self.emitted if m.msg_type == "skill:test"]
+        self.assertEqual(len(fired), 1)
+        self.assertEqual(fired[0].data, {"a": 1})
 
-        es.shutdown()
+    def test_a_one_shot_is_dropped_once_it_has_fired(self):
+        self.scheduler.schedule_event("skill:test", time.time())
+        self.scheduler.check_state()
+        self.assertEqual(self.scheduler.schedules, {})
 
-        # Make sure the dump method wasn't called with test-repeat
-        self.assertEqual(mock_dump.call_args[0][0], {"test": [(900000000000, None, {}, None)]})
+    def test_scheduling_the_same_name_twice_does_not_duplicate(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        self.scheduler.schedule_event("skill:test", time.time() + 7200)
+        self.assertEqual(len(self.scheduler.schedules), 1)
 
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_send_event(self, mock_open, mock_dump, mock_load, mock_thread):
-        """
-        Test save functionality.
-        """
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
+    def test_repeating_events_survive_a_restart(self):
+        self.scheduler.schedule_event("skill:tick", time.time() + 3600, repeat=60)
+        self.scheduler.shutdown()
 
-        # 0 should be in the future for a long time
-        es.schedule_event("test", time.time(), None)
+        revived = EventScheduler(self.bus, self.store, autostart=False)
+        self.addCleanup(revived.shutdown)
+        self.assertIn(("skill", "skill:tick"), revived.schedules)
 
-        es.check_state()
-        self.assertEqual(emitter.emit.call_args[0][0].msg_type, "test")
-        self.assertEqual(emitter.emit.call_args[0][0].data, {})
-        es.shutdown()
+    def test_update_event_changes_the_data(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600,
+                                      data={"a": 1})
+        self.scheduler.update_event("skill:test", {"a": 2})
+        self.assertEqual(
+            self.scheduler.schedules["skill", "skill:test"].record["data"],
+            {"a": 2})
 
-    @patch("threading.Thread")
-    @patch("json.load")
-    @patch("json.dump")
-    @patch("builtins.open")
-    def test_list_events_handler(self, mock_open, mock_dump, mock_load, mock_thread):
-        """
-        Test list_events_handler returns all scheduled events.
-        """
-        mock_load.return_value = ""
-        mock_open.return_value = MagicMock()
-        emitter = MagicMock()
-        es = EventScheduler(emitter)
+    def test_list_events_answers_with_every_schedule(self):
+        self.scheduler.schedule_event("skill:one", time.time() + 36000)
+        self.scheduler.schedule_event("skill:two", time.time() + 7200, repeat=60)
+        self.scheduler.legacy.handle_list(
+            Message(topics.LEGACY_LIST, {},
+                    {"source": ["a"], "destination": ["b"]}))
+        answers = [m for m in self.emitted if "scheduled_events" in m.data]
+        self.assertEqual(set(answers[-1].data["scheduled_events"]),
+                         {"skill:one", "skill:two"})
 
-        # Schedule a couple of events
-        es.schedule_event("test-event-1", 900000000000, None, {"data": "test1"})
-        es.schedule_event("test-event-2", 910000000000, 60, {"data": "test2"})
+    def test_the_store_is_written_on_every_mutation(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        self.assertTrue(os.path.isfile(self.store))
 
-        # Create a mock message
-        mock_message = MagicMock()
-        mock_message.context = {"source": "test"}
 
-        # Call the handler
-        es.handle_list_events(mock_message)
-
-        # Verify message.reply was called with correct msg_type and data
-        mock_message.response.assert_called_once()
-        call_args = mock_message.response.call_args
-        self.assertIn("scheduled_events", call_args[1]["data"])
-
-        # Verify emitter.emit was called with the reply message
-        emitter.emit.assert_called()
-
-        # Verify the scheduled events contain our test events
-        scheduled_events = call_args[1]["data"]["scheduled_events"]
-        self.assertIn("test-event-1", scheduled_events)
-        self.assertIn("test-event-2", scheduled_events)
-
-        es.shutdown()
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_events_api.py
+++ b/test/unittests/test_events_api.py
@@ -135,9 +135,8 @@ class TestUpdateAndCancel(TestCase):
     def test_get_scheduled_event_status_returns_seconds_left(self):
         future = int((datetime.now() + timedelta(seconds=90)).timestamp())
         self.bus.wait_for_response.return_value = Message(
-            "callback", {0: [future]},
+            "callback", {"event": "my.skill:t", "schedule": [future, None, {}, {}]},
         )
-        # response.data[0][0] — confusingly indexed but matches source
         left = self.api.get_scheduled_event_status("t")
         self.assertGreater(left, 60)
 

--- a/test/unittests/test_scheduler_client.py
+++ b/test/unittests/test_scheduler_client.py
@@ -1,0 +1,444 @@
+"""The scheduler client, talking to a real scheduler over an in-memory bus."""
+import os
+import tempfile
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import TestCase
+
+from ovos_utils.fakebus import FakeBus
+
+from ovos_bus_client.apis.events import EventSchedulerInterface
+from ovos_bus_client.message import Message
+from ovos_bus_client.apis.scheduler import SchedulerClient, SchedulerError
+from ovos_bus_client.util.scheduled_events import ScheduledEventService, topics
+
+
+def _fired(event: str) -> Message:
+    """A message shaped like one the scheduler fires."""
+    return Message(event, {}, {"scheduler": {"id": "x"}})
+
+
+class ClientTestCase(TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.service = ScheduledEventService(self.bus, store_path=self.store,
+                                             autostart=False)
+        self.client = self.make_client("skill.a")
+
+    def tearDown(self):
+        self.service.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
+
+    def make_client(self, skill_id):
+        return SchedulerClient(bus=self.bus, skill_id=skill_id)
+
+    def in_an_hour(self):
+        return datetime.now(timezone.utc) + timedelta(hours=1)
+
+    def just_now(self):
+        """An instant already due, so the next evaluation fires it."""
+        return datetime.now(timezone.utc) - timedelta(seconds=1)
+
+
+class TestSchedulingAndReading(ClientTestCase):
+    def test_schedule_returns_an_id_and_get_reads_it_back(self):
+        schedule_id = self.client.schedule("ring", at=self.in_an_hour(),
+                                           data={"k": 1})
+        record = self.client.get(schedule_id)["record"]
+        self.assertEqual(record["event"], "skill.a.ring")
+        self.assertEqual(record["data"], {"k": 1})
+
+    def test_get_returns_nothing_for_an_unknown_id(self):
+        self.assertIsNone(self.client.get("never-scheduled"))
+
+    def test_the_default_id_comes_from_the_event_name_alone(self):
+        now = datetime.now(timezone.utc)
+        ids = {self.client.schedule("ring", at=now + timedelta(hours=n))
+               for n in range(1, 6)}
+        # five calls for one event leave one schedule, whatever the timing
+        self.assertEqual(ids, {"ring"})
+        self.assertEqual(len(self.client.list()), 1)
+
+    def test_the_default_id_does_not_depend_on_the_handler(self):
+        when = self.in_an_hour()
+        first = self.client.schedule("ring", handler=lambda m: None, at=when)
+        second = self.client.schedule("ring", handler=lambda m: None, at=when)
+        self.assertEqual(first, second)
+
+    def test_an_explicit_id_keeps_several_schedules_for_one_event(self):
+        now = datetime.now(timezone.utc)
+        self.client.schedule("ring", at=now + timedelta(hours=1), schedule_id="a")
+        self.client.schedule("ring", at=now + timedelta(hours=2), schedule_id="b")
+        self.assertEqual({s["record"]["id"] for s in self.client.list()},
+                         {"a", "b"})
+
+    def test_a_changed_recurrence_replaces_rather_than_orphans(self):
+        self.client.schedule("sync", every={"seconds": 600})
+        self.client.schedule("sync", every={"seconds": 60})
+        records = [s["record"] for s in self.client.list()]
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["every"]["seconds"], 60)
+
+    def test_a_wall_clock_rule_is_accepted(self):
+        schedule_id = self.client.schedule(
+            "wake", local={"time": "07:30", "zone": "Europe/Lisbon",
+                           "days": ["mon", "fri"]})
+        self.assertIsNotNone(self.client.get(schedule_id)["state"]["next"])
+
+    def test_a_relative_delay_is_accepted(self):
+        schedule_id = self.client.schedule("ring", in_seconds=300)
+        self.assertEqual(self.client.get(schedule_id)["record"]["in"],
+                         {"seconds": 300})
+
+    def test_list_shows_only_this_components_schedules(self):
+        when = self.in_an_hour()
+        self.client.schedule("ring", at=when)
+        self.make_client("skill.b").schedule("ring", at=when)
+        self.assertEqual([s["record"]["owner"] for s in self.client.list()],
+                         ["skill.a"])
+
+
+class TestNamedOptions(ClientTestCase):
+    """misfire, grace_s and ephemeral are parameters, not loose keywords."""
+
+    def test_the_policies_reach_the_record(self):
+        schedule_id = self.client.schedule("ring", at=self.in_an_hour(),
+                                           misfire="skip", grace_s=5,
+                                           ephemeral=True)
+        record = self.client.get(schedule_id)["record"]
+        self.assertEqual(record["misfire"], "skip")
+        self.assertEqual(record["grace_s"], 5)
+        self.assertTrue(record["ephemeral"])
+
+    def test_the_defaults_are_the_specifications_own(self):
+        record = self.client.get(
+            self.client.schedule("ring", at=self.in_an_hour()))["record"]
+        self.assertEqual(record["misfire"], "late")
+        self.assertEqual(record["grace_s"], 60)
+        self.assertFalse(record["ephemeral"])
+
+    def test_a_recurrence_can_be_bounded_by_count_and_until(self):
+        schedule_id = self.client.schedule("tick", every={"seconds": 60},
+                                           count=3, until=self.in_an_hour())
+        record = self.client.get(schedule_id)["record"]
+        self.assertEqual(record["count"], 3)
+        self.assertIsNotNone(record["until"])
+
+    def test_an_unknown_option_is_a_type_error_rather_than_a_wire_field(self):
+        with self.assertRaises(TypeError):
+            self.client.schedule("ring", at=self.in_an_hour(), nonsense=True)
+
+
+class TestTimeZones(ClientTestCase):
+    def test_a_naive_datetime_is_refused_without_a_zone(self):
+        with self.assertRaises(ValueError):
+            self.client.schedule("ring", at=datetime.now() + timedelta(hours=1))
+
+    def test_a_naive_datetime_is_accepted_with_an_explicit_zone(self):
+        schedule_id = self.client.schedule(
+            "ring", zone="Europe/Lisbon", at=datetime.now() + timedelta(hours=1))
+        self.assertIsNotNone(self.client.get(schedule_id))
+
+    def test_something_that_is_not_a_datetime_is_a_type_error(self):
+        with self.assertRaises(TypeError):
+            self.client.schedule("ring", at="in an hour")
+
+    def test_exactly_one_timing_is_required(self):
+        with self.assertRaises(ValueError):
+            self.client.schedule("ring")
+        with self.assertRaises(ValueError):
+            self.client.schedule("ring", at=self.in_an_hour(), in_seconds=5)
+
+
+class TestHandlerOwnership(ClientTestCase):
+    """The client owns the subscription it makes for a schedule (§8)."""
+
+    def test_the_handler_is_registered_before_the_request_goes_out(self):
+        seen = []
+        self.client.schedule("ring", handler=seen.append,
+                             at=datetime.now(timezone.utc) - timedelta(seconds=1))
+        self.service._evaluate()
+        self.assertEqual(len(seen), 1)
+
+    def test_rescheduling_replaces_the_handler_instead_of_stacking_one(self):
+        first, second = [], []
+        self.client.schedule("tick", handler=first.append,
+                             every={"seconds": 10})
+        self.client.schedule("tick", handler=second.append,
+                             every={"seconds": 10})
+        self.bus.emit(_fired("skill.a.tick"))
+        self.assertEqual(len(first), 0)
+        self.assertEqual(len(second), 1)
+
+    def test_cancel_removes_the_handler_schedule_registered(self):
+        seen = []
+        schedule_id = self.client.schedule("ring", handler=seen.append,
+                                           at=self.in_an_hour())
+        self.client.cancel(schedule_id)
+        self.bus.emit(_fired("skill.a.ring"))
+        self.assertEqual(seen, [])
+
+    def test_cancel_reports_whether_the_schedule_existed(self):
+        schedule_id = self.client.schedule("ring", at=self.in_an_hour())
+        self.assertTrue(self.client.cancel(schedule_id))
+        self.assertFalse(self.client.cancel(schedule_id))
+
+    def test_a_schedule_without_a_handler_leaves_the_previous_one_alone(self):
+        seen = []
+        self.client.schedule("tick", handler=seen.append, every={"seconds": 10})
+        self.client.schedule("tick", every={"seconds": 10})
+        self.bus.emit(_fired("skill.a.tick"))
+        self.assertEqual(len(seen), 1)
+
+
+class TestRequestContext(ClientTestCase):
+    def test_the_callers_message_is_not_stamped_in_place(self):
+        # skill_id is what the scheduler reads as the caller's identity, so
+        # leaving ours on the handler's own message would hand it to every
+        # message that handler forwards afterwards
+        contexts = []
+
+        def handler(message):
+            self.client.schedule("ring", at=self.in_an_hour())
+            contexts.append(dict(message.context))
+
+        self.bus.on("some.request", handler)
+        self.bus.emit(Message("some.request", {}, {"source": ["cli"]}))
+        self.assertNotIn("skill_id", contexts[-1])
+
+    def test_the_request_still_carries_the_owners_identity(self):
+        seen = []
+        self.bus.on(topics.SCHEDULER_SCHEDULE, seen.append)
+        self.client.schedule("ring", at=self.in_an_hour())
+        self.assertEqual(seen[-1].context["skill_id"], "skill.a")
+
+
+class TestPresence(ClientTestCase):
+    """Asking whether there is a scheduler before talking to one."""
+
+    def test_a_running_scheduler_is_found(self):
+        self.assertTrue(self.client.is_available())
+
+    def test_no_scheduler_on_the_bus_is_reported_quickly(self):
+        self.service.shutdown()
+        lonely = SchedulerClient(bus=FakeBus(), skill_id="skill.a")
+        started = time.monotonic()
+        self.assertFalse(lonely.is_available(timeout=0.2))
+        self.assertLess(time.monotonic() - started, 2.0)
+
+    def test_the_answer_is_asked_for_once_and_remembered(self):
+        asked = []
+        self.bus.on(topics.SCHEDULER_LIST, lambda m: asked.append(m))
+        self.client.is_available()
+        self.client.is_available()
+        self.assertEqual(len(asked), 1)
+
+
+class TestRescheduling(ClientTestCase):
+    """Changing part of a schedule and leaving the rest of it alone."""
+
+    def test_changing_the_payload_keeps_the_time(self):
+        when = self.in_an_hour()
+        self.client.schedule("ring", at=when, data={"k": 1})
+        self.client.reschedule("ring", data={"k": 2})
+        record = self.client.get("ring")["record"]
+        self.assertEqual(record["data"], {"k": 2})
+        self.assertEqual(record["at"], when.isoformat())
+
+    def test_changing_the_payload_of_a_period_keeps_its_anchor(self):
+        self.client.schedule("tick", every={"seconds": 300}, data={"k": 1})
+        anchor = self.client.get("tick")["record"]["every"]["start"]
+        self.client.reschedule("tick", data={"k": 2})
+        record = self.client.get("tick")["record"]
+        self.assertEqual(record["every"], {"seconds": 300, "start": anchor})
+        self.assertEqual(record["data"], {"k": 2})
+
+    def test_a_delay_keeps_the_instant_it_was_counting_down_to(self):
+        self.client.schedule("ring", in_seconds=3600)
+        upcoming = self.client.get("ring")["state"]["next"]
+        self.client.reschedule("ring", data={"k": 1})
+        # the delay does not start over: what was due in an hour still is
+        self.assertEqual(self.client.get("ring")["record"]["at"], upcoming)
+
+    def test_the_handler_stays_subscribed(self):
+        seen = []
+        self.client.schedule("ring", seen.append, at=self.just_now())
+        self.client.reschedule("ring", data={"k": 1})
+        self.service._evaluate()
+        self.assertEqual([message.data for message in seen], [{"k": 1}])
+
+    def test_a_new_handler_replaces_the_old_one(self):
+        seen = []
+        self.client.schedule("ring", lambda m: seen.append("first"),
+                             at=self.just_now())
+        self.client.reschedule("ring", handler=lambda m: seen.append("second"))
+        self.service._evaluate()
+        self.assertEqual(seen, ["second"])
+
+    def test_a_new_timing_replaces_the_old_one(self):
+        self.client.schedule("ring", at=self.in_an_hour())
+        self.client.reschedule("ring", every={"seconds": 300})
+        record = self.client.get("ring")["record"]
+        self.assertNotIn("at", record)
+        self.assertEqual(record["every"]["seconds"], 300)
+
+    def test_the_bounds_and_policies_are_carried_over(self):
+        self.client.schedule("tick", every={"seconds": 300}, count=5,
+                             until=self.in_an_hour(), misfire="skip",
+                             grace_s=12, ephemeral=True)
+        self.client.reschedule("tick", data={"k": 1})
+        record = self.client.get("tick")["record"]
+        self.assertEqual(record["count"], 5)
+        self.assertEqual(record["misfire"], "skip")
+        self.assertEqual(record["grace_s"], 12)
+        self.assertTrue(record["ephemeral"])
+        self.assertIn("until", record)
+
+    def test_the_event_name_is_carried_over(self):
+        self.client.schedule("ring", at=self.in_an_hour())
+        self.client.reschedule("ring", data={"k": 1})
+        self.assertEqual(self.client.get("ring")["record"]["event"],
+                         "skill.a.ring")
+
+    def test_rescheduling_something_that_is_not_there_is_an_error(self):
+        with self.assertRaises(SchedulerError) as raised:
+            self.client.reschedule("never-scheduled", data={"k": 1})
+        self.assertEqual(raised.exception.error, "not_found")
+
+    def test_another_component_cannot_reschedule_this_one(self):
+        self.client.schedule("ring", at=self.in_an_hour(), data={"k": 1})
+        with self.assertRaises(SchedulerError):
+            self.make_client("skill.b").reschedule("ring", data={"k": 2})
+        self.assertEqual(self.client.get("ring")["record"]["data"], {"k": 1})
+
+
+class TestContextRoundTrip(ClientTestCase):
+    """What a component schedules with is what its handler is called with."""
+
+    def handling(self, context: dict):
+        """A message in flight, as a handler would have one."""
+        return Message("some.request", {}, dict(context))
+
+    def test_the_handler_is_called_with_the_context_of_the_request(self):
+        seen = []
+        given = {"session": {"session_id": "abc", "lang": "pt-pt"},
+                 "source": "audio:0", "destination": ["skill.a"]}
+
+        def schedule_from_a_handler(message):
+            self.client.schedule("ring", seen.append, at=self.just_now())
+
+        schedule_from_a_handler(self.handling(given))
+        self.service._evaluate()
+        for field, value in given.items():
+            self.assertEqual(seen[0].context[field], value)
+        self.assertEqual(seen[0].context["skill_id"], "skill.a")
+        self.assertEqual(seen[0].context["scheduler"]["id"], "ring")
+
+    def test_a_schedule_made_outside_a_handler_carries_only_its_owner(self):
+        seen = []
+        self.client.schedule("ring", seen.append, at=self.just_now())
+        self.service._evaluate()
+        self.assertEqual(set(seen[0].context) - {"session"},
+                         {"skill_id", "scheduler"})
+
+
+class TestGivenContext(ClientTestCase):
+    """A component that says which context an occurrence belongs to."""
+
+    def test_a_given_context_is_what_fires(self):
+        seen = []
+
+        def schedule_from_a_handler(message):
+            self.client.schedule("ring", seen.append, at=self.just_now(),
+                                 context={"mine": True})
+
+        schedule_from_a_handler(Message("some.request", {},
+                                        {"theirs": True}))
+        self.service._evaluate()
+        self.assertTrue(seen[0].context["mine"])
+        self.assertNotIn("theirs", seen[0].context)
+
+    def test_a_given_context_survives_a_restart(self):
+        self.client.schedule("ring", at=self.in_an_hour(),
+                             context={"mine": True})
+        self.assertTrue(
+            self.client.get("ring")["record"]["context"]["mine"])
+
+    def test_rescheduling_keeps_the_context_it_was_created_with(self):
+        self.client.schedule("ring", at=self.in_an_hour(),
+                             context={"mine": True})
+        self.client.reschedule("ring", data={"k": 1})
+        self.assertTrue(
+            self.client.get("ring")["record"]["context"]["mine"])
+
+
+class TestRefusals(ClientTestCase):
+    def test_a_refusal_reaches_the_caller_as_an_error(self):
+        with self.assertRaises(SchedulerError) as caught:
+            self.client.schedule("ring", at=datetime.now(timezone.utc),
+                                 data={"blob": "x" * 20000})
+        self.assertEqual(caught.exception.error, "payload_too_large")
+
+    def test_a_missing_answer_is_surfaced_as_a_timeout(self):
+        self.service.shutdown()
+        with self.assertRaises(SchedulerError) as caught:
+            self.client._request(topics.SCHEDULER_LIST, {}, timeout=0.2)
+        self.assertEqual(caught.exception.error, "timeout")
+
+
+class TestEventSchedulerInterface(ClientTestCase):
+    """The skill-facing interface is the client plus the legacy methods."""
+
+    def make_client(self, skill_id):
+        return EventSchedulerInterface(bus=self.bus, skill_id=skill_id)
+
+    def test_it_speaks_the_specification(self):
+        schedule_id = self.client.schedule("ring", at=self.in_an_hour())
+        self.assertEqual(self.client.get(schedule_id)["record"]["event"],
+                         "skill.a.ring")
+
+    def test_schedule_event_with_a_delta_in_seconds(self):
+        with self.assertWarns(DeprecationWarning):
+            self.client.schedule_event(lambda m: None, when=3600, name="t")
+        self.assertIn(("skill.a", "skill.a:t"), self.service.schedules)
+
+    def test_schedule_event_with_a_datetime(self):
+        with self.assertWarns(DeprecationWarning):
+            self.client.schedule_event(lambda m: None, when=self.in_an_hour(),
+                                       name="t")
+        self.assertIn(("skill.a", "skill.a:t"), self.service.schedules)
+
+    def test_a_repeating_event_becomes_a_recurrence(self):
+        with self.assertWarns(DeprecationWarning):
+            self.client.schedule_repeating_event(lambda m: None, when=None,
+                                                 interval=60, name="tick")
+        record = self.service.schedules["skill.a", "skill.a:tick"].record
+        self.assertEqual(record["every"]["seconds"], 60)
+
+    def test_cancel_scheduled_event_removes_the_schedule(self):
+        with self.assertWarns(DeprecationWarning):
+            self.client.schedule_event(lambda m: None, when=3600, name="t")
+            self.client.cancel_scheduled_event("t")
+        self.assertEqual(self.service.schedules, {})
+
+    def test_get_scheduled_event_status_returns_the_seconds_left(self):
+        with self.assertWarns(DeprecationWarning):
+            self.client.schedule_event(lambda m: None, when=3600, name="t")
+            self.assertGreater(self.client.get_scheduled_event_status("t"), 3500)
+
+    def test_a_scheduled_handler_still_runs_on_its_event(self):
+        seen = []
+        with self.assertWarns(DeprecationWarning):
+            self.client.schedule_event(seen.append, when=0, name="t")
+        self.service._evaluate()
+        self.assertEqual(len(seen), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_scheduler_conformance.py
+++ b/test/unittests/test_scheduler_conformance.py
@@ -1,0 +1,1305 @@
+"""SCHEDULER-1 conformance: one test per MUST of §9, plus the edges around
+them that a scheduler gets wrong in production rather than in a spec.
+"""
+import json
+from glob import glob
+import os
+import tempfile
+import time
+import unittest
+from threading import Event, Thread
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from ovos_utils.fakebus import FakeBus
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import (
+    LEGACY_REMOVAL_VERSION, MAX_DATA_BYTES, MAX_REPORTED, Schedule,
+    ScheduledEventService, format_instant, topics, validate_record)
+
+
+def iso(when: datetime) -> str:
+    return when.isoformat()
+
+
+class Recorder:
+    """Captures every message the scheduler emits, in order."""
+
+    def __init__(self, bus):
+        self.messages = []
+        bus.on("message", self._on_message)
+
+    def _on_message(self, message):
+        if isinstance(message, str):
+            message = Message.deserialize(message)
+        self.messages.append(message)
+
+    def types(self):
+        return [message.msg_type for message in self.messages]
+
+    def of(self, msg_type):
+        return [m for m in self.messages if m.msg_type == msg_type]
+
+    def last(self, msg_type):
+        found = self.of(msg_type)
+        return found[-1] if found else None
+
+
+class SchedulerTestCase(unittest.TestCase):
+    """A scheduler with a store of its own and every message it emits kept."""
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.recorder = Recorder(self.bus)
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.service = ScheduledEventService(self.bus, store_path=self.store,
+                                             autostart=False)
+
+    def tearDown(self):
+        self.service.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
+
+    def request(self, topic, data, context=None):
+        """Deliver a request to the scheduler and return its answer."""
+        self.bus.emit(Message(topic, data, context or {}))
+        return self.recorder.last(f"{topic}.response")
+
+    def schedule(self, request_context=None, **data):
+        data.setdefault("owner", "skill.a")
+        data.setdefault("id", "one")
+        data.setdefault("event", "skill.a.ring")
+        return self.request(topics.SCHEDULER_SCHEDULE, data, request_context)
+
+    def new_scheduler(self):
+        """A second scheduler over the same store, as a restart would be."""
+        revived = ScheduledEventService(self.bus, store_path=self.store,
+                                        autostart=False)
+        self.addCleanup(revived.shutdown)
+        return revived
+
+    def store_content(self):
+        with open(self.store) as handle:
+            return json.load(handle)
+
+
+class TestValidationAndAnswers(SchedulerTestCase):
+    """§9.1 — validate every field and answer every request exactly once."""
+
+    def test_every_request_is_answered_once(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        self.assertEqual(
+            len(self.recorder.of(topics.SCHEDULER_SCHEDULE_RESPONSE)), 1)
+        self.request(topics.SCHEDULER_GET, {"owner": "skill.a", "id": "one"})
+        self.assertEqual(len(self.recorder.of(topics.SCHEDULER_GET_RESPONSE)), 1)
+
+    def test_naive_instant_is_rejected(self):
+        answer = self.schedule(at="2031-03-29T07:30:00")
+        self.assertFalse(answer.data["ok"])
+        self.assertEqual(answer.data["error"], "bad_instant")
+
+    def test_two_timing_fields_are_rejected(self):
+        answer = self.schedule(at=iso(datetime.now(timezone.utc)),
+                               every={"seconds": 10})
+        self.assertEqual(answer.data["error"], "invalid_record")
+
+    def test_missing_timing_is_rejected(self):
+        self.assertEqual(self.schedule().data["error"], "invalid_record")
+
+    def test_an_event_with_a_colon_in_the_name_is_rejected(self):
+        answer = self.schedule(event="skill.a.ring:now",
+                               at=iso(datetime.now(timezone.utc)))
+        self.assertEqual(answer.data["error"], "bad_event")
+
+    def test_an_event_that_is_only_the_owner_is_rejected(self):
+        answer = self.schedule(event="skill.a.",
+                               at=iso(datetime.now(timezone.utc)))
+        self.assertEqual(answer.data["error"], "bad_event")
+
+    def test_a_malformed_recurrence_is_rejected(self):
+        self.assertEqual(self.schedule(every={"seconds": 0}).data["error"],
+                         "bad_recurrence")
+        self.assertEqual(
+            self.schedule(local={"time": "07:30",
+                                 "zone": "Mars/Olympus"}).data["error"],
+            "bad_recurrence")
+
+    def test_a_payload_over_the_cap_is_rejected(self):
+        answer = self.schedule(
+            at=iso(datetime.now(timezone.utc) + timedelta(hours=1)),
+            data={"blob": "x" * (MAX_DATA_BYTES + 100)})
+        self.assertEqual(answer.data["error"], "payload_too_large")
+
+    def test_until_with_a_one_shot_is_rejected(self):
+        answer = self.schedule(at=iso(datetime.now(timezone.utc)),
+                               until=iso(datetime.now(timezone.utc)))
+        self.assertEqual(answer.data["error"], "invalid_record")
+
+    def test_a_recurrence_bounded_before_its_first_occurrence_is_rejected(self):
+        start = datetime.now(timezone.utc) + timedelta(hours=2)
+        answer = self.schedule(id="tick", event="skill.a.tick",
+                               until=iso(start - timedelta(hours=1)),
+                               every={"seconds": 600, "start": iso(start)})
+        self.assertEqual(answer.data["error"], "bad_recurrence")
+        # nothing retires a schedule that never fires, so it must not be stored
+        self.assertEqual(self.service.schedules, {})
+        self.assertFalse(os.path.isfile(self.store))
+
+    def test_a_wall_clock_rule_bounded_in_the_past_is_rejected(self):
+        answer = self.schedule(
+            id="wake", event="skill.a.wake",
+            until=iso(datetime.now(timezone.utc) - timedelta(days=1)),
+            local={"time": "07:30", "zone": "Europe/Lisbon"})
+        self.assertEqual(answer.data["error"], "bad_recurrence")
+        self.assertEqual(self.service.schedules, {})
+
+    def test_a_recurrence_bounded_after_its_first_occurrence_is_accepted(self):
+        start = datetime.now(timezone.utc) + timedelta(hours=1)
+        answer = self.schedule(id="tick", event="skill.a.tick",
+                               until=iso(start + timedelta(hours=1)),
+                               every={"seconds": 600, "start": iso(start)})
+        self.assertTrue(answer.data["ok"])
+
+    def test_cancelling_an_absent_schedule_is_not_an_error(self):
+        answer = self.request(topics.SCHEDULER_CANCEL,
+                              {"owner": "skill.a", "id": "nope"})
+        self.assertTrue(answer.data["ok"])
+        self.assertFalse(answer.data["existed"])
+
+    def test_round_trip_schedule_get_list_cancel(self):
+        when = datetime.now(timezone.utc) + timedelta(hours=1)
+        created = self.schedule(at=iso(when))
+        self.assertTrue(created.data["ok"])
+        self.assertEqual(created.data["next"], iso(when))
+
+        read = self.request(topics.SCHEDULER_GET,
+                            {"owner": "skill.a", "id": "one"})
+        self.assertEqual(read.data["record"]["event"], "skill.a.ring")
+        self.assertEqual(read.data["state"]["next"], iso(when))
+        self.assertIsNone(read.data["state"]["last_fired"])
+        self.assertEqual(read.data["state"]["missed"], [])
+
+        listed = self.request(topics.SCHEDULER_LIST, {"owner": "skill.a"})
+        self.assertEqual(
+            [s["record"]["id"] for s in listed.data["schedules"]], ["one"])
+
+        cancelled = self.request(topics.SCHEDULER_CANCEL,
+                                 {"owner": "skill.a", "id": "one"})
+        self.assertTrue(cancelled.data["existed"])
+        listed = self.request(topics.SCHEDULER_LIST, {"owner": "skill.a"})
+        self.assertEqual(listed.data["schedules"], [])
+
+
+class TestPersistence(SchedulerTestCase):
+    """§9.2 — persist before answering and before firing on, atomically."""
+
+    def test_the_store_is_written_before_the_answer(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        self.assertEqual(
+            self.store_content()["schedules"][0]["record"]["id"], "one")
+
+    def test_the_due_of_a_fired_occurrence_is_persisted_after_the_event(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self.schedule(id="tick", event="skill.a.tick", grace_s=600,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 1)
+        self.assertEqual(
+            self.store_content()["schedules"][0]["last_fired"], iso(start))
+
+    def test_an_occurrence_at_or_before_the_persisted_due_never_fires_again(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self.schedule(id="tick", event="skill.a.tick", grace_s=600,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        schedule = self.service.schedules["skill.a", "tick"]
+        # a replacement scheduler handed a stale cursor must not replay the fire
+        schedule.cursor = start - timedelta(seconds=60)
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 1)
+
+    def test_a_crash_between_the_temporary_write_and_the_replace_keeps_the_old_state(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        before = open(self.store).read()
+        with patch("os.replace", side_effect=OSError("power loss")):
+            answer = self.schedule(
+                id="two",
+                at=iso(datetime.now(timezone.utc) + timedelta(hours=2)))
+        self.assertEqual(open(self.store).read(), before)
+        self.assertEqual(answer.data["error"], "internal")
+
+    def test_an_unstorable_creation_leaves_no_trace_in_memory(self):
+        with patch("os.replace", side_effect=OSError("read-only")):
+            answer = self.schedule(
+                at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        self.assertEqual(answer.data["error"], "internal")
+        # the running process agrees with the store it would restart from
+        self.assertEqual(self.service.schedules, {})
+
+    def test_an_unstorable_replacement_keeps_the_previous_schedule(self):
+        first = datetime.now(timezone.utc) + timedelta(hours=1)
+        self.schedule(at=iso(first))
+        with patch("os.replace", side_effect=OSError("read-only")):
+            answer = self.schedule(
+                at=iso(datetime.now(timezone.utc) + timedelta(hours=5)))
+        self.assertEqual(answer.data["error"], "internal")
+        self.assertEqual(
+            self.service.schedules["skill.a", "one"].record["at"], iso(first))
+
+    def test_an_unstorable_cancel_keeps_the_schedule(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        with patch("os.replace", side_effect=OSError("read-only")):
+            answer = self.request(topics.SCHEDULER_CANCEL,
+                                  {"owner": "skill.a", "id": "one"})
+        self.assertEqual(answer.data["error"], "internal")
+        self.assertIn(("skill.a", "one"), self.service.schedules)
+        # and it is still cancellable once the store is writable again
+        self.assertTrue(self.request(topics.SCHEDULER_CANCEL,
+                                     {"owner": "skill.a", "id": "one"}
+                                     ).data["existed"])
+
+    def test_an_unstorable_wildcard_cancel_keeps_every_schedule(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        self.schedule(owner="skill.b", event="skill.b.ring", at=when)
+        self.service.admins = ["admin.panel"]
+        with patch("os.replace", side_effect=OSError("read-only")):
+            answer = self.request(topics.SCHEDULER_CANCEL,
+                                  {"owner": "*", "id": "one"},
+                                  context={"skill_id": "admin.panel"})
+        self.assertEqual(answer.data["error"], "internal")
+        self.assertEqual(len(self.service.schedules), 2)
+
+    def test_a_corrupt_store_timestamp_does_not_stop_the_scheduler(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        content = self.store_content()
+        content["written_at"] = "nonsense"
+        with open(self.store, "w") as handle:
+            json.dump(content, handle)
+
+        revived = self.new_scheduler()
+        self.assertIn(("skill.a", "one"), revived.schedules)
+        self.assertTrue(revived.clock_synced)
+
+    def test_a_store_written_by_a_newer_scheduler_is_set_aside_not_read(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        content = self.store_content()
+        newer_version = content["version"] + 1
+        content["version"] = newer_version
+        with open(self.store, "w") as handle:
+            json.dump(content, handle)
+        original = open(self.store, "rb").read()
+
+        revived = self.new_scheduler()
+        self.assertEqual(revived.schedules, {})
+
+        # a downgrade must not cost the schedules the newer scheduler held
+        backup = f"{self.store}.v{newer_version}.bak"
+        self.addCleanup(os.unlink, backup)
+        self.assertEqual(open(backup, "rb").read(), original)
+
+        # and this scheduler writes a store of its own from scratch
+        revived._persist()
+        self.assertEqual(self.store_content()["schedules"], [])
+        self.assertEqual(self.store_content()["version"], newer_version - 1)
+
+    def test_a_store_from_an_older_version_is_read_not_set_aside(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)),
+                      request_context={"mine": True})
+        content = self.store_content()
+        # what an older scheduler wrote: no context field on the record
+        content["version"] = content["version"] - 1
+        for entry in content["schedules"]:
+            entry["record"].pop("context", None)
+        with open(self.store, "w") as handle:
+            json.dump(content, handle)
+
+        revived = self.new_scheduler()
+        restored = revived.schedules["skill.a", "one"]
+        self.assertNotIn("context", restored.record)
+        self.assertFalse(glob(f"{self.store}.v*.bak"))
+
+        # and it fires clean rather than with something invented for it
+        revived.replace_schedule(dict(restored.record,
+                                      at=iso(datetime.now(timezone.utc) -
+                                             timedelta(seconds=1))))
+        revived._evaluate()
+        fired = self.recorder.last("skill.a.ring")
+        self.assertEqual(set(fired.context) - {"session"}, {"scheduler"})
+
+    def test_a_store_that_will_not_parse_is_quarantined_not_overwritten(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        whole = open(self.store, "rb").read()
+        damaged = whole[:len(whole) // 2]
+        with open(self.store, "wb") as handle:
+            handle.write(damaged)
+
+        revived = self.new_scheduler()
+        self.assertEqual(revived.schedules, {})
+
+        quarantined = glob(f"{self.store}.corrupt.*.bak")
+        self.assertEqual(len(quarantined), 1)
+        self.addCleanup(os.unlink, quarantined[0])
+        self.assertEqual(open(quarantined[0], "rb").read(), damaged)
+        self.assertFalse(os.path.exists(self.store))
+
+        # and the scheduler is a working one, writing a store of its own
+        revived.replace_schedule(
+            {"id": "two", "owner": "skill.a", "event": "skill.a.ring",
+             "data": {}, "at": iso(datetime.now(timezone.utc) +
+                                   timedelta(hours=1)),
+             "misfire": "late", "grace_s": 60, "ephemeral": False})
+        self.assertEqual(
+            [entry["record"]["id"] for entry in
+             self.store_content()["schedules"]], ["two"])
+
+    def test_one_fire_is_persisted_before_the_next_is_emitted(self):
+        # a kill anywhere inside a backlog may repeat the occurrence that was
+        # in flight, and nothing earlier
+        start = datetime.now(timezone.utc) - timedelta(seconds=35)
+        self.schedule(id="tick", event="skill.a.tick", misfire="all",
+                      grace_s=0, every={"seconds": 10, "start": iso(start)})
+
+        kill_points = self._store_after_every_fire()
+        self.assertEqual(len(kill_points), 4)
+
+        fired = [due for due, _ in kill_points]
+        for position, (due, state) in enumerate(kill_points):
+            repeated = self._replay_from(state, already_fired=fired[:position + 1])
+            self.assertLessEqual(
+                len(repeated), 1,
+                f"a kill just after the fire for {due} repeated "
+                f"{len(repeated)} already-emitted occurrences")
+
+    def _store_after_every_fire(self):
+        """The store as it stands the instant after each event leaves the bus,
+        which is where a kill can land."""
+        kill_points = []
+        emit_one = self.service._fire
+
+        def watched(schedule, due):
+            emit_one(schedule, due)
+            kill_points.append((format_instant(due), open(self.store).read()))
+
+        self.service._fire = watched
+        self.service._evaluate()
+        return kill_points
+
+    def _replay_from(self, state, already_fired):
+        """Occurrences a fresh scheduler repeats when it starts from ``state``."""
+        with open(self.store, "w") as handle:
+            handle.write(state)
+        bus = FakeBus()
+        recorder = Recorder(bus)
+        revived = ScheduledEventService(bus, store_path=self.store,
+                                        autostart=False)
+        revived.replay()
+        revived.shutdown()
+        return [m for m in recorder.of("skill.a.tick")
+                if m.context["scheduler"]["due"] in set(already_fired)]
+
+    def test_ephemeral_schedules_are_never_persisted(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(id="kept", at=when)
+        self.schedule(id="gone", ephemeral=True, at=when)
+        self.assertEqual(
+            [s["record"]["id"] for s in self.store_content()["schedules"]],
+            ["kept"])
+        self.assertEqual([key[1] for key in self.new_scheduler().schedules],
+                         ["kept"])
+
+
+class TestIdempotency(SchedulerTestCase):
+    """§9.3 — replace on identical identity, never duplicate."""
+
+    def test_rescheduling_the_same_identity_replaces(self):
+        first = datetime.now(timezone.utc) + timedelta(hours=1)
+        second = datetime.now(timezone.utc) + timedelta(hours=2)
+        self.assertFalse(self.schedule(at=iso(first)).data["replaced"])
+        answer = self.schedule(at=iso(second))
+        self.assertTrue(answer.data["replaced"])
+        self.assertEqual(answer.data["next"], iso(second))
+        self.assertEqual(len(self.service.schedules), 1)
+
+    def test_two_owners_may_use_the_same_id(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        self.schedule(owner="skill.b", event="skill.b.ring", at=when)
+        self.assertEqual(len(self.service.schedules), 2)
+
+    def test_an_unchanged_period_keeps_its_anchor(self):
+        start = datetime.now(timezone.utc) + timedelta(seconds=90)
+        self.schedule(id="tick", event="skill.a.tick",
+                      every={"seconds": 600, "start": iso(start)})
+        self.schedule(id="tick", event="skill.a.tick", every={"seconds": 600})
+        self.assertEqual(
+            self.service.schedules["skill.a", "tick"].record["every"]["start"],
+            iso(start))
+
+    def test_a_changed_period_is_re_anchored(self):
+        start = datetime.now(timezone.utc) + timedelta(seconds=90)
+        self.schedule(id="tick", event="skill.a.tick",
+                      every={"seconds": 600, "start": iso(start)})
+        self.schedule(id="tick", event="skill.a.tick", every={"seconds": 60})
+        self.assertNotEqual(
+            self.service.schedules["skill.a", "tick"].record["every"]["start"],
+            iso(start))
+
+
+class TestReplacementKeepsWhatFired(SchedulerTestCase):
+    """§9.2, §9.3 and §9.9 — a replacement is not a way to fire again."""
+
+    def hourly_since(self, hours: int, **fields):
+        start = datetime.now(timezone.utc) - timedelta(hours=hours)
+        request = dict(id="hourly", event="skill.a.hourly", misfire="all",
+                       grace_s=0, every={"seconds": 3600, "start": iso(start)})
+        request.update(fields)
+        return request
+
+    def test_an_identical_request_fires_nothing_further(self):
+        request = self.hourly_since(5)
+        self.schedule(**request)
+        self.service._evaluate()
+        already = [m.context["scheduler"]["due"]
+                   for m in self.recorder.of("skill.a.hourly")]
+        self.assertTrue(already)
+
+        # §5.2: an owner re-creating its schedules on every start sends this
+        # very request again, and sending it twice must be sending it once
+        self.schedule(**request)
+        self.service._evaluate()
+        again = [m.context["scheduler"]["due"]
+                 for m in self.recorder.of("skill.a.hourly")]
+        self.assertEqual(again, already)
+
+    def test_an_identical_request_keeps_what_was_consumed(self):
+        request = self.hourly_since(5, count=10)
+        self.schedule(**request)
+        self.service._evaluate()
+        spent = self.service.schedules["skill.a", "hourly"].consumed
+        self.assertGreater(spent, 0)
+        self.schedule(**request)
+        self.assertEqual(self.service.schedules["skill.a", "hourly"].consumed,
+                         spent)
+
+    def test_an_identical_request_does_not_report_the_past_as_missed(self):
+        request = self.hourly_since(5)
+        self.schedule(**request)
+        self.service._evaluate()
+        self.schedule(**request)
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of(topics.SCHEDULER_MISSED)), 1)
+
+    def test_changing_only_the_payload_keeps_the_count_budget(self):
+        self.schedule(**self.hourly_since(5, count=20))
+        self.service._evaluate()
+        spent = self.service.schedules["skill.a", "hourly"].consumed
+        self.schedule(**self.hourly_since(5, count=20, data={"k": 2}))
+        schedule = self.service.schedules["skill.a", "hourly"]
+        self.assertEqual(schedule.consumed, spent)
+        self.assertEqual(schedule.remaining(), 20 - spent)
+        self.assertEqual(schedule.record["data"], {"k": 2})
+
+    def test_a_new_timing_still_cannot_fire_at_or_before_the_last_fire(self):
+        self.schedule(**self.hourly_since(5))
+        self.service._evaluate()
+        last = self.service.schedules["skill.a", "hourly"].last_fired
+        self.assertIsNotNone(last)
+        # a different series entirely, anchored well before that fire
+        self.schedule(id="hourly", event="skill.a.hourly", misfire="all",
+                      grace_s=0,
+                      every={"seconds": 600,
+                             "start": iso(datetime.now(timezone.utc) -
+                                          timedelta(hours=9))})
+        schedule = self.service.schedules["skill.a", "hourly"]
+        self.assertEqual(schedule.last_fired, last)
+        self.assertGreater(schedule.next_from_now(self.service.now()), last)
+
+    def test_a_replacement_survives_a_restart_with_its_history(self):
+        request = self.hourly_since(5)
+        self.schedule(**request)
+        self.service._evaluate()
+        self.schedule(**request)
+        revived = self.new_scheduler()
+        restored = revived.schedules["skill.a", "hourly"]
+        self.assertEqual(restored.last_fired,
+                         self.service.schedules["skill.a", "hourly"].last_fired)
+
+
+class TestRearmingFromInsideTheHandler(SchedulerTestCase):
+    """§4.3 retires the schedule that fired, not whatever holds its id.
+
+    "When it rings, set the next one" is how an owner builds a chain of
+    one-shots, and the replacement it makes is younger than the fire that is
+    still being processed.
+    """
+
+    def overdue(self) -> str:
+        return iso(datetime.now(timezone.utc) - timedelta(seconds=1))
+
+    def arm(self, **fields):
+        request = dict(id="alarm", event="skill.a.alarm", at=self.overdue())
+        request.update(fields)
+        return self.schedule(**request)
+
+    def test_a_one_shot_armed_again_by_its_own_handler_survives(self):
+        rings = []
+
+        def ring(message):
+            rings.append(message.context["scheduler"]["due"])
+            if len(rings) < 3:
+                self.arm()
+
+        self.bus.on("skill.a.alarm", ring)
+        self.arm()
+        for _ in range(3):
+            self.service._evaluate()
+        self.assertEqual(len(rings), 3)
+
+    def test_the_replacement_is_still_there_after_the_batch(self):
+        self.bus.on("skill.a.alarm", lambda m: self.arm(at=iso(
+            datetime.now(timezone.utc) + timedelta(hours=1))))
+        self.arm()
+        self.service._evaluate()
+        self.assertIn(("skill.a", "alarm"), self.service.schedules)
+        self.assertEqual(
+            [entry["record"]["id"] for entry in
+             self.store_content()["schedules"]], ["alarm"])
+
+    def test_a_replacement_from_another_thread_is_not_retired(self):
+        arrived = Event()
+
+        def replace_from_elsewhere(message):
+            worker = Thread(target=lambda: (self.arm(at=iso(
+                datetime.now(timezone.utc) + timedelta(hours=1))),
+                arrived.set()))
+            worker.start()
+            worker.join(5)
+
+        self.bus.on("skill.a.alarm", replace_from_elsewhere)
+        self.arm()
+        self.service._evaluate()
+        self.assertTrue(arrived.is_set())
+        self.assertIn(("skill.a", "alarm"), self.service.schedules)
+
+    def test_a_spent_recurrence_retires_but_its_replacement_does_not(self):
+        started = iso(datetime.now(timezone.utc) - timedelta(seconds=25))
+        fires = []
+
+        def rearm(message):
+            fires.append(message)
+            if len(fires) == 1:
+                self.arm(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+
+        self.bus.on("skill.a.alarm", rearm)
+        # a recurrence with nothing left after this batch
+        self.arm(at=None, every={"seconds": 10, "start": started}, count=3,
+                 misfire="all", grace_s=0)
+        self.service._evaluate()
+        self.assertTrue(fires)
+        surviving = self.service.schedules[("skill.a", "alarm")]
+        self.assertIn("at", surviving.record)
+        self.assertNotIn("every", surviving.record)
+
+
+class TestReplay(SchedulerTestCase):
+    """§9.4 and §9.6 — restore, announce ready, then apply the misfire policy."""
+
+    def _persist_and_restart(self, **record_fields):
+        """Store one schedule, then start a fresh scheduler over that store."""
+        record = validate_record(dict(
+            {"id": "one", "owner": "skill.a", "event": "skill.a.ring"},
+            **record_fields))
+        writer = ScheduledEventService(self.bus, store_path=self.store,
+                                       autostart=False)
+        writer.schedules[record["owner"], record["id"]] = Schedule(record)
+        writer._persist()
+        writer.shutdown()
+        self.recorder.messages.clear()
+
+        revived = self.new_scheduler()
+        revived.replay()
+        return revived
+
+    def test_late_fires_the_missed_one_shot_and_reports_it(self):
+        due = datetime.now(timezone.utc) - timedelta(minutes=30)
+        self._persist_and_restart(misfire="late", at=iso(due))
+
+        missed = self.recorder.last(topics.SCHEDULER_MISSED)
+        self.assertEqual(missed.data["missed"], [iso(due)])
+        self.assertEqual(missed.data["fired_late"], [iso(due)])
+        self.assertEqual(
+            self.recorder.last("skill.a.ring").context["scheduler"]["due"],
+            iso(due))
+        # readiness comes first, so an owner listening for it hears its own
+        # late fire
+        self.assertEqual(self.recorder.types(),
+                         [topics.SCHEDULER_READY, topics.SCHEDULER_MISSED,
+                          "skill.a.ring"])
+        self.assertEqual(self.recorder.last(topics.SCHEDULER_READY).data,
+                         {"schedules": 1, "missed": 1, "clock": "synchronized"})
+
+    def test_skip_reports_but_does_not_fire(self):
+        due = datetime.now(timezone.utc) - timedelta(minutes=30)
+        self._persist_and_restart(misfire="skip", at=iso(due))
+        self.assertEqual(self.recorder.of("skill.a.ring"), [])
+        self.assertEqual(
+            self.recorder.last(topics.SCHEDULER_MISSED).data["fired_late"], [])
+        self.assertIn(topics.SCHEDULER_READY, self.recorder.types())
+
+    def test_a_one_shot_is_deleted_once_it_has_been_reported(self):
+        due = datetime.now(timezone.utc) - timedelta(minutes=30)
+        revived = self._persist_and_restart(misfire="skip", at=iso(due))
+        self.assertEqual(revived.schedules, {})
+
+    def test_all_fires_every_missed_occurrence_oldest_first(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=50)
+        self._persist_and_restart(
+            id="tick", event="skill.a.tick", misfire="all", grace_s=0, count=4,
+            every={"seconds": 10, "start": iso(start)})
+        dues = [m.context["scheduler"]["due"]
+                for m in self.recorder.of("skill.a.tick")]
+        self.assertEqual(dues, sorted(dues))
+        self.assertEqual(len(dues), 4)
+        self.assertEqual(dues[0], iso(start))
+
+    def test_ready_counts_what_the_store_held_not_what_survives_replay(self):
+        now = datetime.now(timezone.utc)
+        writer = ScheduledEventService(self.bus, store_path=self.store,
+                                       autostart=False)
+        for name, when in (("overdue", now - timedelta(minutes=30)),
+                           ("later", now + timedelta(hours=1))):
+            record = validate_record({"id": name, "owner": "skill.a",
+                                      "event": "skill.a.ring", "at": iso(when)})
+            writer.schedules["skill.a", name] = Schedule(record)
+        writer._persist()
+        writer.shutdown()
+        self.recorder.messages.clear()
+
+        self.new_scheduler().replay()
+        self.assertEqual(
+            self.recorder.last(topics.SCHEDULER_READY).data["schedules"], 2)
+
+    def test_a_recurring_schedule_survives_a_restart(self):
+        self.schedule(id="tick", event="skill.a.tick",
+                      every={"seconds": 3600,
+                             "start": iso(datetime.now(timezone.utc) +
+                                          timedelta(hours=1))})
+        self.service.shutdown()
+        self.assertIn(("skill.a", "tick"), self.new_scheduler().schedules)
+
+
+class TestFiredMessage(SchedulerTestCase):
+    """§9.5 — the requester's own context, plus the scheduler block."""
+
+    def requested_with(self):
+        """A context of the shape a real request carries."""
+        return {"session": {"session_id": "abc", "lang": "pt-pt"},
+                "skill_id": "skill.a",
+                "source": "audio:0", "destination": ["skill.a"]}
+
+    def test_a_fired_event_carries_the_context_it_was_scheduled_with(self):
+        due = datetime.now(timezone.utc) - timedelta(seconds=1)
+        given = self.requested_with()
+        self.schedule(at=iso(due), data={"key": "value"},
+                      request_context=given)
+        self.service._evaluate()
+        fired = self.recorder.last("skill.a.ring")
+        self.assertEqual(fired.data, {"key": "value"})
+        # the routing the owner wrote comes back whole: where the request
+        # came from, where its answers go, and which session it belongs to
+        for field, value in given.items():
+            self.assertEqual(fired.context[field], value)
+
+    def test_the_scheduler_block_is_the_only_thing_added(self):
+        due = datetime.now(timezone.utc) - timedelta(seconds=1)
+        given = self.requested_with()
+        self.schedule(at=iso(due), request_context=given)
+        self.service._evaluate()
+        fired = self.recorder.last("skill.a.ring")
+        self.assertEqual(set(fired.context) - set(given), {"scheduler"})
+        self.assertEqual(fired.context["scheduler"]["id"], "one")
+        self.assertEqual(fired.context["scheduler"]["owner"], "skill.a")
+        self.assertEqual(fired.context["scheduler"]["due"], iso(due))
+
+    def test_a_request_with_no_context_fires_with_none_invented(self):
+        due = datetime.now(timezone.utc) - timedelta(seconds=1)
+        self.schedule(at=iso(due))
+        self.service._evaluate()
+        fired = self.recorder.last("skill.a.ring")
+        # only the scheduler block, and the default session the bus stamps on
+        # any message that names none
+        self.assertEqual(set(fired.context) - {"session"}, {"scheduler"})
+
+    def test_the_context_survives_a_restart_with_the_store(self):
+        given = self.requested_with()
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(seconds=1)),
+                      request_context=given)
+        revived = self.new_scheduler()
+        self.assertEqual(revived.schedules["skill.a", "one"].record["context"],
+                         given)
+        time.sleep(1.1)
+        revived._evaluate()
+        fired = self.recorder.last("skill.a.ring")
+        self.assertEqual(fired.context["session"]["session_id"], "abc")
+
+    def test_a_context_planted_in_the_request_body_is_ignored(self):
+        # §3.5 takes the context from the request message and never from the
+        # body, so a component can only schedule a fire into a context it
+        # reached the scheduler from
+        self.schedule(at=iso(datetime.now(timezone.utc) - timedelta(seconds=1)),
+                      context={"source": "ATTACKER",
+                               "session": {"session_id": "victim"}},
+                      request_context={"source": "real-caller",
+                                       "session": {"session_id": "mine"}})
+        stored = self.service.schedules["skill.a", "one"].record
+        self.assertNotIn("ATTACKER", json.dumps(stored))
+
+        self.service._evaluate()
+        fired = self.recorder.last("skill.a.ring")
+        self.assertEqual(fired.context["source"], "real-caller")
+        self.assertEqual(fired.context["session"]["session_id"], "mine")
+        self.assertNotIn("ATTACKER", json.dumps(fired.context))
+
+    def test_the_later_of_two_requests_supplies_the_context(self):
+        # context is carried, not compared: it is no part of the identity
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(at=when, request_context={"mine": "first"})
+        self.schedule(at=when, request_context={"mine": "second"})
+        self.assertEqual(len(self.service.schedules), 1)
+        self.assertEqual(
+            self.service.schedules["skill.a", "one"].record["context"]["mine"],
+            "second")
+
+    def test_remaining_counts_down_across_a_late_batch(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self.schedule(id="tick", event="skill.a.tick", count=10, misfire="all",
+                      grace_s=0, every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        remaining = [m.context["scheduler"]["remaining"]
+                     for m in self.recorder.of("skill.a.tick")]
+        self.assertEqual(remaining, [9, 8, 7])
+
+
+class TestRecurrence(SchedulerTestCase):
+    """§9.7 — anchored periods and wall-clock recurrence with the DST rules."""
+
+    @staticmethod
+    def _schedule(**record_fields):
+        return Schedule(validate_record(
+            dict({"id": "x", "owner": "skill.a", "event": "skill.a.x"},
+                 **record_fields)))
+
+    def test_a_late_fire_does_not_shift_the_following_occurrences(self):
+        start = datetime(2031, 1, 1, 0, 0, tzinfo=timezone.utc)
+        schedule = self._schedule(every={"seconds": 600, "start": iso(start)})
+        # the fire for 00:10 happens five minutes late; the next occurrence is
+        # still on the schedule's own phase, not five minutes behind it
+        schedule.cursor = start + timedelta(minutes=10)
+        self.assertEqual(schedule.next_after(start + timedelta(minutes=15)),
+                         start + timedelta(minutes=20))
+
+    def test_a_wall_clock_rule_crossing_a_spring_forward_gap(self):
+        # Europe/Lisbon jumps 01:00 -> 02:00 on 2031-03-30, so 01:30 does not
+        # exist and the occurrence is the first instant after the gap
+        schedule = self._schedule(
+            local={"time": "01:30", "zone": "Europe/Lisbon"})
+        occurrence = schedule.next_after(
+            datetime(2031, 3, 29, 12, tzinfo=timezone.utc))
+        lisbon = occurrence.astimezone(ZoneInfo("Europe/Lisbon"))
+        self.assertEqual(lisbon.date().isoformat(), "2031-03-30")
+        self.assertEqual(lisbon.strftime("%H:%M"), "02:00")
+
+    def test_a_wall_clock_rule_crossing_a_fall_back_overlap(self):
+        # America/New_York reads 01:30 twice on 2031-11-02; the occurrence is
+        # the first of the two, still on daylight time
+        schedule = self._schedule(
+            local={"time": "01:30", "zone": "America/New_York"})
+        occurrence = schedule.next_after(
+            datetime(2031, 11, 1, 12, tzinfo=timezone.utc))
+        self.assertEqual(occurrence.utcoffset(), timedelta(hours=-4))
+        self.assertEqual(
+            occurrence.astimezone(ZoneInfo("America/New_York")).strftime("%H:%M"),
+            "01:30")
+
+    def test_a_wall_clock_rule_honours_its_day_list(self):
+        schedule = self._schedule(
+            local={"time": "07:30", "zone": "Europe/Lisbon", "days": ["mon"]})
+        # 2031-01-01 is a Wednesday; the next Monday is the 6th
+        occurrence = schedule.next_after(
+            datetime(2031, 1, 1, 12, tzinfo=timezone.utc))
+        self.assertEqual(
+            occurrence.astimezone(ZoneInfo("Europe/Lisbon")).date().isoformat(),
+            "2031-01-06")
+
+    def test_until_stops_the_recurrence(self):
+        start = datetime(2031, 1, 1, tzinfo=timezone.utc)
+        schedule = self._schedule(until=iso(start + timedelta(seconds=25)),
+                                  every={"seconds": 10, "start": iso(start)})
+        schedule.cursor = start + timedelta(seconds=20)
+        self.assertIsNone(schedule.next_after(schedule.cursor))
+
+    def test_count_stops_the_recurrence(self):
+        start = datetime(2031, 1, 1, tzinfo=timezone.utc)
+        schedule = self._schedule(count=2,
+                                  every={"seconds": 10, "start": iso(start)})
+        schedule.consumed = 2
+        self.assertIsNone(schedule.next_after(start))
+
+
+class TestOwnership(SchedulerTestCase):
+    """§9.8 — the event namespace and owner scoping."""
+
+    def test_an_event_outside_the_owner_namespace_is_rejected(self):
+        answer = self.schedule(event="mycroft.stop",
+                               at=iso(datetime.now(timezone.utc)))
+        self.assertEqual(answer.data["error"], "bad_event")
+
+    def test_an_authenticated_identity_may_not_act_for_another_owner(self):
+        answer = self.request(
+            topics.SCHEDULER_SCHEDULE,
+            {"owner": "skill.a", "id": "one", "event": "skill.a.ring",
+             "at": iso(datetime.now(timezone.utc) + timedelta(hours=1))},
+            context={"skill_id": "skill.b"})
+        self.assertEqual(answer.data["error"], "not_owner")
+
+    def test_cancel_and_get_are_scoped_by_owner(self):
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        cancelled = self.request(topics.SCHEDULER_CANCEL,
+                                 {"owner": "skill.b", "id": "one"})
+        self.assertFalse(cancelled.data["existed"])
+        self.assertIn(("skill.a", "one"), self.service.schedules)
+
+        read = self.request(topics.SCHEDULER_GET,
+                            {"owner": "skill.b", "id": "one"})
+        self.assertIsNone(read.data["record"])
+        self.assertFalse(read.data["existed"])
+
+    def test_list_shows_only_the_callers_schedules(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        self.schedule(owner="skill.b", event="skill.b.ring", at=when)
+        listed = self.request(topics.SCHEDULER_LIST, {"owner": "skill.b"})
+        self.assertEqual(
+            [s["record"]["owner"] for s in listed.data["schedules"]],
+            ["skill.b"])
+
+
+class TestAdministrativeOwner(SchedulerTestCase):
+    """``*`` reaches every owner, and only for a configured administrator."""
+
+    def populate(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        self.schedule(owner="skill.b", event="skill.b.ring", at=when)
+
+    def test_the_allowlist_is_empty_unless_configured(self):
+        self.assertEqual(self.service.admins, [])
+
+    def test_an_anonymous_caller_may_not_use_the_wildcard(self):
+        self.populate()
+        listed = self.request(topics.SCHEDULER_LIST, {"owner": "*"})
+        self.assertEqual(listed.data["error"], "not_owner")
+        cancelled = self.request(topics.SCHEDULER_CANCEL,
+                                 {"owner": "*", "id": "one"})
+        self.assertEqual(cancelled.data["error"], "not_owner")
+        self.assertEqual(len(self.service.schedules), 2)
+
+    def test_an_identified_caller_outside_the_allowlist_may_not_either(self):
+        self.populate()
+        listed = self.request(topics.SCHEDULER_LIST, {"owner": "*"},
+                              context={"skill_id": "skill.a"})
+        self.assertEqual(listed.data["error"], "not_owner")
+
+    def test_an_allowlisted_administrator_lists_and_cancels_everything(self):
+        self.populate()
+        self.service.admins = ["admin.panel"]
+        listed = self.request(topics.SCHEDULER_LIST, {"owner": "*"},
+                              context={"skill_id": "admin.panel"})
+        self.assertEqual(len(listed.data["schedules"]), 2)
+        self.request(topics.SCHEDULER_CANCEL, {"owner": "*", "id": "one"},
+                     context={"skill_id": "admin.panel"})
+        self.assertEqual(self.service.schedules, {})
+
+    def test_no_schedule_may_be_created_under_the_wildcard(self):
+        answer = self.schedule(owner="*", event="*.ring",
+                               at=iso(datetime.now(timezone.utc)))
+        self.assertEqual(answer.data["error"], "not_owner")
+
+    def test_an_administrator_may_not_create_under_the_wildcard_either(self):
+        self.service.admins = ["admin.panel"]
+        answer = self.request(
+            topics.SCHEDULER_SCHEDULE,
+            {"owner": "*", "id": "one", "event": "*.ring",
+             "at": iso(datetime.now(timezone.utc) + timedelta(hours=1))},
+            context={"skill_id": "admin.panel"})
+        self.assertEqual(answer.data["error"], "not_owner")
+
+
+class TestClock(SchedulerTestCase):
+    """§9.9 — a clock step never double-fires, an unset clock defers."""
+
+    def test_a_forward_step_fires_each_occurrence_once(self):
+        start = datetime.now(timezone.utc) + timedelta(seconds=10)
+        self.schedule(id="tick", event="skill.a.tick", misfire="all",
+                      grace_s=0, every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a.tick"), [])
+
+        jumped = start + timedelta(seconds=25)
+        with patch.object(ScheduledEventService, "now",
+                          staticmethod(lambda: jumped)):
+            self.service._evaluate()
+            after_first = [m.context["scheduler"]["due"]
+                           for m in self.recorder.of("skill.a.tick")]
+            # a second evaluation at the same instant must add nothing
+            self.service._evaluate()
+        after_second = [m.context["scheduler"]["due"]
+                        for m in self.recorder.of("skill.a.tick")]
+        self.assertEqual(len(after_first), 3)
+        self.assertEqual(after_first, after_second)
+
+    def test_a_backward_step_does_not_refire_a_consumed_occurrence(self):
+        due = datetime.now(timezone.utc) - timedelta(seconds=1)
+        self.schedule(at=iso(due))
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+
+        rewound = due - timedelta(hours=2)
+        with patch.object(ScheduledEventService, "now",
+                          staticmethod(lambda: rewound)):
+            self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+
+    def test_a_step_is_detected_against_the_monotonic_clock(self):
+        self.service._wall_reference = time.time() - 3600
+        self.service._mono_reference = time.monotonic()
+        self.assertGreater(abs(self.service._clock_step()), 2)
+        self.assertEqual(self.service._clock_step(), 0.0)
+
+    def test_an_unsynchronized_clock_defers_rather_than_drops(self):
+        # the wall clock reads before the newest instant a past run recorded
+        self.service.newest_past_instant = (datetime.now(timezone.utc) +
+                                            timedelta(days=400))
+        self.service.clock_synced = False
+        due = datetime.now(timezone.utc) - timedelta(seconds=1)
+        self.assertTrue(self.schedule(at=iso(due)).data["ok"])
+        self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a.ring"), [])
+
+        self.bus.emit(Message(topics.CLOCK_SYNCED))
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+        self.assertEqual(
+            self.recorder.last(topics.SCHEDULER_READY).data["clock"],
+            "synchronized")
+
+    def test_the_clock_syncs_when_the_wall_clock_passes_the_stored_instant(self):
+        self.service.newest_past_instant = (datetime.now(timezone.utc) -
+                                            timedelta(days=1))
+        self.service.clock_synced = False
+        self.service.tick()
+        self.assertTrue(self.service.clock_synced)
+        self.assertIn(topics.SCHEDULER_READY, self.recorder.types())
+
+
+class TestRelativeDelay(SchedulerTestCase):
+    """``in`` runs off the monotonic clock, so a wall step cannot move it."""
+
+    def test_a_wall_clock_step_does_not_fire_a_relative_delay_early(self):
+        self.schedule(**{"in": {"seconds": 300}})
+        jumped = datetime.now(timezone.utc) + timedelta(hours=5)
+        with patch.object(ScheduledEventService, "now",
+                          staticmethod(lambda: jumped)):
+            self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a.ring"), [])
+
+    def test_a_relative_delay_fires_when_its_monotonic_deadline_passes(self):
+        self.schedule(**{"in": {"seconds": 300}})
+        self.service.schedules["skill.a", "one"].deadline = time.monotonic() - 1
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+        self.assertEqual(self.service.schedules, {})
+
+    def test_a_relative_delay_is_persisted_as_a_wall_clock_estimate(self):
+        self.schedule(**{"in": {"seconds": 300}})
+        entry = self.store_content()["schedules"][0]
+        self.assertIsNotNone(entry["estimate"])
+        self.assertEqual(entry["record"]["in"], {"seconds": 300})
+
+    def test_until_and_count_are_refused_for_a_relative_delay(self):
+        answer = self.schedule(count=2, **{"in": {"seconds": 300}})
+        self.assertEqual(answer.data["error"], "invalid_record")
+
+
+class TestMisfireBounds(SchedulerTestCase):
+    """Occurrences the misfire policy drops still count against ``count``."""
+
+    def test_skipped_occurrences_are_consumed_against_count(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      grace_s=0, count=3,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a.tick"), [])
+        # three occurrences passed; the bound is spent and the record is gone
+        self.assertEqual(self.service.schedules, {})
+
+    def test_all_respects_until(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=55)
+        self.schedule(id="tick", event="skill.a.tick", misfire="all", grace_s=0,
+                      until=iso(start + timedelta(seconds=25)),
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 3)
+
+    def test_a_long_downtime_caps_and_flags_the_missed_report(self):
+        backlog = 5 * MAX_REPORTED
+        start = datetime.now(timezone.utc) - timedelta(seconds=backlog)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      grace_s=0, every={"seconds": 1, "start": iso(start)})
+        self.service._evaluate()
+        missed = self.recorder.last(topics.SCHEDULER_MISSED)
+        self.assertEqual(len(missed.data["missed"]), MAX_REPORTED)
+        self.assertTrue(missed.data["truncated"])
+        # the whole backlog was consumed even though only part was reported
+        self.assertGreaterEqual(
+            self.service.schedules["skill.a", "tick"].consumed, backlog)
+
+    def test_a_backlog_inside_the_cap_is_not_flagged(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      grace_s=0, every={"seconds": 1, "start": iso(start)})
+        self.service._evaluate()
+        self.assertFalse(
+            self.recorder.last(topics.SCHEDULER_MISSED).data["truncated"])
+
+    def test_missed_dues_show_up_in_the_computed_state(self):
+        due = datetime.now(timezone.utc) - timedelta(hours=2)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      every={"seconds": 86400, "start": iso(due)})
+        self.service._evaluate()
+        read = self.request(topics.SCHEDULER_GET,
+                            {"owner": "skill.a", "id": "tick"})
+        self.assertEqual(read.data["state"]["missed"], [iso(due)])
+
+    def test_a_fire_clears_the_missed_dues_that_precede_it(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self.schedule(id="tick", event="skill.a.tick", misfire="late",
+                      grace_s=0, every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        read = self.request(topics.SCHEDULER_GET,
+                            {"owner": "skill.a", "id": "tick"})
+        self.assertEqual(read.data["state"]["missed"], [])
+        self.assertEqual(read.data["state"]["last_fired"],
+                         iso(start + timedelta(seconds=20)))
+
+    def test_a_series_exhausted_in_the_same_evaluation_reports_no_next(self):
+        # the report goes out before the fires it announces, so a next read
+        # from the pre-batch tally would name an occurrence count forbids
+        start = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self.schedule(id="tick", event="skill.a.tick", misfire="all",
+                      grace_s=0, count=3,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 3)
+        self.assertIsNone(self.recorder.last(topics.SCHEDULER_MISSED).data["next"])
+        self.assertEqual(self.service.schedules, {})
+
+    def test_a_series_that_continues_still_reports_its_next(self):
+        start = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self.schedule(id="tick", event="skill.a.tick", misfire="skip",
+                      grace_s=0, count=10,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service._evaluate()
+        self.assertIsNotNone(
+            self.recorder.last(topics.SCHEDULER_MISSED).data["next"])
+
+    def test_replay_reports_every_occurrence_it_produces(self):
+        # an occurrence emitted just before a crash may have lost its record,
+        # so replay reports it even when it is inside the grace period
+        start = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self.schedule(id="tick", event="skill.a.tick", grace_s=600,
+                      every={"seconds": 10, "start": iso(start)})
+        self.service.replay()
+        missed = self.recorder.last(topics.SCHEDULER_MISSED)
+        self.assertEqual(missed.data["missed"], [iso(start)])
+        self.assertEqual(missed.data["fired_late"], [])
+        self.assertEqual(len(self.recorder.of("skill.a.tick")), 1)
+
+
+class TestLegacyAdapter(SchedulerTestCase):
+    """The pre-specification protocol keeps working for one stable cycle."""
+
+    def emit_legacy_schedule(self, context=None, **data):
+        self.bus.emit(Message(topics.LEGACY_SCHEDULE, data, context or {}))
+
+    def test_schedule_and_fire_through_the_legacy_topic(self):
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() - 1,
+                                  data={"k": 1})
+        self.service._evaluate()
+        self.assertEqual(self.recorder.last("skill.a:ring").data, {"k": 1})
+
+    def test_scheduling_an_existing_name_replaces_instead_of_stacking(self):
+        for _ in range(3):
+            self.emit_legacy_schedule(event="skill.a:ring",
+                                      time=time.time() + 3600)
+        self.assertEqual(len(self.service.schedules), 1)
+        self.service._evaluate()
+        self.assertEqual(self.recorder.of("skill.a:ring"), [])
+
+    def test_a_legacy_schedule_fires_with_the_context_it_was_made_with(self):
+        # these owners predate §4.2 and were promised their own context back;
+        # the specification path stays fresh, this one does not
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() - 1,
+                                  context={"skill_id": "skill.a",
+                                           "session": {"session_id": "abc"}})
+        self.service._evaluate()
+        fired = self.recorder.last("skill.a:ring")
+        self.assertEqual(fired.context["skill_id"], "skill.a")
+        self.assertEqual(fired.context["scheduler"]["id"], "skill.a:ring")
+        # whole, session and all, as the scheduler this replaced did it and
+        # as a schedule made through the specified protocol does it
+        self.assertEqual(fired.context["session"]["session_id"], "abc")
+
+    def test_a_legacy_repeat_carries_its_context_to_every_occurrence(self):
+        start = time.time() - 25
+        self.emit_legacy_schedule(event="skill.a:tick", time=start, repeat=10,
+                                  context={"mine": True})
+        self.service._evaluate()
+        fired = self.recorder.of("skill.a:tick")
+        self.assertTrue(fired)
+        self.assertTrue(all(m.context["mine"] for m in fired))
+
+    def test_a_legacy_context_survives_a_restart(self):
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() + 1,
+                                  context={"mine": True})
+        revived = self.new_scheduler()
+        revived._evaluate()
+        time.sleep(1.1)
+        revived._evaluate()
+        self.assertTrue(self.recorder.last("skill.a:ring").context["mine"])
+
+    def test_a_stored_legacy_context_keeps_its_session(self):
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() + 3600,
+                                  context={"mine": True,
+                                           "session": {"session_id": "abc"}})
+        record = self.service.schedules["skill.a", "skill.a:ring"].record
+        self.assertEqual(record["context"]["mine"], True)
+        self.assertEqual(record["context"]["session"]["session_id"], "abc")
+
+    def test_the_get_reply_carries_the_stored_context(self):
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() + 3600,
+                                  context={"mine": True})
+        self.bus.emit(Message(topics.LEGACY_GET, {"name": "skill.a:ring"}))
+        reply = self.recorder.last(
+            f"{topics.LEGACY_GET_REPLY_PREFIX}skill.a:ring")
+        self.assertTrue(reply.data["schedule"][3]["mine"])
+
+    def test_a_legacy_context_is_stored_the_way_any_other_one_is(self):
+        # both protocols reach the same field: the adapter is a translation,
+        # not a second set of rules about context
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() + 3600,
+                                  context={"mine": True})
+        self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)),
+                      request_context={"mine": True})
+        for key in (("skill.a", "skill.a:ring"), ("skill.a", "one")):
+            self.assertTrue(self.service.schedules[key].record["context"]["mine"])
+
+    def test_remove_event(self):
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() + 3600)
+        self.bus.emit(Message(topics.LEGACY_REMOVE, {"event": "skill.a:ring"}))
+        self.assertEqual(self.service.schedules, {})
+
+    def test_update_event_replaces_the_data(self):
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() + 3600,
+                                  data={"k": 1})
+        self.bus.emit(Message(topics.LEGACY_UPDATE,
+                              {"event": "skill.a:ring", "data": {"k": 2}}))
+        self.assertEqual(
+            self.service.schedules["skill.a", "skill.a:ring"].record["data"],
+            {"k": 2})
+
+    def test_get_event_answers_on_its_callback_topic(self):
+        when = time.time() + 3600
+        self.emit_legacy_schedule(event="skill.a:ring", time=when)
+        self.bus.emit(Message(topics.LEGACY_GET, {"name": "skill.a:ring"}))
+        reply = self.recorder.last(
+            f"{topics.LEGACY_GET_REPLY_PREFIX}skill.a:ring")
+        # the schedule travels under a key: the wire refuses a list payload
+        self.assertAlmostEqual(reply.data["schedule"][0], when, places=0)
+
+    def test_list_events_keeps_its_reply_shape(self):
+        self.emit_legacy_schedule(event="skill.a:ring", time=time.time() + 3600)
+        self.bus.emit(Message(topics.LEGACY_LIST, {},
+                              {"source": ["x"], "destination": ["y"]}))
+        listed = [m for m in self.recorder.messages if "scheduled_events" in m.data]
+        self.assertIn("skill.a:ring", listed[-1].data["scheduled_events"])
+
+    def test_a_repeat_becomes_a_fixed_period_recurrence(self):
+        self.emit_legacy_schedule(event="skill.a:tick", time=time.time() + 60,
+                                  repeat=30)
+        record = self.service.schedules["skill.a", "skill.a:tick"].record
+        self.assertEqual(record["every"]["seconds"], 30)
+
+    def test_an_unnamespaced_event_belongs_to_no_component_in_particular(self):
+        self.emit_legacy_schedule(event="bare", time=time.time() + 60)
+        self.assertIn(("legacy", "bare"), self.service.schedules)
+
+    def test_the_deprecation_notice_names_the_removal_version(self):
+        with patch("ovos_bus_client.util.scheduled_events.legacy.LOG") as log:
+            self.emit_legacy_schedule(event="skill.a:ring", time=time.time() + 60)
+            self.emit_legacy_schedule(event="skill.a:other", time=time.time() + 60)
+        notices = [call.args[0] for call in log.warning.call_args_list]
+        # warned once for the topic, naming the release that drops it
+        self.assertEqual(len(notices), 1)
+        self.assertIn(LEGACY_REMOVAL_VERSION, notices[0])
+
+    def test_the_store_moves_out_of_the_configuration_directory(self):
+        with tempfile.TemporaryDirectory() as config_dir:
+            source = os.path.join(config_dir, "schedule.json")
+            with open(source, "w") as handle:
+                json.dump({"skill.a:ring": [[time.time() + 3600, None, {}, {}]]},
+                          handle)
+            if os.path.isfile(self.store):
+                os.unlink(self.store)
+
+            with patch("ovos_bus_client.util.scheduled_events.legacy."
+                       "get_xdg_config_save_path", return_value=config_dir):
+                migrated = self.new_scheduler()
+                self.assertIn(("skill.a", "skill.a:ring"), migrated.schedules)
+                self.assertTrue(os.path.isfile(self.store))
+                # the original stays put so a downgrade still finds it
+                self.assertTrue(os.path.isfile(source))
+                self.assertTrue(os.path.isfile(f"{source}.migrated"))
+
+                self.assertEqual(len(self.new_scheduler().schedules), 1)
+
+
+class TestSubscriptions(SchedulerTestCase):
+    def test_shutdown_leaves_an_unrelated_observer_subscribed(self):
+        seen = []
+        self.bus.on(topics.SCHEDULER_SCHEDULE, seen.append)
+        self.service.shutdown()
+        self.bus.emit(Message(topics.SCHEDULER_SCHEDULE, {}))
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(self.recorder.of(topics.SCHEDULER_SCHEDULE_RESPONSE), [])
+
+
+class TestInstants(unittest.TestCase):
+    def test_an_instant_round_trips(self):
+        when = datetime(2031, 3, 29, 7, 30, tzinfo=timezone.utc)
+        self.assertEqual(format_instant(when), "2031-03-29T07:30:00+00:00")
+
+    def test_a_zulu_suffix_is_accepted(self):
+        record = validate_record({"id": "x", "owner": "s", "event": "s.e",
+                                  "at": "2031-03-29T07:30:00Z"})
+        self.assertEqual(record["at"], "2031-03-29T07:30:00+00:00")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_scheduler_extra.py
+++ b/test/unittests/test_scheduler_extra.py
@@ -1,181 +1,107 @@
-"""Coverage tests for ovos_bus_client.util.scheduler — EventScheduler."""
+"""The legacy scheduling topics, reached over the bus."""
 import os
 import tempfile
 import time
 import unittest
 from unittest import TestCase
-from unittest.mock import MagicMock
 
-from ovos_bus_client.message import Message
-from ovos_bus_client.util.scheduler import EventScheduler, repeat_time
 from ovos_utils.fakebus import FakeBus
 
-
-class TestRepeatTime(TestCase):
-    def test_repeat_time_advances_until_future(self):
-        past = time.time() - 100
-        future = repeat_time(past, 30)
-        self.assertGreaterEqual(future, time.time())
-
-    def test_repeat_time_negative_returns_future(self):
-        next_time = repeat_time(time.time(), -30)
-        self.assertGreaterEqual(next_time, time.time())
+from ovos_bus_client.message import Message
+from ovos_bus_client.util.scheduled_events import topics
+from ovos_bus_client.util.scheduler import EventScheduler
 
 
-class TestEventScheduler(TestCase):
+class TestLegacyBusSurface(TestCase):
     def setUp(self):
         self.bus = FakeBus()
-        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
-        self.tmpfile.close()
-        os.unlink(self.tmpfile.name)
-        self.sched = EventScheduler(self.bus, schedule_file=self.tmpfile.name,
-                                    autostart=False)
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.scheduler = EventScheduler(self.bus, schedule_file=self.store,
+                                        autostart=False)
 
     def tearDown(self):
-        self.sched._stopping.set()
-        try:
-            self.sched.shutdown()
-        except Exception:
-            pass
-        try:
-            os.unlink(self.tmpfile.name)
-        except OSError:
-            pass
+        self.scheduler.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
 
     def test_initial_state(self):
-        self.assertEqual(self.sched.events, {})
-        self.assertFalse(self.sched.is_running)
+        self.assertEqual(self.scheduler.schedules, {})
+        self.assertFalse(self.scheduler.is_running)
 
     def test_schedule_event_one_shot(self):
-        # ensure clock-sync check passes
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
+        self.scheduler.schedule_event("skill:ev", time.time() + 60, data={"x": 1})
+        self.assertIn(("skill", "skill:ev"), self.scheduler.schedules)
+
+    def test_a_request_made_while_the_clock_is_behind_is_kept(self):
+        # a board that boots before it reaches a time source must not lose the
+        # schedules made in that window
+        self.scheduler.clock_synced = False
+        self.scheduler.schedule_event("skill:ev", time.time() + 60)
+        self.assertIn(("skill", "skill:ev"), self.scheduler.schedules)
+        self.assertTrue(os.path.isfile(self.store))
+
+    def test_scheduling_a_repeat_twice_keeps_one_record(self):
         future = time.time() + 60
-        self.sched.schedule_event("ev", future, data={"x": 1})
-        self.assertIn("ev", self.sched.events)
+        self.scheduler.schedule_event("skill:ev", future, repeat=10)
+        self.scheduler.schedule_event("skill:ev", future, repeat=10)
+        self.assertEqual(len(self.scheduler.schedules), 1)
 
-    def test_schedule_event_clock_in_past_drops(self):
-        # leave _last_sync at its initial past value
-        from ovos_utils.time import now_local
-        from datetime import timedelta
-        self.sched._last_sync = now_local() - timedelta(days=800)
-        self.sched.schedule_event("ev", time.time() + 60)
-        self.assertNotIn("ev", self.sched.events)
-        self.assertEqual(self.sched._dropped_events, 1)
+    def test_schedule_event_via_a_bus_message(self):
+        self.bus.emit(Message(topics.LEGACY_SCHEDULE,
+                              {"event": "skill:fromBus",
+                               "time": time.time() + 60, "data": {}}))
+        self.assertIn(("skill", "skill:fromBus"), self.scheduler.schedules)
 
-    def test_schedule_repeating_event_dedupes(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        future = time.time() + 60
-        self.sched.schedule_event("ev", future, repeat=10)
-        # second schedule should be ignored
-        self.sched.schedule_event("ev", future, repeat=10)
-        self.assertEqual(len(self.sched.events["ev"]), 1)
+    def test_a_schedule_request_without_an_event_is_ignored(self):
+        self.bus.emit(Message(topics.LEGACY_SCHEDULE,
+                              {"time": time.time() + 60}))
+        self.assertEqual(self.scheduler.schedules, {})
 
-    def test_handle_schedule_event_via_bus_message(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        future = time.time() + 60
-        msg = Message("mycroft.scheduler.schedule_event",
-                      {"event": "fromBus", "time": future, "data": {}})
-        self.sched.handle_schedule_event(msg)
-        self.assertIn("fromBus", self.sched.events)
-
-    def test_handle_schedule_event_missing_event_logs(self):
-        # missing event name → logged error, no addition
-        msg = Message("e", {"time": time.time() + 60})
-        self.sched.handle_schedule_event(msg)
-        self.assertEqual(self.sched.events, {})
-
-    def test_handle_schedule_event_missing_time(self):
-        msg = Message("e", {"event": "x"})
-        self.sched.handle_schedule_event(msg)
-        self.assertNotIn("x", self.sched.events)
+    def test_a_schedule_request_without_a_time_is_ignored(self):
+        self.bus.emit(Message(topics.LEGACY_SCHEDULE, {"event": "skill:x"}))
+        self.assertEqual(self.scheduler.schedules, {})
 
     def test_remove_event_present(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60)
-        self.sched.remove_event("ev")
-        self.assertNotIn("ev", self.sched.events)
+        self.scheduler.schedule_event("skill:ev", time.time() + 60)
+        self.scheduler.remove_event("skill:ev")
+        self.assertNotIn(("skill", "skill:ev"), self.scheduler.schedules)
 
-    def test_remove_event_absent_noop(self):
-        self.sched.remove_event("missing")  # no error
+    def test_removing_an_absent_event_does_nothing(self):
+        self.scheduler.remove_event("skill:missing")
 
-    def test_handle_remove_event(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60)
-        self.sched.handle_remove_event(Message("e", {"event": "ev"}))
-        self.assertNotIn("ev", self.sched.events)
+    def test_remove_event_via_a_bus_message(self):
+        self.scheduler.schedule_event("skill:ev", time.time() + 60)
+        self.bus.emit(Message(topics.LEGACY_REMOVE, {"event": "skill:ev"}))
+        self.assertNotIn(("skill", "skill:ev"), self.scheduler.schedules)
 
-    def test_update_event_present(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60, data={"x": 1})
-        self.sched.update_event("ev", {"x": 2})
-        new_data = self.sched.events["ev"][0][2]
-        self.assertEqual(new_data["x"], 2)
+    def test_updating_an_absent_event_does_nothing(self):
+        self.scheduler.update_event("skill:missing", {"x": 1})
 
-    def test_update_event_absent_noop(self):
-        self.sched.update_event("missing", {"x": 1})
+    def test_update_event_via_a_bus_message(self):
+        self.scheduler.schedule_event("skill:ev", time.time() + 60, data={"x": 1})
+        self.bus.emit(Message(topics.LEGACY_UPDATE,
+                              {"event": "skill:ev", "data": {"x": 2}}))
+        self.assertEqual(
+            self.scheduler.schedules["skill", "skill:ev"].record["data"],
+            {"x": 2})
 
-    def test_handle_update_event(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60, data={"x": 1})
-        self.sched.handle_update_event(
-            Message("u", {"event": "ev", "data": {"x": 2}})
-        )
-
-    def test_handle_get_event_for_unknown_emits_none(self):
-        # for an unknown event name the handler still hits the emitter;
-        # an internal assertion errors on non-dict data, so just verify it doesn't crash
-        # the lookup path
-        try:
-            self.sched.handle_get_event(Message("g", {"name": "never-scheduled"}))
-        except AssertionError:
-            pass  # Message.reply enforces dict-data; not our concern here
-
-    def test_clear_empty_removes_empty_entries(self):
-        self.sched.events["empty"] = []
-        self.sched.events["full"] = [(time.time() + 60, None, {}, {})]
-        self.sched.clear_empty()
-        self.assertNotIn("empty", self.sched.events)
-        self.assertIn("full", self.sched.events)
-
-    def test_clear_repeating_filters_repeats_in_place(self):
-        # clear_repeating filters the tuple list per event key to drop
-        # repeats (tup[1] is None means one-shot)
-        self.sched.events["mixed"] = [
-            (time.time() + 60, 30, {}, {}),    # repeat
-            (time.time() + 60, None, {}, {}),  # one-shot
-        ]
-        self.sched.clear_repeating()
-        # one-shot survives
-        self.assertEqual(len(self.sched.events["mixed"]), 1)
-        self.assertIsNone(self.sched.events["mixed"][0][1])
+    def test_get_event_for_an_unknown_name_answers_with_nothing(self):
+        answers = []
+        self.bus.on(f"{topics.LEGACY_GET_REPLY_PREFIX}never-scheduled",
+                    answers.append)
+        self.bus.emit(Message(topics.LEGACY_GET, {"name": "never-scheduled"}))
+        self.assertIsNone(answers[-1].data["schedule"])
 
     def test_store_and_reload(self):
-        # bypass clock-in-past check (_last_sync is a datetime)
-        from ovos_utils.time import now_local
-        self.sched._last_sync = now_local()
-        self.sched.schedule_event("ev", time.time() + 60)
-        self.sched.store()
-        # constructing a new scheduler should reload from disk
-        new = EventScheduler(self.bus, schedule_file=self.tmpfile.name,
-                             autostart=False)
-        try:
-            self.assertIn("ev", new.events)
-        finally:
-            new._stopping.set()
+        self.scheduler.schedule_event("skill:ev", time.time() + 60)
+        self.scheduler.store()
+        revived = EventScheduler(self.bus, schedule_file=self.store,
+                                 autostart=False)
+        self.addCleanup(revived.shutdown)
+        self.assertIn(("skill", "skill:ev"), revived.schedules)
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_util.py
+++ b/test/unittests/test_util.py
@@ -26,8 +26,8 @@ class TestEventScheduler(unittest.TestCase):
         cls.scheduler = EventScheduler(cls.bus, cls.test_schedule_name, False)
 
     def test_00_init(self):
-        self.assertEqual(self.scheduler.events, dict())
-        self.assertIsNotNone(self.scheduler.event_lock)
+        self.assertEqual(self.scheduler.schedules, dict())
+        self.assertIsNotNone(self.scheduler.lock)
         self.assertEqual(self.scheduler.bus, self.bus)
         self.assertFalse(isfile(self.scheduler.schedule_file))
         self.assertEqual(


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

This is the SCHEDULER-1 reference implementation, resubmitted with readability as the point of the exercise. The previous attempt was one 922-line module; this is the same behaviour laid out so that a maintainer can find one thing in one place. Under `ovos_bus_client/util/scheduled_events/`: `topics` holds the bus topic names and nothing else, `records` is the vocabulary a record is written in (instants, wall-clock times, the refusal error), `validation` is what a request must contain to become a stored record, `timing` is the occurrence arithmetic for the four timing forms including the daylight-saving rules, `schedules` is a stored record plus the state and bounds the scheduler keeps beside it, `store` is the file and its atomic replace, `service` is the service itself, and `legacy` is the pre-specification protocol translated. The client is `SchedulerClient` in `ovos_bus_client/apis/scheduler.py`; `EventSchedulerInterface` is that client plus the older `*_scheduled_event` methods, and `EventScheduler` is the service under the name `ovos-core` starts it by.

The delivery choice is at-least-once bounded to a single occurrence. An accepted request reaches the store before its answer goes out, and the due instant of a fired occurrence reaches the store immediately after the event and before the next one leaves. A kill in the window between an event hitting the bus and its due hitting the store repeats that one occurrence on the next start and nothing earlier, which is what the persisted last-fire instant bounds. Owners deduplicate on the pair (id, due); the spec says so and the docs say so. The alternative — persisting before emitting — would silently lose fires instead, which is worse for an alarm.

Three things change for callers of the legacy protocol, and all three are things the old shape could not express. Scheduling a name that already exists now replaces it instead of appending a second entry, which is what stops a skill that re-creates its schedules on every boot from doubling them. `mycroft.scheduler.get_event` answers with `{"event": ..., "schedule": [...]}` rather than a bare list, because the wire refuses a list-shaped payload and the old reply could not be constructed at all. And a request made while the clock is unsynchronized is persisted and deferred rather than dropped, which is the failure that made a board without an RTC ring yesterday's alarm an hour at a time. The store also moves from the configuration directory to the state directory: an existing `schedule.json` is copied on first start and the original left where it is, marked so the copy is not repeated, so a downgrade still finds it.

A fired occurrence carries the context of the request that created it, unchanged, with the `scheduler` block added on top. This follows SCHEDULER-1 §3.5 and §4.2 as amended by OpenVoiceOS/architecture#171: the record stores the request message's context verbatim, taken from the message and never from the request body, and the fire is that context plus the added `scheduler` key with no other change — §9.5 is the MUST. §8 forbids a client putting routing keys in the request body to the same end, which is why `context=` travels as the request message's context.

The reason is routing. A context carries `source`, `destination` and the session carrier of whoever asked, and that identity is what a layer-2 deployment routes by: replaying it verbatim is what makes an alarm asked for on a remote satellite ring on that satellite rather than wherever the scheduler happens to run. Whether a session snapshot inside it is still current is a consumer's question under SESSION-2, not the scheduler's.

The record keeps that context and it survives a restart with the store, which the version moves from 1 to 2 for; a store written by version 1 is read as it is, its records simply having no context, and only a store from a version newer than this one is still set aside.

The legacy adapter follows the same rule, which means an earlier revision's session-strip is gone: a `mycroft.scheduler.schedule_event` schedule replays its context whole, session included, exactly as the scheduler it replaces did. Three tests that pinned the strip are reversed and say so, and there is nothing different about context on either path — the adapter is a translation, not a second set of rules. Nothing is invented: a request made with no context fires with the `scheduler` key alone.

One operational consequence to watch. A real request message carries a full session snapshot, so a schedule persists roughly a kilobyte of context and the store is rewritten on every fire; a handful of schedules on a short recurrence is a meaningful amount of flash traffic on an SD card. `validate_record` already holds context to the same 16 KB limit as `data` and refuses anything larger with `payload_too_large`, so the remedy if this bites is a tighter cap rather than a return to stripping. The live rig watches write volume.

`schedule(context=...)` lets a component name the context an occurrence belongs to instead of inheriting the one it is handling, and `reschedule` carries it across.

A replacement carries what the schedule it replaces has already done. §5.2 makes sending the same request twice the same as sending it once, which it is not if the replacement arrives with an empty history and fires this morning again — and §5.1 and §9.9 say without exception that an occurrence at or before the most recent fire is never fired again. So `last_fired` comes across whatever else changed, and `consumed` comes across too: nothing grants a replacement a fresh `count` budget, and where the spec is silent the reading that cannot ring an alarm twice is the one to take. The cursor and the missed list are positions in a series, so they come across only when the timing still describes that series; `last_fired` floors everything a new one can produce. An owner that wants to start over cancels and creates again.

There is no update request on the wire and there should not be: replacing a schedule is how the protocol changes one (§5.2), and a replacement that repeats the stored period without an anchor keeps its phase. What was missing was the client-side convenience, so consumers were reading a record back and reassembling a `schedule` call by hand and losing the phase while they did it. `reschedule(schedule_id, **changes)` is that call, filled in from what is already stored: change the payload and the hourly job stays on its hour, the countdown keeps counting down to the instant it was already counting down to, the bounds and policies come along, and the handler stays subscribed unless a new one is given.

Topic names come from a single private constants block that mirrors the `SCHEDULER_*` constants of `ovos_spec_tools.messages.SpecMessage`. Those constants live in OpenVoiceOS/ovos-spec-tools#111, which is unmerged; when it lands, `topics.py` becomes a re-export and no call site changes, because nothing outside that module writes a topic literal.

One trade-off is worth knowing before you deploy it: `misfire: "all"` drains its whole backlog inside a single evaluation, up to ten thousand occurrences, each emitted and then written to the store. Days of downtime on a short recurrence therefore make for one very busy tick and a lot of flash writes. The spec makes pacing a MAY and this does not pace; `docs/scheduler.md` says so and points at `late` as the default for a reason.

The conformance suite has a test per MUST of §9 plus the edges that bite in production rather than in a spec: kill points inside a backlog, report truncation, what the ready count counts, per-fire `remaining`, rollback when the store cannot be written, a recurrence bounded before its own first occurrence, a missed report for a series that count exhausts in the same evaluation, the administrative allowlist, Lisbon's spring gap and New York's autumn overlap, an unsynchronized clock, a store written by a newer scheduler, and the legacy adapter's replace-on-name, object-shaped `get_event` reply and context replay. A handler can schedule from inside the event it is handling, including under the same id. "When it rings, set the next one" is how an owner builds a chain of one-shots, and the replacement it makes is younger than the fire still being processed — so retiring a spent schedule now checks that the stored schedule is the one that fired, rather than deleting whatever holds its id. The same check covers a replacement arriving from another thread while the batch runs. Without it the owner's request was undone silently and there was nothing it could observe to find out.

A store the scheduler cannot parse is now moved to a `.corrupt.<timestamp>.bak` sibling before it starts empty, and the quarantine path is logged. It used to keep its name, which meant the damaged bytes — the only account of what the scheduler was holding — were silently overwritten by the next write.

The full suite goes from 840 passing on `dev` to 1000.

`is_available()` answers whether there is a scheduler on the bus at all. A component can be installed alongside a client and still be talking to a core that predates the protocol, where every request costs a full timeout and then raises; asking once, cheaply, is what lets it fall back instead. The answer is remembered.

The line between this PR and OpenVoiceOS/ovos-workshop#574 is that everything about the wire lives here — the presence probe, the replacement that keeps a schedule's phase, and what a fired context carries on each protocol — while everything about what a skill sees lives there. So the skill-side wrapper that gives a scheduled handler back the context it scheduled with is in #574, on top of the split above; it covers every case except a context expected to survive a restart, which lives in the skill process and does not.

This ran on a live rig as well as in tests: a real message bus, the scheduler in its own process, every frame captured, through eight scenarios including three kill points inside a backlog, clock steps in both directions and the Lisbon daylight-saving gap and overlap. The scenario table is in `scratchpad/scheduler-live-rig.md`. It found the store quarantine gap above, and it found `docs/scheduler.md` describing the misfire policy wrongly: the doc said `late` fires the most recent missed occurrence and drops the rest, full stop, while a ten-second recurrence coming back from a hundred-and-fifty-second outage emitted seven messages. Both spec and implementation are right and the doc was wrong — `grace_s` decides where a backlog stops being ordinary lateness, so everything inside the grace window fires and only what is older is subject to the policy. The page now says that, with the seven-message example.

The review set is OpenVoiceOS/architecture#169 and #171 for the specification and its context amendment, OpenVoiceOS/ovos-spec-tools#111 for the topic constants, and OpenVoiceOS/ovos-workshop#574 and OpenVoiceOS/ovos-skill-alerts#173 for the two consumers whose friction shaped the client surface. Draft on purpose: not to be merged without your read.




