### PR TITLE
fix: stamp wire_payload in Session.deserialize for SESSION-2 §5.1 field-merge

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,6 +9,27 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `1.5.0 -> next-stable` jump, and a new, empty
 quirks log starts.
 
+## 2.10.1a2
+
+`Session.deserialize()` built its result from a hand-enumerated
+constructor call rather than the `ovos_spec_tools.session.Session` instance
+`_SpecSession.from_dict()` already stamped with `wire_payload`, so the
+`Session` object bus-client actually returned to callers was always
+snapshot-less. `SessionManager._store()` (inherited from ovos-spec-tools)
+reads `wire_payload` to decide, per OVOS-SESSION-2 §5.1, which fields an
+inbound default-session message actually carried; without it every
+serialized field -- and bus-client's `serialize()` emits `location`,
+`is_speaking`, `is_recording`, `system_unit`, `time_format`, `date_format`,
+`active_skills` and `context` unconditionally -- counted as carried, so a
+minimal inbound default-session message (e.g. `{"session_id": "default",
+"lang": "en-us"}`) silently overwrote previously stored default-session
+state such as `location_preferences`, `is_speaking`, `blacklisted_skills`
+and `intent_context` with deployment defaults. `Session.deserialize()` now
+stamps `wire_payload` on the object it returns, matching the
+`ovos_spec_tools.session.Session.from_dict()` contract. This requires
+`ovos-spec-tools>=1.9.1a1`, which shipped the `wire_payload`-aware
+`merge_from()`/`_store()` behavior this fix activates.
+
 ## 2.10.0a2
 
 A clean `close()` could still surface `RuntimeError: cannot schedule new

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1,5 +1,6 @@
 import enum
 import time
+from copy import deepcopy
 from threading import Event, RLock
 from typing import Optional, List, Tuple, Union, Iterable, Dict, Any
 from uuid import uuid4
@@ -1261,7 +1262,7 @@ class Session(_SpecSession):
         is_recording = data.get("is_recording", False)
         is_speaking = data.get("is_speaking", False)
 
-        return Session(uid,
+        sess = Session(uid,
                        active_skills=active,
                        utterance_states=states,
                        lang=lang,
@@ -1277,6 +1278,17 @@ class Session(_SpecSession):
                        blacklisted_intents=blacklisted_intents,
                        blacklisted_skills=blacklisted_skills,
                        **canonical_kwargs)
+        # OVOS-SESSION-2 §5.1: SessionManager._store's default-session merge
+        # (Session.merge_from) is presence-aware only when the deserialized
+        # object still carries the arrival snapshot on ``wire_payload`` — a
+        # Session built without one is treated as its own baseline, so every
+        # field it presents (bus-client emits the full overlay unconditionally
+        # in ``serialize()``) counts as carried and clobbers stored state that
+        # the arriving message never actually mentioned. Stamp it here to match
+        # the ``_SpecSession.from_dict`` contract this method otherwise
+        # replicates by hand.
+        sess.wire_payload = deepcopy(data)
+        return sess
 
     # update_from is inherited from ovos_spec_tools.session.Session: it rebuilds
     # via type(self).deserialize(other.serialize()), so a bus-client Session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "ovos-config>=1.0.0,<4.0.0",
     "ovos-utils>=0.8.2,<1.0.0",
-    "ovos-spec-tools[langcodes]>=1.7.0a1",  # narrowed is_intent_topic + intent-pair mirror guard
+    "ovos-spec-tools[langcodes]>=1.9.1a1",  # SESSION-2 §5.1 default-session field-merge (wire_payload presence)
     "websocket-client>=0.54.0",
     "pyee>=8.1.0,<13.0.0",
 ]

--- a/test/unittests/test_session_default_merge.py
+++ b/test/unittests/test_session_default_merge.py
@@ -1,0 +1,102 @@
+import unittest
+
+
+class TestSessionDeserializeWirePayload(unittest.TestCase):
+    """OVOS-SESSION-2 §5.1: SessionManager._store's default-session fold
+    (Session.merge_from) is presence-aware only when the deserialized
+    Session still carries the arrival snapshot on ``wire_payload``.
+    ``Session.deserialize`` must stamp it, matching the
+    ``ovos_spec_tools.session.Session.from_dict`` contract.
+    """
+
+    def test_deserialize_stamps_wire_payload(self):
+        from ovos_bus_client.session import Session
+        payload = {"session_id": "default", "lang": "en-us",
+                   "site_id": "somewhere"}
+        sess = Session.deserialize(payload)
+        self.assertEqual(sess.wire_payload, payload)
+
+    def test_deserialize_empty_payload_still_stamped(self):
+        from ovos_bus_client.session import Session
+        sess = Session.deserialize({})
+        # even an empty wire payload is a real arrival snapshot (all fields
+        # omitted = all fields carried-as-unset), never None
+        self.assertIsNotNone(sess.wire_payload)
+        self.assertEqual(sess.wire_payload, {})
+
+    def test_from_message_stamps_wire_payload(self):
+        from ovos_bus_client.session import Session
+        from ovos_bus_client.message import Message
+        payload = {"session_id": "default", "lang": "pt-pt"}
+        msg = Message("recognizer_loop:utterance",
+                      context={"session": payload})
+        sess = Session.from_message(msg)
+        self.assertEqual(sess.wire_payload, payload)
+
+
+class TestSessionManagerDefaultSessionFieldMerge(unittest.TestCase):
+    """End-to-end repro of the §5.1 defect: a minimal inbound default-session
+    message must not clobber previously-stored default-session state it
+    never mentioned.
+    """
+
+    def setUp(self):
+        from ovos_bus_client.session import SessionManager
+        SessionManager.sessions.clear()
+        SessionManager.default_session = None
+
+    def tearDown(self):
+        from ovos_bus_client.session import SessionManager
+        SessionManager.sessions.clear()
+        SessionManager.default_session = None
+
+    def test_minimal_default_session_message_does_not_clobber(self):
+        from ovos_bus_client.session import Session, SessionManager
+
+        first = Session.deserialize({
+            "session_id": "default",
+            "lang": "en-us",
+            "intent_context": {"naptime:sleeping": [{"entities": [],
+                                                      "metadata": {}}]},
+            "location": {"city": {"name": "Lisbon"}},
+            "is_speaking": True,
+        })
+        SessionManager.update(first)
+
+        stored = SessionManager.sessions["default"]
+        self.assertTrue(stored.is_speaking)
+        self.assertIn("naptime:sleeping", stored.intent_context)
+        self.assertEqual(stored.location_preferences["city"]["name"], "Lisbon")
+
+        second = Session.deserialize({"session_id": "default", "lang": "en-us"})
+        SessionManager.update(second)
+
+        stored = SessionManager.sessions["default"]
+        self.assertTrue(stored.is_speaking,
+                         "is_speaking got clobbered by a minimal inbound "
+                         "default-session message that never mentioned it")
+        self.assertIn("naptime:sleeping", stored.intent_context,
+                       "intent_context got wiped by a minimal inbound "
+                       "default-session message that never mentioned it")
+        self.assertEqual(stored.location_preferences["city"]["name"], "Lisbon",
+                          "location_preferences got wiped by a minimal inbound "
+                          "default-session message that never mentioned it")
+
+    def test_post_deserialize_mutation_still_reaches_store(self):
+        """A touch()-shape flow: deserialize, mutate a field, then hand the
+        object to SessionManager.update — the mutated field must land in the
+        singleton store (wire_payload stamping must not freeze the snapshot
+        against later in-process mutation).
+        """
+        from ovos_bus_client.session import Session, SessionManager
+
+        sess = Session.deserialize({"session_id": "default", "lang": "en-us"})
+        sess.site_id = "kitchen"
+        SessionManager.update(sess)
+
+        stored = SessionManager.sessions["default"]
+        self.assertEqual(stored.site_id, "kitchen")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

`Session.deserialize()` harvested canonical fields via `_SpecSession.from_dict()` on a throwaway instance, then threw that instance away and built a fresh `Session` by hand-enumerated constructor call. The instance `from_dict()` builds is the one ovos-spec-tools stamps with `wire_payload`, so the object bus-client actually returned to every caller was always snapshot-less.

`SessionManager._store()`, inherited from ovos-spec-tools, uses `wire_payload` to implement OVOS-SESSION-2 §5.1: for the reserved default-session id, an omitted inbound field must leave the stored field unchanged, and that reading only works when the incoming object still carries its arrival snapshot. A snapshot-less object is treated as its own baseline, so every field it presents counts as carried. Since bus-client's `serialize()` unconditionally emits `location`, `is_speaking`, `is_recording`, `system_unit`, `time_format`, `date_format`, `active_skills` and `context`, a minimal inbound default-session message (just `session_id` and `lang`) silently overwrote previously stored default-session state — location preferences, `is_speaking`, `blacklisted_skills`, `intent_context` — with deployment defaults.

The fix stamps `sess.wire_payload = deepcopy(data)` on the object `Session.deserialize()` actually returns, matching the `from_dict()` contract. `Session.from_message()` delegates to `deserialize()`, so it inherits the fix without a separate edit; `SessionManager.reset_default_session()` also goes through `deserialize()` and is left untouched, since a fresh reset baseline correctly carrying only `session_id` is the intended behavior there. The floor pin on `ovos-spec-tools` is bumped to `>=1.9.1a1`, the version that shipped the `wire_payload`-aware `merge_from()`/`_store()` this activates.

Fail-before: with only the `session.py` hunk reverted, 4 of the 5 new regression tests go red — `wire_payload` reads back `None` instead of the arrival dict, and after a second minimal default-session message `is_speaking` reads `False` instead of the previously stored `True`. With the fix restored all 5 pass. The full existing suite runs 840 passed / 6 skipped on `dev` and 845 passed / 6 skipped on this branch — the delta is exactly the 5 new tests, nothing else changed status.

A `docs/prerelease-quirks.md` entry documents the behavior change for anyone tracking bus-client alphas.