### PR TITLE
fix: stop folding the default session on every observed bus message

### DIFF
--- a/ovos_bus_client/client/async_client.py
+++ b/ovos_bus_client/client/async_client.py
@@ -38,8 +38,7 @@ from ovos_bus_client.client.client import (_bus_flag,
                                            _compute_legacy_namespace_twin)
 from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf
 from ovos_bus_client.message import Message, CollectionMessage
-from ovos_bus_client.session import (SessionManager, Session,
-                                     DEFAULT_SESSION_ID, HAS_FOLD_INBOUND,
+from ovos_bus_client.session import (SessionManager, Session, DEFAULT_SESSION_ID,
                                      resolve_session_id, session_carrier)
 
 
@@ -293,11 +292,10 @@ class AsyncMessageBusClient:
 
     async def _on_message(self, raw: str):
         parsed = Message.deserialize(raw)
-        # see MessageBusClient._take_inbound_session
+        # see MessageBusClient._take_inbound_session -- the §5.1 arrival fold
+        # is orchestrator-intake-only; this client only tracks named sessions.
         carrier = session_carrier(parsed)
-        if HAS_FOLD_INBOUND and resolve_session_id(carrier) == DEFAULT_SESSION_ID:
-            SessionManager.fold_inbound(parsed)
-        else:
+        if resolve_session_id(carrier) != DEFAULT_SESSION_ID:
             sess = Session.from_message(parsed)
             if sess.session_id != DEFAULT_SESSION_ID:
                 SessionManager.update(sess)

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -26,7 +26,7 @@ from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      MalformedMessage,
                                      encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import (SessionManager, Session, MalformedSession,
-                                     DEFAULT_SESSION_ID, HAS_FOLD_INBOUND,
+                                     DEFAULT_SESSION_ID,
                                      resolve_session_id, session_carrier)
 from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
 
@@ -596,24 +596,37 @@ class MessageBusClient:
     def _take_inbound_session(self, message: Message):
         """Take an arriving message's session into whatever state holds it.
 
-        A carrier that names no usable id IS the default session (SESSION-1
-        §3.1), which is why the branch is taken off the raw carrier rather than
-        off a parsed Session: parsing rejects an empty or wrong-typed id, and
-        rejecting it here would silently discard a message the spec says to
-        route to the default session.
+        OVOS-SESSION-2 §5.1's arrival merge is an orchestrator-intake fold: it
+        happens exactly once, at the process that owns the default-session
+        store, when an utterance is first taken in. This client is a bus
+        *consumer* -- a listener, a satellite, a skill container, or the
+        orchestrator itself -- and every one of those observes far more
+        default-session messages than the single intake per utterance the
+        spec merges (replies, handled-acks, forwarded frames all carry a
+        session too). Folding on each of those would merge stale field values
+        back into the live store on every observed message, not just at
+        intake, and would silently overwrite whatever the orchestrator's own
+        intake fold just wrote (see OVOS-SESSION-2 §2.6: mutation only at
+        lifecycle boundaries, not on every observation). The orchestrator
+        process folds for itself, explicitly, at its own intake point; this
+        client only needs to be able to *resolve* a session for handlers,
+        which ``SessionManager.get`` already does purely off the carrier
+        without touching the store.
 
-        For the default session that means the OVOS-SESSION-2 §5.1 arrival
-        merge, which folds the carrier into the store field by field so an
-        omitted field leaves the stored one standing. A named session is
-        client-owned and the orchestrator holds nothing for it (§2.2), so it
-        only goes through ``update``, which is a no-op wherever the registry
-        honours §2.2 and the utterance-scoped registration on older releases.
+        A carrier that names no usable id IS the default session (SESSION-1
+        §3.1) and is left exactly alone: it dispatches without touching the
+        store, whether or not it would otherwise construct into a well-formed
+        ``Session`` (an empty/falsy id is unusable but still names the
+        default per §3.1, so it must not be rejected as malformed here). A
+        named session is client-owned and the orchestrator holds nothing for
+        it (§2.2), so it still goes through ``update``, which is a no-op
+        wherever the registry honours §2.2 and the utterance-scoped
+        registration on older releases.
 
         @raises MalformedSession: the message carries a non-object session
         """
         carrier = session_carrier(message)
-        if HAS_FOLD_INBOUND and resolve_session_id(carrier) == DEFAULT_SESSION_ID:
-            SessionManager.fold_inbound(message)
+        if resolve_session_id(carrier) == DEFAULT_SESSION_ID:
             return
         sess = Session.from_message(message)
         if sess.session_id != DEFAULT_SESSION_ID:

--- a/test/unittests/test_async_client.py
+++ b/test/unittests/test_async_client.py
@@ -169,6 +169,57 @@ class TestOnMessage(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         self.assertEqual(len(raw_received), 1)
 
+    async def test_on_message_leaves_the_default_store_alone(self):
+        # OVOS-SESSION-2 §5.1's arrival fold is orchestrator-intake-only (see
+        # ovos_bus_client.client.client.MessageBusClient._take_inbound_session);
+        # this is the async twin of that assertion.
+        from ovos_bus_client.session import SessionManager
+        SessionManager.reset_default_session()
+        self.addCleanup(SessionManager.reset_default_session)
+        stored = SessionManager.get_default_session()
+        stored.lang = "pt-PT"
+        stored.site_id = "kitchen"
+
+        bus = _make_bus()
+        # an omitted-field default carrier must not reset a field the store
+        # has already moved past
+        raw = json.dumps({"type": "recognizer_loop:utterance",
+                          "data": {"utterances": ["hi"]},
+                          "context": {"session": {"session_id": "default"}}})
+        await bus._on_message(raw)
+        self.assertIs(SessionManager.get_default_session(), stored)
+        self.assertEqual(stored.lang, "pt-PT")
+        self.assertEqual(stored.site_id, "kitchen")
+
+        # nor does a fully-populated observed carrier overwrite it
+        raw2 = json.dumps({"type": "recognizer_loop:utterance",
+                           "data": {"utterances": ["hi"]},
+                           "context": {"session": {"session_id": "default",
+                                                    "site_id": "bedroom"}}})
+        await bus._on_message(raw2)
+        self.assertEqual(stored.site_id, "kitchen")
+
+    async def test_on_message_still_updates_a_named_session(self):
+        # a named-session carrier still goes through SessionManager.update()
+        # exactly once (§2.2/#313 held-session handling), unlike the default
+        # session above.
+        from ovos_bus_client.session import SessionManager
+        SessionManager.reset_default_session()
+        self.addCleanup(SessionManager.reset_default_session)
+        self.addCleanup(SessionManager.sessions.pop, "kitchen-sat", None)
+
+        bus = _make_bus()
+        with patch.object(SessionManager, "update",
+                          wraps=SessionManager.update) as mock_update:
+            raw = json.dumps({"type": "recognizer_loop:utterance",
+                              "data": {"utterances": ["hi"]},
+                              "context": {"session": {"session_id": "kitchen-sat",
+                                                       "site_id": "bedroom"}}})
+            await bus._on_message(raw)
+            mock_update.assert_called_once()
+            called_sess = mock_update.call_args[0][0]
+            self.assertEqual(called_sess.session_id, "kitchen-sat")
+
 
 # ---------------------------------------------------------------------------
 # Event registration tests

--- a/test/unittests/test_default_session_fold.py
+++ b/test/unittests/test_default_session_fold.py
@@ -1,9 +1,16 @@
-"""OVOS-SESSION-2 §5.1 — an arriving default session merges into the store.
+"""OVOS-SESSION-2 §5.1 — the arrival fold is orchestrator-intake-only.
 
-The receive path hands the raw Message to ``SessionManager.fold_inbound``, so a
-field the message omits leaves the stored value standing. That merge only
-exists once the registry offers an arrival point; older spec-tools releases
-fold lazily inside ``get`` and these tests do not apply to them.
+The §5.1 merge happens exactly once per utterance, at the process that owns
+the default-session store on intake (see core#915). A bus-client instance is
+a consumer -- a listener, a satellite, a skill container, or the orchestrator
+itself reading its own bus -- and observes far more default-session traffic
+than one fold per utterance (replies, handled-acks, forwarded frames all
+carry a session). Folding every observed message would re-merge stale field
+values into the live store on each one and silently clobber whatever the
+orchestrator's own intake fold just wrote (§2.6: mutation only at lifecycle
+boundaries, not on every observation). So ``on_message`` never folds the
+default session; only an explicit ``SessionManager.fold_inbound`` call, made
+by whoever owns intake, does.
 """
 import unittest
 from unittest.mock import MagicMock
@@ -18,9 +25,9 @@ def _inbound(carrier):
                    {"session": carrier}).serialize()
 
 
-@unittest.skipUnless(HAS_FOLD_INBOUND,
-                     "spec-tools registry has no fold_inbound arrival point")
-class TestDefaultSessionFoldOnReceive(unittest.TestCase):
+class TestObservedMessagesNeverFoldTheDefaultStore(unittest.TestCase):
+    """The client only *resolves* sessions for handlers; it never folds."""
+
     def setUp(self):
         SessionManager.reset_default_session()
         self.bus = MessageBusClient()
@@ -30,45 +37,92 @@ class TestDefaultSessionFoldOnReceive(unittest.TestCase):
     def tearDown(self):
         SessionManager.reset_default_session()
 
-    def test_omitted_fields_survive_the_next_arrival(self):
-        self.bus.on_message(_inbound({"session_id": "default",
-                                      "lang": "pt-pt",
-                                      "site_id": "kitchen"}))
+    def test_observed_default_session_traffic_leaves_the_store_alone(self):
         stored = SessionManager.get_default_session()
-        self.assertEqual(stored.lang, "pt-PT")
-        self.assertEqual(stored.site_id, "kitchen")
+        stored.lang = "pt-PT"
+        stored.site_id = "kitchen"
 
-        # a minimal second arrival carries no lang and no site_id, so §5.1
-        # leaves both stored values alone
+        # A message an orchestrator-side skill/handler emitted (e.g. the
+        # ovos.utterance.handled ack) can legitimately carry a STALE default
+        # carrier from earlier in the pipeline. Observing it must not wipe
+        # fields the live store has moved on from.
         self.bus.on_message(_inbound({"session_id": "default"}))
         self.assertIs(SessionManager.get_default_session(), stored)
         self.assertEqual(stored.lang, "pt-PT")
         self.assertEqual(stored.site_id, "kitchen")
 
-    def test_carried_field_replaces_the_stored_one(self):
-        self.bus.on_message(_inbound({"session_id": "default",
-                                      "lang": "pt-pt",
-                                      "site_id": "kitchen"}))
+        # nor does a fully-populated observed carrier overwrite the store --
+        # that fold belongs to the orchestrator's intake alone.
         self.bus.on_message(_inbound({"session_id": "default",
                                       "site_id": "bedroom"}))
-        stored = SessionManager.get_default_session()
-        self.assertEqual(stored.site_id, "bedroom")
-        self.assertEqual(stored.lang, "pt-PT")
+        self.assertEqual(stored.site_id, "kitchen")
 
-    def test_absent_carrier_is_the_default_session(self):
-        self.bus.on_message(_inbound({"session_id": "default",
-                                      "site_id": "kitchen"}))
+    def test_absent_carrier_still_dispatches_without_folding_the_store(self):
+        # An absent carrier IS the default session (SESSION-1 §2.1/§3.1), so
+        # it must still dispatch normally -- but observing it is not intake,
+        # so it must not touch the store either.
+        stored = SessionManager.get_default_session()
+        stored.site_id = "kitchen"
         raw = Message("recognizer_loop:utterance",
                       {"utterances": ["hello"]}).serialize()
         self.bus.on_message(raw)
-        self.assertEqual(SessionManager.get_default_session().site_id,
-                         "kitchen")
+        self.assertIs(SessionManager.get_default_session(), stored)
+        self.assertEqual(stored.site_id, "kitchen")
 
-    def test_named_session_leaves_the_default_store_alone(self):
-        self.bus.on_message(_inbound({"session_id": "default",
-                                      "site_id": "kitchen"}))
+    def test_named_session_arrival_leaves_the_default_store_alone(self):
+        # a named-session arrival still goes through `update` (#313), which
+        # is a §2.2 no-op for a non-default id on this spec-tools release --
+        # what matters here is that observing it never touches the default
+        # store, the same as any other observed message.
+        stored = SessionManager.get_default_session()
+        stored.site_id = "kitchen"
         self.bus.on_message(_inbound({"session_id": "kitchen-sat",
                                       "site_id": "bedroom"}))
+        self.assertIs(SessionManager.get_default_session(), stored)
+        self.assertEqual(stored.site_id, "kitchen")
+
+
+@unittest.skipUnless(HAS_FOLD_INBOUND,
+                     "spec-tools registry has no fold_inbound arrival point")
+class TestExplicitIntakeFoldStillWorksThroughTheSameClient(unittest.TestCase):
+    """The orchestrator's own explicit §5.1 fold at intake is untouched.
+
+    This is core's job now (core#915), but it still goes through the same
+    bus-client Message plumbing -- so an explicit ``fold_inbound`` call made
+    by whoever owns intake must still merge correctly.
+    """
+
+    def setUp(self):
+        SessionManager.reset_default_session()
+
+    def tearDown(self):
+        SessionManager.reset_default_session()
+
+    def test_explicit_fold_inbound_merges_field_by_field(self):
+        first = Message.deserialize(_inbound({"session_id": "default",
+                                              "lang": "pt-pt",
+                                              "site_id": "kitchen"}))
+        SessionManager.fold_inbound(first)
+        stored = SessionManager.get_default_session()
+        self.assertEqual(stored.lang, "pt-PT")
+        self.assertEqual(stored.site_id, "kitchen")
+
+        # a minimal second intake carries no lang and no site_id, so §5.1
+        # leaves both stored values alone
+        second = Message.deserialize(_inbound({"session_id": "default"}))
+        SessionManager.fold_inbound(second)
+        self.assertIs(SessionManager.get_default_session(), stored)
+        self.assertEqual(stored.lang, "pt-PT")
+        self.assertEqual(stored.site_id, "kitchen")
+
+    def test_absent_carrier_at_intake_is_the_default_session(self):
+        first = Message.deserialize(_inbound({"session_id": "default",
+                                              "site_id": "kitchen"}))
+        SessionManager.fold_inbound(first)
+        second = Message.deserialize(
+            Message("recognizer_loop:utterance",
+                   {"utterances": ["hello"]}).serialize())
+        SessionManager.fold_inbound(second)
         self.assertEqual(SessionManager.get_default_session().site_id,
                          "kitchen")
 

--- a/test/unittests/test_session_authority.py
+++ b/test/unittests/test_session_authority.py
@@ -79,14 +79,18 @@ class TestFalsySessionIdIsTheDefaultSession(unittest.TestCase):
                                  DEFAULT_SESSION_ID,
                                  f"{unusable!r} names no session")
 
-    @unittest.skipUnless(HAS_FOLD_INBOUND, "no §3.1 predicate in the registry")
-    def test_empty_id_folds_into_the_store_and_still_dispatches(self):
+    def test_empty_id_still_dispatches_without_folding_the_store(self):
+        # An unusable id IS the default session (§3.1), but the §5.1 arrival
+        # fold is orchestrator-intake-only (see core#915) -- a bus-client
+        # observing this message dispatches it normally without merging its
+        # carrier into the live default-session store.
         seen = []
         self.bus.on("speak", seen.append)
+        stored_lang = SessionManager.get_default_session().lang
         raw = Message("speak", {"utterance": "hi"},
                       {"session": {"session_id": "", "lang": "pt-pt"}}).serialize()
         self.bus.on_message(raw)
-        self.assertEqual(SessionManager.get_default_session().lang, "pt-PT")
+        self.assertEqual(SessionManager.get_default_session().lang, stored_lang)
         self.assertEqual(len(seen), 1)
 
     def test_malformed_carrier_is_still_rejected(self):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-SESSION-2 §5.1's arrival merge is a once-per-utterance intake fold that belongs to the orchestrator (core#915 folds it exactly once at ovos-core's own intake now). `MessageBusClient._take_inbound_session` and its async twin instead called `SessionManager.fold_inbound` for every inbound default-session message a client observed. A bus-client instance is not the orchestrator: a listener, a satellite, a GUI, or a skill container all import this library, and every one of them sees far more default-session traffic than one fold per utterance -- replies, handled-acks, and forwarded frames all carry a session too. Live-verified repro: an observed `ovos.utterance.handled` carrying a stale default carrier wiped fields the live store had already moved past, which is exactly the §2.6 violation this PR closes (mutation only at lifecycle boundaries, not on every observation).

`_take_inbound_session` now only decides where an inbound carrier's session lives, via `resolve_session_id(carrier) == DEFAULT_SESSION_ID` (rebased onto dev's #324, which renamed this repo's carrier-resolution helper from `names_the_default` to the now-public `resolve_session_id`, ovos-spec-tools >=1.10.3a1 -- the intake-narrowing logic itself is unchanged, only the resolver call site). A carrier that names the default session (§3.1, including the unusable-id carve-out for an empty/falsy id) is left alone -- it still dispatches normally, but nothing is written to the store. A carrier that names a real session id still goes through `update()`, exactly as before (#313's held-session handling for named sessions is untouched). The orchestrator process folds for itself, explicitly, at its own intake point; every other consumer resolves a session for its own handlers through `SessionManager.get()`, which already reads the carrier purely without needing a fold.

`test_default_session_fold.py` is rewritten to pin the new contract: observing default-session traffic (an omitted-field carrier, a fully-populated one, and an absent carrier) never touches the store, a named-session arrival doesn't touch the default store either, and an explicit `fold_inbound` call -- the shape core's own intake now uses -- still merges field-by-field for both a populated carrier and an absent one. Every case the original 4-test file covered is preserved, adapted to the new intake-vs-observation split; the file now holds 5 tests, none dropped, one net addition. `test_session_authority.py`'s empty-session-id test is updated the same way (same test count, contract flipped, since it previously asserted the old fold-on-observe behavior as the expected outcome). `test_async_client.py` gains the async twin of the same assertions: `AsyncMessageBusClient._on_message` leaves the default store untouched for both an omitted-field and a fully-populated observed carrier, and still calls `SessionManager.update()` exactly once for a named-session carrier.

Fail-before: both rewritten test files fail against the unfixed source. The default-session-fold test fails with `'bedroom' != 'kitchen'` (an observed carrier overwrote a field the live store had already been given locally). The session-authority test caught a real regression during the fix itself: a first-pass rewrite that simply dropped the fold call broke §3.1's unusable-id carve-out, since `Session.from_message` legitimately rejects an empty `session_id` as malformed outside the special "this IS the default session" case -- the final fix keeps that carve-out as a no-store-write short-circuit instead of removing it. The new async test fails the same way against a patch-revert of `async_client.py` alone (`'bedroom' != 'kitchen'` on the async `_on_message` path). All pass after the final fix.

Full suite: clean `origin/dev` (c1a3221, 2.11.4a1) is 1051 passed / 6 skipped. This branch is 1054 passed / 6 skipped -- +1 from `test_default_session_fold.py`'s net gain (4 tests -> 5) and +2 from the two new `test_async_client.py` tests; `test_session_authority.py` stays at its prior count.

**Limitation.** An out-of-process consumer whose only bus client is NOT the orchestrator -- a satellite, a GUI, a standalone skill container -- no longer mirrors observed default-session traffic into its own local `SessionManager` store. `SessionManager.get()` with no message argument still digs the current handler's message (`session.py:1612`), so a handler on such a process reads a satellite-injected field straight off that message's carrier; a read made outside any handler's message context on such a process sees the deployment default rather than whatever the orchestrator's store last held. This is §5.1's model working as specified -- the fold happens once, at orchestrator intake, not by every observer -- but it is a real behavior change from the previous fold-on-every-message shape for any process built to read the store directly instead of through a message.

This is the bus-client half of the once-per-utterance fold from core#915. Flagging for skills-QA: naptime and its neighboring four fixtures may have relied on the old fakebus/bus-client fold-on-every-message behavior and should be re-gated against this change and the companion ovos-utils FakeBus fix (ovos-utils#437).

## Test plan
- [x] `pytest test/` on the branch: 1054 passed, 6 skipped (clean dev baseline 1051/6)
- [x] Fail-before/after on all rewritten/added regression tests, including the async twin, via patch-revert (see PR body)
- [x] `pr_hygiene_lint.py --base origin/dev`: clean, 1 commit, 5 files