### PR TITLE
fix: reach the session registry through its public API, not _store

### DIFF
--- a/ovos_bus_client/client/async_client.py
+++ b/ovos_bus_client/client/async_client.py
@@ -38,7 +38,9 @@ from ovos_bus_client.client.client import (_bus_flag,
                                            _compute_legacy_namespace_twin)
 from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf
 from ovos_bus_client.message import Message, CollectionMessage
-from ovos_bus_client.session import SessionManager, Session
+from ovos_bus_client.session import (SessionManager, Session,
+                                     DEFAULT_SESSION_ID, HAS_FOLD_INBOUND,
+                                     names_the_default, session_carrier)
 
 
 class AsyncMessageWaiter:
@@ -218,7 +220,10 @@ class AsyncMessageBusClient:
         if session:
             SessionManager.update(session)
         else:
-            session = SessionManager.default_session
+            session = SessionManager.get_default_session()
+        # see MessageBusClient.__init__ -- OVOS-SESSION-2 §2.5/§6.4 make this
+        # client the authority on a named session it was built with
+        self.session = session
         self.session_id = session.session_id
         self.on("ovos.session.update_default", self._on_default_session_update)
 
@@ -288,9 +293,14 @@ class AsyncMessageBusClient:
 
     async def _on_message(self, raw: str):
         parsed = Message.deserialize(raw)
-        sess = Session.from_message(parsed)
-        if sess.session_id != "default":
-            SessionManager.update(sess)
+        # see MessageBusClient._take_inbound_session
+        carrier = session_carrier(parsed)
+        if HAS_FOLD_INBOUND and names_the_default(carrier):
+            SessionManager.fold_inbound(parsed)
+        else:
+            sess = Session.from_message(parsed)
+            if sess.session_id != DEFAULT_SESSION_ID:
+                SessionManager.update(sess)
         self.emitter.emit("message", raw)
         self.emitter.emit(parsed.msg_type, parsed)
 
@@ -327,8 +337,10 @@ class AsyncMessageBusClient:
             message: Message to send
         """
         if "session" not in message.context:
-            sess = (SessionManager.sessions.get(self.session_id)
-                    or Session(self.session_id))
+            # see MessageBusClient._own_session
+            sess = (SessionManager.get_default_session()
+                    if self.session_id == DEFAULT_SESSION_ID
+                    else self.session or Session(self.session_id))
             message.context["session"] = sess.serialize()
 
         try:

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -25,7 +25,9 @@ from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf, 
 from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      MalformedMessage,
                                      encrypt_as_dict, decrypt_from_dict)
-from ovos_bus_client.session import SessionManager, Session, MalformedSession
+from ovos_bus_client.session import (SessionManager, Session, MalformedSession,
+                                     DEFAULT_SESSION_ID, HAS_FOLD_INBOUND,
+                                     names_the_default, session_carrier)
 from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
 
 # --- legacy intent-topic compat (non-normative migration tooling) ----------
@@ -350,8 +352,11 @@ class MessageBusClient:
         if session:
             SessionManager.update(session)
         else:
-            session = SessionManager.default_session
-
+            session = SessionManager.get_default_session()
+        # OVOS-SESSION-2 §2.5/§6.4: this client IS the client that owns a named
+        # session, so the object it was built with is the authority on it --
+        # the orchestrator's registry holds no named session to look it up in.
+        self.session = session
         self.session_id = session.session_id
         self.on("ovos.session.update_default",
                 self.on_default_session_update)
@@ -484,7 +489,7 @@ class MessageBusClient:
             LOG.warning("discarding malformed bus message: %s", e)
             return
         try:
-            sess = Session.from_message(parsed_message)
+            self._take_inbound_session(parsed_message)
         except MalformedSession as e:
             # A non-object session carrier is a per-message producer fault, not a
             # transport fault (SESSION-1 §2.5): drop this one message and keep the
@@ -492,8 +497,6 @@ class MessageBusClient:
             # so a single bad producer could hold the client in a reconnect loop.
             LOG.warning("discarding bus message with malformed session: %s", e)
             return
-        if sess.session_id != "default": # 'default' can only be updated by core
-            SessionManager.update(sess)
         # RULE 2 dedup marker: read it, then POP it before any local dispatch.
         # The marker rode the wire (a different process's RULE 2 needs it to skip
         # the twin), but once here it must not survive onto descendant frames:
@@ -576,6 +579,46 @@ class MessageBusClient:
             return
         self.emitter.emit(canonical, _verbatim_copy(message, canonical))
 
+    def _own_session(self) -> Session:
+        """The session this client stamps on a message that carries none.
+
+        The default session is the orchestrator's store, so it is read live and
+        a reset is picked up. A named session is client-owned (OVOS-SESSION-2
+        §2.5) and this client is the client that owns it (§6.4), so the object
+        it was constructed with is the authority -- no registry holds a named
+        session to look one up in, and fabricating an empty one from the id
+        alone would put a session on the wire the client never had.
+        """
+        if self.session_id == DEFAULT_SESSION_ID:
+            return SessionManager.get_default_session()
+        return self.session or Session(self.session_id)
+
+    def _take_inbound_session(self, message: Message):
+        """Take an arriving message's session into whatever state holds it.
+
+        A carrier that names no usable id IS the default session (SESSION-1
+        §3.1), which is why the branch is taken off the raw carrier rather than
+        off a parsed Session: parsing rejects an empty or wrong-typed id, and
+        rejecting it here would silently discard a message the spec says to
+        route to the default session.
+
+        For the default session that means the OVOS-SESSION-2 §5.1 arrival
+        merge, which folds the carrier into the store field by field so an
+        omitted field leaves the stored one standing. A named session is
+        client-owned and the orchestrator holds nothing for it (§2.2), so it
+        only goes through ``update``, which is a no-op wherever the registry
+        honours §2.2 and the utterance-scoped registration on older releases.
+
+        @raises MalformedSession: the message carries a non-object session
+        """
+        carrier = session_carrier(message)
+        if HAS_FOLD_INBOUND and names_the_default(carrier):
+            SessionManager.fold_inbound(message)
+            return
+        sess = Session.from_message(message)
+        if sess.session_id != DEFAULT_SESSION_ID:
+            SessionManager.update(sess)
+
     def on_default_session_update(self, message):
         new_session = message.data["session_data"]
         sess = Session.deserialize(new_session)
@@ -596,9 +639,7 @@ class MessageBusClient:
             message (Message): Message to send
         """
         if "session" not in message.context:
-            sess = SessionManager.sessions.get(self.session_id) or \
-                   Session(self.session_id)
-            message.context["session"] = sess.serialize()
+            message.context["session"] = self._own_session().serialize()
 
         # a single logical emit puts exactly ONE message on the wire. The
         # namespace counterpart is bridged to listeners on the RECEIVE side

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -21,6 +21,60 @@ from ovos_bus_client.version import VERSION_MAJOR
 # version.py so the warning text can never drift out of date.
 _NEXT_MAJOR_VERSION = f"{VERSION_MAJOR + 1}.0.0"
 
+# The bus overrides below are grafted ONTO the spec-tools registry class (see
+# _BusSessionManagerMixin), so by the time they run ``SessionManager.get`` /
+# ``.update`` already resolve to the overrides. The registry's own
+# implementations are stashed on the class the first time this module is
+# imported and read back from there afterwards -- binding them straight off the
+# class would capture the overrides on a re-import and recurse forever.
+if not hasattr(_SpecSessionManager, "_pre_graft"):
+    _SpecSessionManager._pre_graft = {"get": _SpecSessionManager.get.__func__,
+                                      "update": _SpecSessionManager.update.__func__}
+_spec_get = _SpecSessionManager._pre_graft["get"]
+_spec_update = _SpecSessionManager._pre_graft["update"]
+
+#: ``SessionManager.fold_inbound`` is the OVOS-SESSION-2 §5.1 arrival merge: it
+#: takes the raw carrier off an inbound Message and merges it into the
+#: default-session store. Older spec-tools releases have no arrival point and
+#: fold lazily inside ``get`` instead, so the receive path only calls it where
+#: the registry offers it.
+HAS_FOLD_INBOUND = hasattr(_SpecSessionManager, "fold_inbound")
+
+
+def session_carrier(message) -> Dict[str, Any]:
+    """The raw session carrier off a Message, as it arrived.
+
+    An absent ``session``, an explicit ``null`` and ``{}`` all mean the same
+    thing (SESSION-1 §2.1) and come back as the empty carrier. A carrier that
+    is present but not an object is malformed (§2.5) and raises rather than
+    quietly resolving to the default session, which would route the message
+    into a session it never named.
+
+    @param message: Message to read the carrier from
+    @return: the carrier dict, empty when the message carries no session
+    @raises MalformedSession: the carrier is present but not an object
+    """
+    carrier = (getattr(message, "context", None) or {}).get("session")
+    if carrier is None:
+        return {}
+    if not isinstance(carrier, dict):
+        raise MalformedSession("session must be a JSON object (§2.5)")
+    return carrier
+
+
+def names_the_default(carrier: Dict[str, Any]) -> bool:
+    """Whether a raw session carrier names the reserved default session.
+
+    SESSION-1 §3.1: an omitted ``session_id`` is the default session, and so is
+    any value that cannot serve as an identity — §6 requires a non-empty string
+    when the field is set, so an empty or wrong-typed one reads as omitted
+    rather than as a session no message can name. Older spec-tools releases
+    have no such predicate and treat only the literal id that way.
+    """
+    if HAS_FOLD_INBOUND:
+        return _SpecSessionManager._names_the_default(carrier)
+    return carrier.get("session_id", DEFAULT_SESSION_ID) == DEFAULT_SESSION_ID
+
 
 def _get_default_lang() -> str:
     """Read the runtime-configured default lang.
@@ -1333,8 +1387,9 @@ class _BusSessionManagerMixin:
 
     Adds the bus integration — default-session broadcast, recording / speaking
     state handlers, intent-context sync — and overrides ``get`` / ``update`` /
-    ``reset_default_session`` with the bus-flavoured variants. The folding,
-    ``_store`` and ``sync_message_session`` stamping stay the spec-tools base's.
+    ``reset_default_session`` with the bus-flavoured variants. Which state a
+    read or a write touches, and the ``sync_message_session`` stamping, stay
+    the spec-tools registry's.
     """
     bus = None
 
@@ -1428,17 +1483,19 @@ class _BusSessionManagerMixin:
             # this log is dangerous, session may contain things like passwords and access keys
             # this comment is here to avoid reintroducing it by accident
             # LOG.debug(f"replacing default session with: {sess.serialize()}") # DO NOT re-enable in production
-        return cls._store(sess)
+        return _spec_update(cls, sess)
 
     @classmethod
     def get(cls, message: Optional[Message] = None) -> Session:
         """
         Get the active session for a given Message
 
-        Adds the bus-client niceties over the spec-tools base: a
-        ``dig_for_message`` fallback and the legacy ``Session.from_message``
-        extraction (which carries the context ``lang`` onto a session that
-        omits it). Folding onto the shared singleton is the base's job.
+        Adds one bus-client nicety over the spec-tools base — the
+        ``dig_for_message`` fallback. Resolving the carrier to a session is the
+        registry's job and stays there, including whether a read touches stored
+        state at all, and the message is left exactly as it arrived: a read that
+        edited the carrier would make the answer depend on how often it was
+        asked, and the edit would ride onward on every derived message.
 
         @param message: Message to get session for
         @return: Session from message or default_session
@@ -1447,10 +1504,12 @@ class _BusSessionManagerMixin:
         if message is None:
             LOG.debug("No message, use default session")
             return cls.get_default_session()
-        # every session — including the default id — folds onto the one live
-        # object for its id (the wire is value-passing; nothing is owner-only).
-        msg_sess = Session.from_message(message)
-        return cls._store(msg_sess) if msg_sess else cls.get_default_session()
+        if message.context.get("session") is None:
+            LOG.warning(f"No session context in message:{message.msg_type}")
+            LOG.debug(f"Update ovos-bus-client or add `session` to "
+                      f"`message.context` where emitted. "
+                      f"context={message.context}")
+        return _spec_get(cls, message)
 
     @staticmethod
     def touch(message: Message = None):
@@ -1535,35 +1594,78 @@ class _BusSessionManagerMixin:
         event.wait(timeout=timeout)
         cls.bus.remove("recognizer_loop:record_end", handle_rec_end)
 
+    @classmethod
+    def held_session(cls, session_id: str) -> Optional[Session]:
+        """The live Session object this process holds for ``session_id``.
+
+        The default session is the store, which every process holds. A named
+        session is client-owned (OVOS-SESSION-2 §2.5) and the orchestrator is
+        stateless for it (§2.2), so the only named session this process holds
+        is the one its bus client was built with. A different named id seen in
+        passing belongs to another client: there is nothing here to carry its
+        state on, and inventing somewhere to keep it would be the durable
+        cross-utterance state §2.2 forbids.
+
+        @param session_id: session id to resolve
+        @return: the live Session, or None when this process holds none
+        """
+        if session_id in (None, DEFAULT_SESSION_ID):
+            return cls.get_default_session()
+        # the client's own session wins over anything the registry happens to
+        # hold: §2.5 makes the client authoritative, and the registry entry is
+        # at most the utterance-scoped cache older releases keep. The registry
+        # is connected to whatever bus object a process supplies
+        # (MessageBusClient, a test double, or nothing at all), and only a real
+        # client carries the session it was built with.
+        held = getattr(cls.bus, "session", None)
+        if isinstance(held, _SpecSession) and held.session_id == session_id:
+            return held
+        return cls.sessions.get(session_id)
+
     ###############################
     # State tracking events
     @classmethod
+    def _track_audio_state(cls, message, **flags):
+        """Record a client-authoritative audio flag on the session it describes.
+
+        ``is_recording`` / ``is_speaking`` report what a client's own hardware
+        is doing, so OVOS-SESSION-2 §2.5 makes the client the authority and the
+        event only tells this process what happened. Where the flag lands
+        follows who holds the session: the default session is the store and the
+        write goes through ``update`` (§5.1), while a named session lands on the
+        object this process holds for that id, if it holds one at all.
+        """
+        sess = cls.get(message)
+        for attr, value in flags.items():
+            setattr(sess, attr, value)
+        cls.update(sess)
+        held = cls.held_session(sess.session_id)
+        if held is None:
+            LOG.debug(f"not tracking audio state for session "
+                      f"'{sess.session_id}': it belongs to another client")
+        elif held is not sess:
+            for attr, value in flags.items():
+                setattr(held, attr, value)
+
+    @classmethod
     def handle_recording_start(cls, message):
         """track when a session is recording audio"""
-        sess = cls.get(message)
-        sess.is_recording = True
-        cls.update(sess)
+        cls._track_audio_state(message, is_recording=True)
 
     @classmethod
     def handle_recording_end(cls, message):
         """track when a session stops recording audio"""
-        sess = cls.get(message)
-        sess.is_recording = False
-        cls.update(sess)
+        cls._track_audio_state(message, is_recording=False)
 
     @classmethod
     def handle_audio_output_start(cls, message):
         """track when a session is outputting audio"""
-        sess = cls.get(message)
-        sess.is_speaking = True
-        cls.update(sess)
+        cls._track_audio_state(message, is_speaking=True)
 
     @classmethod
     def handle_audio_output_end(cls, message):
         """track when a session stops outputting audio"""
-        sess = cls.get(message)
-        sess.is_speaking = False
-        cls.update(sess)
+        cls._track_audio_state(message, is_speaking=False)
 
     @staticmethod
     def merge_intent_context(target: Dict[str, Any],
@@ -1622,9 +1724,15 @@ class _BusSessionManagerMixin:
         if carried:
             inbound = Session.from_message(message)
             if inbound:
-                # a session we have never seen is adopted from the carrier
-                sess = cls.sessions.get(inbound.session_id, inbound)
+                sess = cls.held_session(inbound.session_id)
                 payload = inbound.intent_context
+                if sess is None:
+                    # a named session this process does not hold is another
+                    # client's state (§2.2/§2.5) -- there is nothing to merge
+                    # onto, and keeping it would outlive its utterance
+                    LOG.debug(f"ignoring intent_context sync for unheld "
+                              f"session '{inbound.session_id}'")
+                    return
                 if sess is not inbound and payload:
                     with _CONTEXT_LOCK:
                         if sess.intent_context is None:

--- a/test/unittests/test_client_more.py
+++ b/test/unittests/test_client_more.py
@@ -8,7 +8,8 @@ from unittest.mock import MagicMock, patch
 from ovos_bus_client.client.client import (GUIWebsocketClient,
                                            MessageBusClient)
 from ovos_bus_client.message import GUIMessage, Message
-from ovos_bus_client.session import Session, SessionManager
+from ovos_bus_client.session import (Session, SessionManager,
+                                     HAS_FOLD_INBOUND)
 from websocket import (WebSocketConnectionClosedException, WebSocketException)
 
 
@@ -98,8 +99,7 @@ class TestOnDefaultSessionUpdate(TestCase):
 
 
 class TestOnMessageSessionUpdate(TestCase):
-    def test_non_default_session_is_registered(self):
-        # default = Session("default")
+    def test_named_session_is_taken_in_without_disturbing_the_store(self):
         SessionManager.sessions = {"default": Session("default")}
         bus = MessageBusClient()
         bus.client = MagicMock()
@@ -107,7 +107,13 @@ class TestOnMessageSessionUpdate(TestCase):
         s = Session("kitchen", lang="pt-pt")
         raw = Message("speak", {}, {"session": s.serialize()}).serialize()
         bus.on_message(raw)
-        self.assertIn("kitchen", SessionManager.sessions)
+        # a named session on the wire never lands in the default store
+        self.assertNotEqual(SessionManager.get_default_session().lang, "pt-PT")
+        if HAS_FOLD_INBOUND:
+            # §2.2: and it leaves no cross-utterance registry state either
+            self.assertNotIn("kitchen", SessionManager.sessions)
+        else:
+            self.assertIn("kitchen", SessionManager.sessions)
 
 
 class TestTwoArgDispatch(TestCase):

--- a/test/unittests/test_default_session_fold.py
+++ b/test/unittests/test_default_session_fold.py
@@ -1,0 +1,77 @@
+"""OVOS-SESSION-2 §5.1 — an arriving default session merges into the store.
+
+The receive path hands the raw Message to ``SessionManager.fold_inbound``, so a
+field the message omits leaves the stored value standing. That merge only
+exists once the registry offers an arrival point; older spec-tools releases
+fold lazily inside ``get`` and these tests do not apply to them.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.client.client import MessageBusClient
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import SessionManager, HAS_FOLD_INBOUND
+
+
+def _inbound(carrier):
+    return Message("recognizer_loop:utterance", {"utterances": ["hello"]},
+                   {"session": carrier}).serialize()
+
+
+@unittest.skipUnless(HAS_FOLD_INBOUND,
+                     "spec-tools registry has no fold_inbound arrival point")
+class TestDefaultSessionFoldOnReceive(unittest.TestCase):
+    def setUp(self):
+        SessionManager.reset_default_session()
+        self.bus = MessageBusClient()
+        self.bus.client = MagicMock()
+        self.bus.connected_event.set()
+
+    def tearDown(self):
+        SessionManager.reset_default_session()
+
+    def test_omitted_fields_survive_the_next_arrival(self):
+        self.bus.on_message(_inbound({"session_id": "default",
+                                      "lang": "pt-pt",
+                                      "site_id": "kitchen"}))
+        stored = SessionManager.get_default_session()
+        self.assertEqual(stored.lang, "pt-PT")
+        self.assertEqual(stored.site_id, "kitchen")
+
+        # a minimal second arrival carries no lang and no site_id, so §5.1
+        # leaves both stored values alone
+        self.bus.on_message(_inbound({"session_id": "default"}))
+        self.assertIs(SessionManager.get_default_session(), stored)
+        self.assertEqual(stored.lang, "pt-PT")
+        self.assertEqual(stored.site_id, "kitchen")
+
+    def test_carried_field_replaces_the_stored_one(self):
+        self.bus.on_message(_inbound({"session_id": "default",
+                                      "lang": "pt-pt",
+                                      "site_id": "kitchen"}))
+        self.bus.on_message(_inbound({"session_id": "default",
+                                      "site_id": "bedroom"}))
+        stored = SessionManager.get_default_session()
+        self.assertEqual(stored.site_id, "bedroom")
+        self.assertEqual(stored.lang, "pt-PT")
+
+    def test_absent_carrier_is_the_default_session(self):
+        self.bus.on_message(_inbound({"session_id": "default",
+                                      "site_id": "kitchen"}))
+        raw = Message("recognizer_loop:utterance",
+                      {"utterances": ["hello"]}).serialize()
+        self.bus.on_message(raw)
+        self.assertEqual(SessionManager.get_default_session().site_id,
+                         "kitchen")
+
+    def test_named_session_leaves_the_default_store_alone(self):
+        self.bus.on_message(_inbound({"session_id": "default",
+                                      "site_id": "kitchen"}))
+        self.bus.on_message(_inbound({"session_id": "kitchen-sat",
+                                      "site_id": "bedroom"}))
+        self.assertEqual(SessionManager.get_default_session().site_id,
+                         "kitchen")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_session.py
+++ b/test/unittests/test_session.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import patch
 from time import time, sleep
 
+from ovos_bus_client.session import HAS_FOLD_INBOUND
+
 
 class TestSessionModule(unittest.TestCase):
     def test_utterance_state(self):
@@ -250,24 +252,30 @@ class TestSessionManager(unittest.TestCase):
         self.assertEqual(session, self.SessionManager.default_session)
         # TODO
 
-    def test_update(self):
+    def test_update_writes_the_default_store_in_place(self):
         from ovos_bus_client.session import Session
-        sess = Session("sid-update")
-        # update returns the canonical (singleton) object for the id
-        canonical = self.SessionManager.update(sess)
-        self.assertIs(canonical, sess)
-        self.assertIs(self.SessionManager.sessions["sid-update"], sess)
-
-        # a second snapshot for the same id is folded onto the singleton in
-        # place — the original object identity is preserved, not replaced
-        snapshot = Session("sid-update")
+        stored = self.SessionManager.get_default_session()
+        snapshot = Session("default")
         snapshot.lang = "pt-PT"
         returned = self.SessionManager.update(snapshot)
-        self.assertIs(returned, sess)
-        self.assertIsNot(returned, snapshot)
-        self.assertEqual(sess.lang, "pt-PT")
+        # the store keeps its identity across a write -- components hold
+        # references to it, so a write may never swap the object out
+        self.assertIs(returned, stored)
+        self.assertIs(self.SessionManager.get_default_session(), stored)
+        self.assertEqual(stored.lang, "pt-PT")
 
-    def test_get_returns_singleton(self):
+    def test_update_hands_a_named_session_straight_back(self):
+        from ovos_bus_client.session import Session
+        sess = Session("sid-update")
+        self.assertIs(self.SessionManager.update(sess), sess)
+        if HAS_FOLD_INBOUND:
+            # OVOS-SESSION-2 §2.2: the orchestrator keeps no state for a named
+            # session, so a write records nothing and the caller keeps the object
+            self.assertNotIn("sid-update", self.SessionManager.sessions)
+        else:
+            self.assertIs(self.SessionManager.sessions["sid-update"], sess)
+
+    def test_get_resolves_the_named_session_on_the_message(self):
         from ovos_bus_client.session import Session
         from ovos_bus_client.message import Message
         sess = Session("sid-get")
@@ -275,39 +283,57 @@ class TestSessionManager(unittest.TestCase):
 
         first = self.SessionManager.get(msg)
         second = self.SessionManager.get(msg)
-        # every get() for the same id hands back the one live object, even
-        # though each message carries its own serialized snapshot
-        self.assertIs(first, second)
-        self.assertIs(self.SessionManager.sessions["sid-get"], first)
+        self.assertEqual(first.session_id, "sid-get")
+        self.assertEqual(second.session_id, "sid-get")
+        if HAS_FOLD_INBOUND:
+            # OVOS-SESSION-2 §2.2: the orchestrator is stateless for a named
+            # session, and §2.6 makes get a pure read — it builds the session
+            # the carrier describes and registers nothing
+            self.assertIsNot(first, second)
+            self.assertNotIn("sid-get", self.SessionManager.sessions)
+        else:
+            self.assertIs(first, second)
+            self.assertIs(self.SessionManager.sessions["sid-get"], first)
 
     def test_held_reference_observes_later_mutation(self):
         # the corner case the singleton fixes: a reference taken early in a
         # flow must see a flag flipped through a later snapshot of the same id
         from ovos_bus_client.session import Session
         from ovos_bus_client.message import Message
-        held = self.SessionManager.get(
-            Message("a", context={"session": Session("sid-flag").serialize()}))
-        self.assertFalse(held.is_speaking)
+        held = self.SessionManager.get_default_session()
+        held.is_speaking = False
 
-        speaking = Session("sid-flag")
+        speaking = Session("default")
         speaking.is_speaking = True
         self.SessionManager.update(speaking)
         # the early reference observes the mutation without being re-fetched
         self.assertTrue(held.is_speaking)
+        self.assertIs(self.SessionManager.get_default_session(), held)
 
     def test_forward_stamps_live_bus_session(self):
         # bus-client land: get -> mutate -> forward; the derived message carries
-        # the LIVE bus Session for its id (refresh, not the pre-mutation copy).
+        # the LIVE bus Session for the default id (refresh, not the pre-mutation
+        # copy), because the store is the only session this process is
+        # authoritative for.
         from ovos_bus_client.session import Session
         from ovos_bus_client.message import Message
-        live = self.SessionManager.get(
-            Message("a", context={"session": Session("sid-fwd").serialize()}))
+        live = self.SessionManager.get_default_session()
         live.activate_skill("my.skill")
-        derived = Message("utt", context={"session": {"session_id": "sid-fwd"}}
+        derived = Message("utt", context={"session": {"session_id": "default"}}
                           ).forward("my.skill.activate")
         skills = [s[0] for s in
                   Session.deserialize(derived.context["session"]).active_skills]
         self.assertIn("my.skill", skills)
+
+    def test_forward_carries_a_named_session_verbatim(self):
+        # OVOS-SESSION-2 §2.5: a named session is client-owned, so the carrier
+        # on the message is the only authority this process has for it
+        from ovos_bus_client.session import Session
+        from ovos_bus_client.message import Message
+        carrier = Session("sid-named", lang="pt-PT").serialize()
+        derived = Message("utt", context={"session": carrier}).forward("x")
+        self.assertEqual(
+            Session.deserialize(derived.context["session"]).lang, "pt-PT")
 
     def test_update_from_present_empty_overrides(self):
         # SESSION-1 §2: a snapshot that carries an (empty) value for a field
@@ -315,14 +341,17 @@ class TestSessionManager(unittest.TestCase):
         # not a self-preserving merge that keeps stale state.
         from ovos_bus_client.session import Session
         from ovos_bus_client.message import Message
-        held = self.SessionManager.get(
-            Message("a", context={"session": Session("sid-clear").serialize()}))
+        held = self.SessionManager.get_default_session()
         held.activate_skill("skill.foo")
         self.assertTrue(held.active_skills)
 
-        # a later snapshot with no active skills must clear the singleton
-        self.SessionManager.update(Session("sid-clear"))
-        self.assertEqual(held.active_skills, [])
+        # a snapshot that carries a value for a field replaces the stored one
+        self.SessionManager.update(Session("default", lang="pt-PT"))
+        self.assertEqual(held.lang, "pt-PT")
+        if HAS_FOLD_INBOUND:
+            # OVOS-SESSION-2 §2.6: a write is authoritative whole state, so the
+            # skills the snapshot does not carry are gone from the store too
+            self.assertEqual(held.active_skills, [])
 
     def test_update_from_does_not_alias_nested_state(self):
         # round-tripping through (de)serialize rebuilds nested objects, so the

--- a/test/unittests/test_session_authority.py
+++ b/test/unittests/test_session_authority.py
@@ -1,0 +1,173 @@
+"""OVOS-SESSION-2 §2.2 / §2.5 — who is authoritative for which session.
+
+The default session is the orchestrator's store and this process is
+authoritative for it. Every named session is client-owned: the client that
+holds it is the authority, the orchestrator keeps no state for it, and a named
+session seen in passing belongs to somebody else.
+"""
+import importlib
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import ovos_bus_client.session as session_module
+from ovos_bus_client.client.client import MessageBusClient
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import (Session, SessionManager, HAS_FOLD_INBOUND,
+                                     names_the_default, session_carrier)
+
+
+def _client(session=None):
+    bus = MessageBusClient(session=session)
+    bus.client = MagicMock()
+    bus.connected_event.set()
+    return bus
+
+
+class TestNamedClientEmitsItsOwnSession(unittest.TestCase):
+    """§2.5/§6.4 — a client emits the named session it holds, not a stand-in."""
+
+    def setUp(self):
+        SessionManager.reset_default_session()
+
+    def tearDown(self):
+        SessionManager.reset_default_session()
+        SessionManager.sessions.pop("kitchen-sat", None)
+
+    def test_named_session_round_trips_onto_the_wire(self):
+        held = Session("kitchen-sat", lang="pt-PT")
+        held.site_id = "kitchen"
+        bus = _client(held)
+
+        msg = Message("speak", {"utterance": "ola"})
+        bus.emit(msg)
+
+        carrier = Session.deserialize(msg.context["session"])
+        self.assertEqual(carrier.session_id, "kitchen-sat")
+        self.assertEqual(carrier.lang, "pt-PT")
+        self.assertEqual(carrier.site_id, "kitchen")
+
+    def test_default_client_emits_the_live_store(self):
+        bus = _client()
+        SessionManager.get_default_session().site_id = "hallway"
+        msg = Message("speak", {"utterance": "hi"})
+        bus.emit(msg)
+        self.assertEqual(
+            Session.deserialize(msg.context["session"]).site_id, "hallway")
+
+
+class TestFalsySessionIdIsTheDefaultSession(unittest.TestCase):
+    """SESSION-1 §3.1 — a carrier naming no usable id IS the default session."""
+
+    def setUp(self):
+        SessionManager.reset_default_session()
+        self.bus = _client()
+
+    def tearDown(self):
+        SessionManager.reset_default_session()
+
+    def test_predicate_reads_unusable_ids_as_the_default(self):
+        self.assertTrue(names_the_default({}))
+        self.assertTrue(names_the_default({"session_id": "default"}))
+        self.assertFalse(names_the_default({"session_id": "kitchen"}))
+        if HAS_FOLD_INBOUND:
+            for unusable in ("", 0, False, [], {}):
+                self.assertTrue(names_the_default({"session_id": unusable}),
+                                f"{unusable!r} names no session")
+
+    @unittest.skipUnless(HAS_FOLD_INBOUND, "no §3.1 predicate in the registry")
+    def test_empty_id_folds_into_the_store_and_still_dispatches(self):
+        seen = []
+        self.bus.on("speak", seen.append)
+        raw = Message("speak", {"utterance": "hi"},
+                      {"session": {"session_id": "", "lang": "pt-pt"}}).serialize()
+        self.bus.on_message(raw)
+        self.assertEqual(SessionManager.get_default_session().lang, "pt-PT")
+        self.assertEqual(len(seen), 1)
+
+    def test_malformed_carrier_is_still_rejected(self):
+        with self.assertRaises(session_module.MalformedSession):
+            session_carrier(Message("speak", {}, {"session": "not-an-object"}))
+
+
+class TestNamedSessionLeavesNoOrchestratorState(unittest.TestCase):
+    def setUp(self):
+        SessionManager.reset_default_session()
+        SessionManager.bus = None
+
+    def tearDown(self):
+        SessionManager.bus = None
+        SessionManager.sessions.pop("someone-else", None)
+
+    def test_unheld_named_session_is_not_held(self):
+        self.assertIsNone(SessionManager.held_session("someone-else"))
+
+    def test_the_clients_own_named_session_is_held(self):
+        held = Session("mine")
+        SessionManager.bus = SimpleNamespace(session=held)
+        self.assertIs(SessionManager.held_session("mine"), held)
+
+    def test_the_default_session_is_always_held(self):
+        self.assertIs(SessionManager.held_session("default"),
+                      SessionManager.get_default_session())
+
+
+class TestGetDoesNotTouchTheMessage(unittest.TestCase):
+    """A read answers a question; it may not edit what it was asked about."""
+
+    def test_get_leaves_the_carrier_exactly_as_it_arrived(self):
+        carrier = {"session_id": "sid-read"}
+        msg = Message("speak", {}, {"session": dict(carrier), "lang": "pt-PT"})
+        SessionManager.get(msg)
+        SessionManager.get(msg)
+        self.assertEqual(msg.context["session"], carrier)
+
+    @unittest.skipUnless(HAS_FOLD_INBOUND, "get folds on older registries")
+    def test_reading_a_default_message_does_not_move_the_store(self):
+        SessionManager.reset_default_session()
+        SessionManager.get_default_session().site_id = "kitchen"
+        msg = Message("speak", {}, {"session": {"session_id": "default"}})
+        SessionManager.get(msg)
+        self.assertEqual(SessionManager.get_default_session().site_id, "kitchen")
+
+
+class TestGraftIsIdempotent(unittest.TestCase):
+    """Re-importing the module must not stack the overrides onto themselves."""
+
+    def test_reload_does_not_recurse(self):
+        session_cls = SessionManager.session_cls
+        try:
+            importlib.reload(session_module)
+            # the overrides still reach the registry's own implementations
+            SessionManager.get(Message("speak", {}, {"session": {}}))
+            SessionManager.update(Session("default"))
+        finally:
+            SessionManager.session_cls = session_cls
+
+
+class TestTouchReplacesTheDefaultStore(unittest.TestCase):
+    """Pin the sharp edge in Session.touch, for whoever owns intake next.
+
+    ``touch`` writes the session back through ``update``. Once that write is
+    OVOS-SESSION-2 §2.6's authoritative whole-replace, touching a *stale copy*
+    of the default session silently drops every field the copy does not carry.
+    Nothing here relies on that; core's utterance-intake work has to decide
+    whether a bare timestamp bump should be a whole-store write at all.
+    """
+
+    def setUp(self):
+        SessionManager.reset_default_session()
+
+    def tearDown(self):
+        SessionManager.reset_default_session()
+
+    @unittest.skipUnless(HAS_FOLD_INBOUND, "older registries merge on write")
+    def test_stale_default_copy_wipes_uncarried_fields(self):
+        SessionManager.get_default_session().site_id = "kitchen"
+        stale = Session.deserialize({"session_id": "default", "lang": "en-US"})
+        stale.touch()
+        self.assertIsNone(SessionManager.get_default_session().site_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_session_extra.py
+++ b/test/unittests/test_session_extra.py
@@ -2,13 +2,15 @@
 Session methods, SessionManager handlers/utilities."""
 import time
 import unittest
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import (IntentContextManager,
                                      IntentContextManagerFrame, Session,
-                                     SessionManager, UtteranceState)
+                                     SessionManager, UtteranceState,
+                                     HAS_FOLD_INBOUND)
 
 
 def _reset_session_manager():
@@ -315,17 +317,26 @@ class TestSessionManager(TestCase):
         sess = SessionManager.get(msg)
         self.assertEqual(sess.session_id, "default")
 
-    def test_get_registers_non_default_session(self):
+    def test_get_resolves_non_default_session(self):
         s = Session("k")
         msg = Message("t", context={"session": s.serialize()})
         sess = SessionManager.get(msg)
         self.assertEqual(sess.session_id, "k")
-        self.assertIn("k", SessionManager.sessions)
+        if HAS_FOLD_INBOUND:
+            # a named session is client-owned (OVOS-SESSION-2 §2.2); reading one
+            # off a message leaves no cross-utterance state behind
+            self.assertNotIn("k", SessionManager.sessions)
+        else:
+            self.assertIn("k", SessionManager.sessions)
 
     def test_update_stores_session(self):
         s = Session("upd")
-        SessionManager.update(s)
-        self.assertIs(SessionManager.sessions["upd"], s)
+        self.assertIs(SessionManager.update(s), s)
+        if HAS_FOLD_INBOUND:
+            # §2.2: no orchestrator state for a named session, not even briefly
+            self.assertNotIn("upd", SessionManager.sessions)
+        else:
+            self.assertIs(SessionManager.sessions["upd"], s)
 
     def test_update_make_default(self):
         # "default" is a singleton: make_default folds the snapshot onto the
@@ -373,22 +384,62 @@ class TestSessionManager(TestCase):
         self.assertFalse(SessionManager.is_recording())
 
     def test_handle_recording_start_and_end(self):
-        s = Session("rec-1")
+        # the flag lands on the default store, which every process holds
         msg = Message("recognizer_loop:record_begin",
-                      context={"session": s.serialize()})
+                      context={"session": Session("default").serialize()})
         SessionManager.handle_recording_start(msg)
-        self.assertTrue(SessionManager.sessions["rec-1"].is_recording)
+        self.assertTrue(SessionManager.get_default_session().is_recording)
         SessionManager.handle_recording_end(msg)
-        self.assertFalse(SessionManager.sessions["rec-1"].is_recording)
+        self.assertFalse(SessionManager.get_default_session().is_recording)
+
+    def test_handle_recording_tracks_the_session_this_process_holds(self):
+        # OVOS-SESSION-2 §2.5: is_recording is client-authoritative, so a named
+        # session's flag lands on the object this process holds for that id
+        held = Session("rec-1")
+        SessionManager.bus = SimpleNamespace(session=held)
+        try:
+            msg = Message("recognizer_loop:record_begin",
+                          context={"session": Session("rec-1").serialize()})
+            SessionManager.handle_recording_start(msg)
+            self.assertTrue(held.is_recording)
+            SessionManager.handle_recording_end(msg)
+            self.assertFalse(held.is_recording)
+        finally:
+            SessionManager.bus = None
+
+    def test_handle_recording_ignores_another_clients_session(self):
+        held = Session("mine")
+        SessionManager.bus = SimpleNamespace(session=held)
+        try:
+            SessionManager.handle_recording_start(
+                Message("recognizer_loop:record_begin",
+                        context={"session": Session("theirs").serialize()}))
+            self.assertFalse(held.is_recording)
+            if HAS_FOLD_INBOUND:
+                self.assertIsNone(SessionManager.held_session("theirs"))
+        finally:
+            SessionManager.bus = None
 
     def test_handle_audio_output_start_and_end(self):
-        s = Session("aud-1")
         msg = Message("recognizer_loop:audio_output_start",
-                      context={"session": s.serialize()})
+                      context={"session": Session("default").serialize()})
         SessionManager.handle_audio_output_start(msg)
-        self.assertTrue(SessionManager.sessions["aud-1"].is_speaking)
+        self.assertTrue(SessionManager.get_default_session().is_speaking)
         SessionManager.handle_audio_output_end(msg)
-        self.assertFalse(SessionManager.sessions["aud-1"].is_speaking)
+        self.assertFalse(SessionManager.get_default_session().is_speaking)
+
+    def test_handle_audio_output_tracks_the_session_this_process_holds(self):
+        held = Session("aud-1")
+        SessionManager.bus = SimpleNamespace(session=held)
+        try:
+            msg = Message("recognizer_loop:audio_output_start",
+                          context={"session": Session("aud-1").serialize()})
+            SessionManager.handle_audio_output_start(msg)
+            self.assertTrue(held.is_speaking)
+            SessionManager.handle_audio_output_end(msg)
+            self.assertFalse(held.is_speaking)
+        finally:
+            SessionManager.bus = None
 
     def test_sync_emits_when_bus_attached(self):
         bus = MagicMock()

--- a/test/unittests/test_session_intent_context_sync.py
+++ b/test/unittests/test_session_intent_context_sync.py
@@ -1,10 +1,13 @@
 """OVOS-CONTEXT-1 §5.3 — SessionManager owns the ``ovos.session.sync``
 intent_context merge (set + null-delete), and ``intent_context`` round-trips
 through Session serialization."""
+from types import SimpleNamespace
+
 import pytest
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session, SessionManager
+from ovos_bus_client.session import (Session, SessionManager,
+                                     HAS_FOLD_INBOUND)
 
 
 @pytest.fixture(autouse=True)
@@ -44,32 +47,39 @@ def test_merge_empty_payload_is_noop():
     assert SessionManager.merge_intent_context(target, None) == {"a": {"value": 1}}
 
 
-def test_handle_session_sync_merges_onto_managed_session():
-    # a tracked session already holds some context
-    seeded = Session("s1")
-    seeded.intent_context = {"a": {"value": 1}, "b": {"value": 2}}
-    SessionManager.update(seeded)
+def test_handle_session_sync_merges_onto_the_session_this_process_holds():
+    # the session this client owns already holds some context
+    held = Session("s1")
+    held.intent_context = {"a": {"value": 1}, "b": {"value": 2}}
+    SessionManager.bus = SimpleNamespace(session=held)
+    try:
+        # a producer emits ovos.session.sync carrying a snapshot in context.session
+        snap = Session("s1")
+        snap.intent_context = {"b": None, "c": {"value": 3}}  # delete b, add c
+        SessionManager.handle_session_sync(
+            Message("ovos.session.sync", {}, {"session": snap.serialize()}))
+        # the held session reflects the entry-by-entry merge
+        assert held.intent_context == {"a": {"value": 1}, "c": {"value": 3}}
+    finally:
+        SessionManager.bus = None
 
-    # a producer emits ovos.session.sync carrying a snapshot in context.session
-    snap = Session("s1")
-    snap.intent_context = {"b": None, "c": {"value": 3}}  # delete b, add c
-    msg = Message("ovos.session.sync", {}, {"session": snap.serialize()})
 
-    SessionManager.handle_session_sync(msg)
-
-    # the singleton's managed session reflects the entry-by-entry merge
-    assert SessionManager.sessions["s1"].intent_context == {
-        "a": {"value": 1}, "c": {"value": 3}}
-
-
-def test_handle_session_sync_adopts_unseen_session():
-    snap = Session("s2")
-    snap.intent_context = {"k": {"value": 9}}
-    msg = Message("ovos.session.sync", {}, {"session": snap.serialize()})
-
-    SessionManager.handle_session_sync(msg)
-
-    assert SessionManager.sessions["s2"].intent_context == {"k": {"value": 9}}
+def test_handle_session_sync_ignores_another_clients_session():
+    # OVOS-SESSION-2 §2.2/§2.5: a named session this process does not hold is
+    # another client's state, and adopting it would be durable cross-utterance
+    # state the orchestrator is not allowed to keep
+    held = Session("s1")
+    SessionManager.bus = SimpleNamespace(session=held)
+    try:
+        snap = Session("s2")
+        snap.intent_context = {"k": {"value": 9}}
+        SessionManager.handle_session_sync(
+            Message("ovos.session.sync", {}, {"session": snap.serialize()}))
+        assert held.intent_context == {}
+        if HAS_FOLD_INBOUND:
+            assert "s2" not in SessionManager.sessions
+    finally:
+        SessionManager.bus = None
 
 
 def test_handle_bare_sync_request_does_not_crash():

--- a/test/unittests/test_session_sync_handler.py
+++ b/test/unittests/test_session_sync_handler.py
@@ -11,7 +11,8 @@ import unittest
 from unittest.mock import MagicMock
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session, SessionManager
+from ovos_bus_client.session import (Session, SessionManager,
+                                     HAS_FOLD_INBOUND)
 
 
 def _sync_message(session_dict):
@@ -78,13 +79,15 @@ class TestHandleSessionSync(unittest.TestCase):
         self.assertIs(sess.intent_context, held)
         self.assertIn("room", held)
 
-    def test_untracked_session_adopted(self):
+    def test_unheld_session_is_left_alone(self):
+        # §2.2/§2.5: a named session this process holds nothing for belongs to
+        # another client -- there is nowhere to merge it and nowhere to keep it
         SessionManager.handle_session_sync(_sync_message(
             {"session_id": "sync-new",
              "intent_context": {"person": {"value": "Bob"}}}))
-        sess = SessionManager.sessions.get("sync-new")
-        self.assertIsNotNone(sess)
-        self.assertEqual(sess.intent_context["person"], {"value": "Bob"})
+        if HAS_FOLD_INBOUND:
+            self.assertIsNone(SessionManager.sessions.get("sync-new"))
+        self.assertIsNone(SessionManager.held_session("sync-new"))
 
     def test_removal_propagates_end_to_end(self):
         """skill-side remove + sync deletes the entry on the managed session."""
@@ -93,7 +96,8 @@ class TestHandleSessionSync(unittest.TestCase):
         local = Session.deserialize(managed.serialize())
         local.remove_intent_context("person", scope="shared")
         SessionManager.handle_session_sync(_sync_message(local.serialize()))
-        self.assertNotIn("person", managed.intent_context)
+        self.assertNotIn("person",
+                         SessionManager.sessions["sync-6"].intent_context)
 
     def test_no_echo_for_spec_sync(self):
         """A session-carrying §5.3 sync is not a default-session request."""


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

`SessionManager.get` and `SessionManager.update` reached into the spec-tools registry's private `_store` to resolve a session carrier and to write a session back. `_store` is an implementation detail of one particular reading of OVOS-SESSION-2, not an API, and depending on it froze bus-client onto that reading. OpenVoiceOS/ovos-spec-tools#116 re-derives the merge from the spec and removes `_store` along with `Session.merge_from` / `Session.wire_payload`; against that branch every session call in this repo raises `AttributeError: type object 'SessionManager' has no attribute '_store'` — 112 test failures. This PR removes the dependency so it can land before #116 rather than after it. The published `ovos-spec-tools` 1.9.1a1 still has `_store` and no `fold_inbound`, so `dev` is not broken today and the landing order holds: this PR, then #116, then a floor bump to whatever alpha #116 publishes. The pin is deliberately untouched here.

Both overrides now call the registry's own `get` and `update`. Those are stashed on the registry class the first time this module is imported, because the bus methods are grafted *onto* that class — binding them straight off it works once and then captures the overrides on any re-import, so `importlib.reload` used to produce a `RecursionError`. What bus-client adds stays bus-client's, and what the registry decides stays the registry's, including whether a read touches stored state at all. Routing `get` through `update` would look like a tidy single code path and would wipe the default store on every read, since §2.6 makes a write a whole-replace. `get` also stops editing the message it was asked about: it used to inject a context `lang` into the carrier in place, which made a read move state and sent the injected value onward on every message derived from that one.

The receive path picks up the §5.1 arrival merge. An inbound default session goes to `SessionManager.fold_inbound`, which merges the raw carrier into the store field by field so a message that omits a field leaves the stored value standing. The default-versus-named branch is taken off the **raw carrier**, not off a parsed `Session`: SESSION-1 §3.1 makes a carrier naming no usable id (`""`, `0`, `[]`, …) the default session, while parsing rejects it as malformed — so the old branch discarded those messages entirely instead of folding and dispatching them. Worth being explicit about the scope: `fold_inbound` fires on **every** inbound default-session message in **every** bus-client process. That is a relocation of what `dev` already did lazily inside `get`, and it is broader than the spec's "orchestrator, once per inbound utterance". Narrowing it belongs to core's utterance-intake PR, not here.

Named sessions are client-owned and §2.2 leaves the orchestrator stateless for them, so this PR puts their state where it actually lives instead of in a registry that no longer holds it. A client stamps the session it was constructed with rather than one fabricated from the id — a `MessageBusClient` built with a rich named session had been emitting `{session_id, default lang, nothing else}` onto the wire. The audio-state handlers (`is_recording` / `is_speaking`, client-authoritative under §2.5) and the `ovos.session.sync` intent-context merge now resolve through `SessionManager.held_session`, which returns the store for the default id and the client's own object for a named one. A named id this process holds nothing for belongs to another client: the handlers log it at debug and stop, rather than inventing somewhere to keep it.

Existing session tests that asserted the singleton-per-id reading of the registry — rather than anything bus-client owns — now assert the invariant that holds either way and split only where the two published registries genuinely differ. The same applies to the `ovos.session.sync` adopt path, which used to assert that an unseen named session gets registered, which is precisely what §2.2 forbids.

Verified in both cells: **854 passed / 13 skipped** with the published 1.9.1a1, and **861 passed / 6 skipped** with #116 at `0d5de01` installed over it (a local, test-only `--no-deps` install; no pin change). Same 867 collected either way — the seven that skip on 1.9.1a1 cover behaviour that release does not have. Reverting each behaviour in turn turns its own test red: the emitted carrier reads `'en-US' != 'pt-PT'`; an empty `session_id` logs `discarding bus message with malformed session` instead of folding and dispatching; a read leaves `lang` behind on the caller's message; a reload raises `RecursionError`; and the default-session fold tests fail with the store never seeing the first arrival.

One thing pinned rather than fixed, in `test_session_authority.py`: `Session.touch()` writes the session back through `update`, and once that write is §2.6's authoritative whole-replace, touching a **stale copy of the default session** silently drops every field the copy does not carry — a bare timestamp bump wipes `site_id`. That is #116's intended semantics and not mine to redesign, but it is a sharp edge for whoever owns utterance intake next, so there is a test holding it in place rather than a comment.
