### PR TITLE
fix: resolve session_id per SESSION-1 without reaching into ovos-spec-tools internals

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -62,18 +62,33 @@ def session_carrier(message) -> Dict[str, Any]:
     return carrier
 
 
+try:
+    from ovos_spec_tools.session import resolve_session_id
+except ImportError:
+    def resolve_session_id(carrier: Dict[str, Any]) -> str:
+        """Resolve the session id a raw carrier names.
+
+        SESSION-1 §3.1: an omitted ``session_id`` names the default session.
+        §6 requires a non-empty string when the field is set, so an empty or
+        wrong-typed value reads as omitted rather than as a session no
+        message can name.
+
+        @param carrier: the raw session carrier off a Message
+        @return: the session id the carrier names, or the default session id
+        """
+        session_id = carrier.get("session_id")
+        if isinstance(session_id, str) and session_id:
+            return session_id
+        return DEFAULT_SESSION_ID
+
+
 def names_the_default(carrier: Dict[str, Any]) -> bool:
     """Whether a raw session carrier names the reserved default session.
 
-    SESSION-1 §3.1: an omitted ``session_id`` is the default session, and so is
-    any value that cannot serve as an identity — §6 requires a non-empty string
-    when the field is set, so an empty or wrong-typed one reads as omitted
-    rather than as a session no message can name. Older spec-tools releases
-    have no such predicate and treat only the literal id that way.
+    Thin wrapper around ``resolve_session_id`` for callers that only need the
+    boolean.
     """
-    if HAS_FOLD_INBOUND:
-        return _SpecSessionManager._names_the_default(carrier)
-    return carrier.get("session_id", DEFAULT_SESSION_ID) == DEFAULT_SESSION_ID
+    return resolve_session_id(carrier) == DEFAULT_SESSION_ID
 
 
 def _get_default_lang() -> str:

--- a/test/unittests/test_session_id_resolution.py
+++ b/test/unittests/test_session_id_resolution.py
@@ -1,0 +1,69 @@
+"""SESSION-1 §2/§3.1/§6 — resolving a raw carrier's ``session_id`` locally.
+
+``resolve_session_id`` and ``names_the_default`` must not reach into
+``ovos_spec_tools.session.SessionManager._names_the_default`` (a private that
+package is removing) and must apply the same non-empty-string rule §6
+requires: a wrong-typed value is malformed and reads as omitted (§2.1), and
+an omitted id names the default session (§3.1).
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.client.client import MessageBusClient
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import (DEFAULT_SESSION_ID, SessionManager,
+                                     names_the_default, resolve_session_id)
+
+
+class TestResolveSessionId(unittest.TestCase):
+
+    def test_absent_and_unusable_ids_resolve_to_the_default(self):
+        for carrier in ({}, {"session_id": None}, {"session_id": ""},
+                         {"session_id": "default"}, {"session_id": 123},
+                         {"session_id": 1.5}, {"session_id": True},
+                         {"session_id": []}, {"session_id": {}}):
+            self.assertEqual(resolve_session_id(carrier), DEFAULT_SESSION_ID,
+                              f"{carrier!r} should resolve to the default")
+
+    def test_a_named_string_id_resolves_to_itself(self):
+        self.assertEqual(resolve_session_id({"session_id": "abc"}), "abc")
+
+    def test_names_the_default_agrees_with_resolve_session_id(self):
+        for carrier in ({}, {"session_id": 123}, {"session_id": "kitchen"}):
+            self.assertEqual(names_the_default(carrier),
+                              resolve_session_id(carrier) == DEFAULT_SESSION_ID)
+
+
+class TestWrongTypedIdOnTheWireIsTheDefaultSession(unittest.TestCase):
+    """A carrier naming a wrong-typed id must dispatch as the default session,
+    not be treated as a distinct named session (which minted a fresh uuid4 /
+    dropped the message entirely before this fix)."""
+
+    def setUp(self):
+        SessionManager.reset_default_session()
+        self.bus = MessageBusClient()
+        self.bus.client = MagicMock()
+        self.bus.connected_event.set()
+
+    def tearDown(self):
+        SessionManager.reset_default_session()
+
+    def test_int_session_id_dispatches_as_the_default_session(self):
+        before = set(SessionManager.sessions.keys())
+        seen = []
+        self.bus.on("speak", seen.append)
+        raw = Message("speak", {"utterance": "hi"},
+                      {"session": {"session_id": 123,
+                                   "lang": "pt-pt"}}).serialize()
+        self.bus.on_message(raw)
+
+        self.assertEqual(len(seen), 1, "the message must still dispatch")
+        self.assertEqual(SessionManager.get_default_session().session_id,
+                          DEFAULT_SESSION_ID)
+        self.assertEqual(set(SessionManager.sessions.keys()), before,
+                          "no spurious session may be minted for a "
+                          "wrong-typed session_id")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`names_the_default(carrier)` in `ovos_bus_client/session.py:65-76` delegated to the private `ovos_spec_tools.session.SessionManager._names_the_default`, a method that package is deleting in favour of a public `resolve_session_id(carrier)`. Once an ovos-spec-tools alpha without that private ships, every bare-floor install of ovos-bus-client raises `AttributeError` at the call sites in `client/client.py:615` and `client/async_client.py:298`, since `HAS_FOLD_INBOUND` is true and the module always takes that branch.

The delegated predicate was also falsiness-based (`carrier.get("session_id") or DEFAULT_SESSION_ID`), so a carrier like `{"session_id": 123}` is truthy and gets classified as a named session, even though SESSION-1 §6 requires `session_id` to be a non-empty string when set and §2.1 says a malformed value reads as omitted. On the wire this reproduces on 2.11.1a1 + ovos-spec-tools 1.10.1a1 as a message carrying `session_id: 123` being discarded outright ("malformed session") on `MessageBusClient.on_message`, instead of dispatching as the default session per §3.1.

This adds a local `resolve_session_id(carrier) -> str` that implements the SESSION-1 rule directly with no reach into spec-tools internals — a non-empty string resolves to itself, everything else resolves to `DEFAULT_SESSION_ID` — and prefers `ovos_spec_tools.session.resolve_session_id` when that package ships it, falling back to the local definition otherwise. `names_the_default` becomes a thin wrapper around it. This is step 1 of 2, ordered consumers-first: callers in `client.py`/`async_client.py` are unchanged, and dropping the fallback follows once the spec-tools release with the public resolver exists and the floor pin is bumped.

Fail-before: reverting only the source change (keeping the new test) makes `from ovos_bus_client.session import resolve_session_id` raise `ImportError` (the name did not exist yet), and reproduces the wire symptom directly — a `session_id: 123` carrier is discarded as malformed rather than dispatching as the default session. After the fix, the new tests pass and no spurious session is minted for that carrier. Full suite: 1022 passed / 6 skipped on `origin/dev`, 1026 passed / 6 skipped with this change (the 4 new tests), no regressions.
