### PR TITLE
fix: carry session.location as {lat, lon, tz} per OVOS-SESSION-1 §3.5

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -91,6 +91,64 @@ def names_the_default(carrier: Dict[str, Any]) -> bool:
     return resolve_session_id(carrier) == DEFAULT_SESSION_ID
 
 
+_LEGACY_LOCATION_KEYS = ("city", "coordinate", "timezone")
+
+
+def _sanitize_location(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate the OVOS-SESSION-1 §3.5 ``location`` keys, dropping the rest.
+
+    Only ``lat``/``lon``/``tz`` carry normative meaning on this field (§3.5:
+    "``location`` carries only these three keys"). A malformed value for one
+    of them (wrong type, or ``lat``/``lon`` outside its range) is dropped as
+    if omitted, per the field's own malformed-key rule; any other key is
+    tolerated on ingest (§2.4 -- it does not raise) but is not re-emitted,
+    since this field defines no wire representation for it.
+    """
+    out: Dict[str, Any] = {}
+    lat = raw.get("lat")
+    if isinstance(lat, (int, float)) and not isinstance(lat, bool) and -90 <= lat <= 90:
+        out["lat"] = float(lat)
+    lon = raw.get("lon")
+    if isinstance(lon, (int, float)) and not isinstance(lon, bool) and -180 <= lon <= 180:
+        out["lon"] = float(lon)
+    tz = raw.get("tz")
+    if isinstance(tz, str) and tz:
+        out["tz"] = tz
+    return out
+
+
+def _normalize_location_input(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Accept either the SESSION-1 §3.5 wire shape or the legacy nested one.
+
+    Pre-spec producers on this compatibility line ship the nested
+    mycroft.conf ``location`` shape (``city``/``coordinate``/``timezone``)
+    instead of the flat ``{lat, lon, tz}`` object. That shape is normalized
+    here to the three keys, with a deprecation warning naming the version
+    the shim is removed in. A carrier that already uses (or mixes in) any of
+    ``lat``/``lon``/``tz`` is treated as the modern shape.
+    """
+    if not isinstance(raw, dict) or not raw:
+        return {}
+    if any(k in raw for k in _LEGACY_LOCATION_KEYS) and not any(
+            k in raw for k in ("lat", "lon", "tz")):
+        log_deprecation(
+            "the nested mycroft.conf 'location' shape (city/coordinate/"
+            "timezone) on session.location is deprecated; producers must "
+            "emit the OVOS-SESSION-1 §3.5 {lat, lon, tz} shape instead",
+            _NEXT_MAJOR_VERSION)
+        coordinate = raw.get("coordinate", {}) or {}
+        timezone = raw.get("timezone", {}) or {}
+        legacy: Dict[str, Any] = {}
+        if "latitude" in coordinate:
+            legacy["lat"] = coordinate["latitude"]
+        if "longitude" in coordinate:
+            legacy["lon"] = coordinate["longitude"]
+        if "code" in timezone:
+            legacy["tz"] = timezone["code"]
+        return _sanitize_location(legacy)
+    return _sanitize_location(raw)
+
+
 def _get_default_lang() -> str:
     """Read the runtime-configured default lang.
 
@@ -730,7 +788,12 @@ class Session(_SpecSession):
             pipeline (List[str]): Ordered intent processing pipeline identifiers.
             stt_prefs (Dict): Deprecated; provided value will be ignored.
             tts_prefs (Dict): Deprecated; provided value will be ignored.
-            location_prefs (Dict): Location preferences or metadata for the session.
+            location_prefs (Dict): OVOS-SESSION-1 §3.5 `location` -- either the wire shape
+                `{lat, lon, tz}` or the legacy nested mycroft.conf shape (normalized on
+                ingest, with a deprecation warning). Stored as given (key-wise validated);
+                since the deployment default for this field IS the deployment
+                configuration (§4.1), an omitted/empty/malformed value is stored as `{}`,
+                never materialized from configuration -- readers fall back at read time.
             system_unit (str): Measurement system preference (e.g., "metric" or "imperial").
             time_format (str): Time format preference identifier.
             date_format (str): Date format preference identifier.
@@ -830,7 +893,15 @@ class Session(_SpecSession):
         self.touch_time = int(time.time())
         self.expiration_seconds = expiration_seconds or \
                                   Configuration().get('session', {}).get("ttl", -1)
-        self.location_preferences = location_prefs or Configuration().get("location", {})
+        # OVOS-SESSION-1 §3.5: ``location``'s deployment default IS a
+        # deployment-configured value (the mycroft.conf location), so §4.1
+        # forbids materializing it into session state or onto the wire on
+        # the origin's behalf. `self.location` therefore stores ONLY what the
+        # caller/wire actually provided (key-wise validated, possibly `{}`);
+        # the configured fallback is applied at READ time only -- see
+        # `timezone` and `location_preferences` below, mirroring how
+        # `timezone` already falls back to config without storing it.
+        self.location: Dict[str, Any] = _normalize_location_input(location_prefs or {})
         # Legacy back-compat: a caller (or a legacy wire payload via
         # deserialize) may hand an ``IntentContextManager`` frame stack. It is
         # NOT stored as a parallel object — its entities fold into the canonical
@@ -905,12 +976,57 @@ class Session(_SpecSession):
     @property
     def timezone(self) -> Optional[str]:
         """
-        Return the session's configured timezone code.
+        Return the session's timezone code.
+
+        OVOS-SESSION-1 §3.5: ``location.tz``, when present, MUST be used to
+        resolve wall-clock time for this session. When absent, the consumer
+        falls back to its own deployment-configured timezone (§2.1).
 
         Returns:
-            timezone_code (Optional[str]): Timezone identifier like 'America/Los_Angeles' if set in location preferences, `None` otherwise.
+            timezone_code (Optional[str]): IANA timezone identifier like
+                'America/Los_Angeles', or `None` if neither the session nor
+                the deployment configures one.
         """
-        return self.location_preferences.get('timezone', {}).get('code')
+        return self.location.get('tz') or \
+            Configuration().get("location", {}).get("timezone", {}).get("code")
+
+    @property
+    def location_preferences(self) -> Dict[str, Any]:
+        """DEPRECATED legacy nested view of ``location``.
+
+        Reconstructs the pre-spec mycroft.conf shape (``city``/
+        ``coordinate``/``timezone``) for callers written before
+        OVOS-SESSION-1 §3.5 adopted the flat ``{lat, lon, tz}`` wire shape.
+        ``city``/``state``/``country`` have no slot in the three-key field --
+        they are read from deployment configuration, not from session state.
+        """
+        log_deprecation("Session.location_preferences is a legacy nested "
+                        "view of the canonical OVOS-SESSION-1 §3.5 "
+                        "'location' field ({lat, lon, tz}); use "
+                        "session.location directly",
+                        _NEXT_MAJOR_VERSION)
+        cfg = Configuration().get("location", {}) or {}
+        return {
+            "city": cfg.get("city", {}),
+            "coordinate": {
+                "latitude": self.location.get(
+                    "lat", cfg.get("coordinate", {}).get("latitude")),
+                "longitude": self.location.get(
+                    "lon", cfg.get("coordinate", {}).get("longitude")),
+            },
+            "timezone": {**cfg.get("timezone", {}),
+                        "code": self.location.get(
+                            "tz", cfg.get("timezone", {}).get("code"))},
+        }
+
+    @location_preferences.setter
+    def location_preferences(self, value: Optional[Dict[str, Any]]):
+        log_deprecation("Session.location_preferences is a legacy nested "
+                        "view of the canonical OVOS-SESSION-1 §3.5 "
+                        "'location' field ({lat, lon, tz}); use "
+                        "session.location directly",
+                        _NEXT_MAJOR_VERSION)
+        self.location = _normalize_location_input(value or {})
 
     # ------------------------------------------------------------------
     # touch() on mutation — lifecycle bookkeeping the canonical class omits.
@@ -1237,13 +1353,18 @@ class Session(_SpecSession):
                                  if mode.get("skill_id") else {}),
             "session_id": self.session_id,
             "context": self._context_view().serialize(),
-            "location": self.location_preferences,
             "system_unit": self.system_unit,
             "time_format": self.time_format,
             "date_format": self.date_format,
             "is_speaking": self.is_speaking,
             "is_recording": self.is_recording,
         })
+        # OVOS-SESSION-1 §3.5/§2.1: the three-key location object, omitted
+        # entirely when none of lat/lon/tz is set (equivalent to omission).
+        if self.location:
+            data["location"] = dict(self.location)
+        else:
+            data.pop("location", None)
         return data
 
     def update_history(self, message: Message = None):

--- a/test/unittests/test_session_extra.py
+++ b/test/unittests/test_session_extra.py
@@ -117,9 +117,19 @@ class TestSessionLifecycle(TestCase):
         self.assertEqual(s.timezone, "Europe/Lisbon")
 
     def test_timezone_none_when_missing(self):
-        # explicitly empty timezone block to bypass any global config defaults
-        s = Session(location_prefs={"timezone": {}})
-        self.assertIsNone(s.timezone)
+        # Pre-spec pin: this used to assert that an explicit-but-empty legacy
+        # nested `location_prefs` bypassed the deployment config default by
+        # being STORED as the empty session state. Under OVOS-SESSION-1
+        # §3.5/§4.1 the deployment default for `location` is itself a
+        # deployment-configured value, so it is never materialized into
+        # `self.location` -- the fallback happens at READ time only, exactly
+        # like this case: `self.location` stays `{}` and `timezone` falls
+        # back to whatever `Configuration()` reports (here, nothing).
+        with patch("ovos_bus_client.session.Configuration", return_value={}):
+            s = Session(location_prefs={"timezone": {}})
+            self.assertEqual(s.location, {})
+            self.assertIsNone(s.timezone)
+            self.assertEqual(s.location, {}, "read must not mutate stored state")
 
     def test_active_property(self):
         s = Session()
@@ -210,16 +220,24 @@ class TestSessionSerialization(TestCase):
         _reset_session_manager()
 
     def test_serialize_includes_all_keys(self):
+        # Pre-spec pin: `location` used to always be present, materialized
+        # from the deployment config even when the session named none. Under
+        # OVOS-SESSION-1 §3.5/§4.1 `location`'s deployment default IS a
+        # deployment-configured value, so it is never materialized onto the
+        # wire on the origin's behalf (§4.1) -- it is omitted here because no
+        # `location` was ever provided to this session, same as an omitted
+        # override field with no session-carried value.
         s = Session("sid", lang="pt-pt", site_id="kitchen", persona_id="p1",
                     blacklisted_skills=["bad.skill"],
                     blacklisted_intents=["bad:intent"])
         d = s.serialize()
         for key in ["active_skills", "utterance_states", "session_id",
                     "persona_id", "lang", "context", "site_id", "pipeline",
-                    "location", "system_unit", "time_format", "date_format",
+                    "system_unit", "time_format", "date_format",
                     "is_speaking", "is_recording", "blacklisted_skills",
                     "blacklisted_intents"]:
             self.assertIn(key, d)
+        self.assertNotIn("location", d)
         self.assertEqual(d["session_id"], "sid")
         self.assertEqual(d["persona_id"], "p1")
         self.assertEqual(d["site_id"], "kitchen")

--- a/test/unittests/test_session_location.py
+++ b/test/unittests/test_session_location.py
@@ -1,0 +1,194 @@
+"""OVOS-SESSION-1 §3.5 ``location`` -- the {lat, lon, tz} carrier.
+
+``location`` is a bus-client-only overlay field (not yet claimed in
+``ovos_spec_tools``'s registered field set). Its deployment default IS a
+deployment-configured value (the mycroft.conf ``location`` block), so
+OVOS-SESSION-1 §4.1 forbids materializing that default into session state or
+onto the wire on the origin's behalf: ``self.location`` stores ONLY what the
+wire/caller actually provided (key-wise validated, possibly ``{}``), and the
+deployment fallback is applied at READ time only (mirroring how
+``Session.timezone`` already falls back to config without storing it).
+"""
+import unittest
+from unittest.mock import patch
+
+import ovos_bus_client.session as session_module
+from ovos_bus_client.session import Session
+
+_CONFIG_WITH_LOCATION = {
+    "location": {
+        "city": {"code": "Lisbon", "name": "Lisbon",
+                 "state": {"code": "LX", "name": "Lisbon",
+                          "country": {"code": "PT", "name": "Portugal"}}},
+        "coordinate": {"latitude": 38.7167, "longitude": -9.1333},
+        "timezone": {"code": "Europe/Lisbon", "name": "Western European Time",
+                    "dstOffset": 3600000, "offset": 0},
+    },
+}
+
+
+class TestLocationNeverMaterializedFromConfig(unittest.TestCase):
+    """§4.1: a configured deployment default MUST NOT be written into state."""
+
+    def test_no_location_carrier_serializes_without_location_key(self):
+        # Reviewer-proved regression: a no-location carrier must NOT come back
+        # out re-serialized with the deployment's own coordinates, or a
+        # HiveMind hop would permanently stamp the first node's location onto
+        # every session that passes through it.
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session.deserialize({"session_id": "s1"})
+        self.assertEqual(sess.location, {})
+        data = sess.serialize()
+        self.assertNotIn("location", data)
+
+    def test_constructing_without_location_prefs_stores_empty_not_config(self):
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session()
+        self.assertEqual(sess.location, {})
+
+    def test_empty_location_object_stores_empty_not_config(self):
+        # §2.1: an object with none of the three keys is equivalent to an
+        # omitted location -- it still must not be materialized into state.
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session.deserialize({"session_id": "s1", "location": {}})
+        self.assertEqual(sess.location, {})
+        self.assertNotIn("location", sess.serialize())
+
+    def test_all_malformed_location_stores_empty_not_config(self):
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session.deserialize({"session_id": "s1",
+                                       "location": {"lat": "x", "tz": 123}})
+        self.assertEqual(sess.location, {})
+        self.assertNotIn("location", sess.serialize())
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_no_location_key_round_trips_to_no_location_key(self):
+        sess = Session.deserialize({"session_id": "s1"})
+        data = sess.serialize()
+        self.assertNotIn("location", data)
+
+    def test_partial_object_round_trips_byte_stable(self):
+        sess = Session.deserialize({"location": {"tz": "Asia/Tokyo"}})
+        data = sess.serialize()
+        self.assertEqual(data["location"], {"tz": "Asia/Tokyo"})
+
+    def test_full_object_round_trips_byte_stable(self):
+        sess = Session.deserialize({"location": {"lat": 1.5, "lon": -2.5,
+                                                  "tz": "Europe/Lisbon"}})
+        self.assertEqual(sess.serialize()["location"],
+                         {"lat": 1.5, "lon": -2.5, "tz": "Europe/Lisbon"})
+
+
+class TestLocationIngest(unittest.TestCase):
+    def test_spec_shape_round_trips(self):
+        sess = Session.deserialize({"session_id": "s1",
+                                    "location": {"lat": 1.5, "lon": -2.5,
+                                                "tz": "Europe/Lisbon"}})
+        self.assertEqual(sess.location, {"lat": 1.5, "lon": -2.5,
+                                         "tz": "Europe/Lisbon"})
+
+    def test_legacy_nested_shape_normalizes_and_warns_once(self):
+        legacy = {
+            "coordinate": {"latitude": 38.7167, "longitude": -9.1333},
+            "timezone": {"code": "Europe/Lisbon"},
+        }
+        with patch.object(session_module, "log_deprecation") as mock_warn:
+            sess = Session.deserialize({"session_id": "s1", "location": legacy})
+        self.assertEqual(sess.location, {"lat": 38.7167, "lon": -9.1333,
+                                         "tz": "Europe/Lisbon"})
+        mock_warn.assert_called_once()
+        self.assertIn("nested", mock_warn.call_args[0][0])
+
+    def test_malformed_keys_dropped_rest_kept(self):
+        sess = Session.deserialize({
+            "session_id": "s1",
+            "location": {"lat": "x", "lon": 200, "tz": 123},
+        })
+        self.assertEqual(sess.location, {})
+
+        sess = Session.deserialize({
+            "session_id": "s1",
+            "location": {"lat": 95, "lon": 10.0, "tz": 123},
+        })
+        self.assertEqual(sess.location, {"lon": 10.0})
+
+    def test_unlisted_keys_tolerated_but_not_reemitted(self):
+        sess = Session.deserialize({
+            "session_id": "s1",
+            "location": {"lat": 1.0, "city": "Lisbon"},
+        })
+        self.assertEqual(sess.location, {"lat": 1.0})
+        self.assertNotIn("city", sess.serialize()["location"])
+
+
+class TestTimezoneProperty(unittest.TestCase):
+    def test_prefers_session_location_tz(self):
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session.deserialize({"session_id": "s1",
+                                       "location": {"tz": "America/New_York"}})
+            self.assertEqual(sess.timezone, "America/New_York")
+
+    def test_falls_back_to_deployment_timezone_without_mutating_state(self):
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session.deserialize({"session_id": "s1"})
+            self.assertEqual(sess.timezone, "Europe/Lisbon")
+        # the fallback is read-time only -- stored state stays empty.
+        self.assertEqual(sess.location, {})
+
+    def test_no_config_and_no_location_is_none_without_mutating_state(self):
+        with patch.object(session_module, "Configuration", return_value={}):
+            sess = Session.deserialize({"session_id": "s1"})
+            self.assertIsNone(sess.timezone)
+        self.assertEqual(sess.location, {})
+
+
+class TestLocationPreferencesLegacyView(unittest.TestCase):
+    def test_reconstructs_nested_shape_from_three_keys(self):
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session.deserialize({"session_id": "s1",
+                                       "location": {"lat": 1.0, "lon": 2.0,
+                                                    "tz": "America/New_York"}})
+            prefs = sess.location_preferences
+        self.assertEqual(prefs["coordinate"]["latitude"], 1.0)
+        self.assertEqual(prefs["coordinate"]["longitude"], 2.0)
+        self.assertEqual(prefs["timezone"]["code"], "America/New_York")
+        # city/state/country have no slot on the three-key field: read from config.
+        self.assertEqual(prefs["city"], _CONFIG_WITH_LOCATION["location"]["city"])
+
+    def test_view_on_empty_location_returns_config_derived_dict_unstored(self):
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session.deserialize({"session_id": "s1"})
+            prefs = sess.location_preferences
+        self.assertEqual(prefs["coordinate"]["latitude"], 38.7167)
+        self.assertEqual(prefs["timezone"]["code"], "Europe/Lisbon")
+        # the view is computed at read time -- it must never be written back.
+        self.assertEqual(sess.location, {})
+
+    def test_setter_normalizes_legacy_nested_input(self):
+        sess = Session()
+        sess.location_preferences = {
+            "coordinate": {"latitude": 5.0, "longitude": 6.0},
+            "timezone": {"code": "Europe/Lisbon"},
+        }
+        self.assertEqual(sess.location, {"lat": 5.0, "lon": 6.0,
+                                         "tz": "Europe/Lisbon"})
+
+    def test_setter_with_only_config_default_stores_empty_not_config(self):
+        with patch.object(session_module, "Configuration",
+                          return_value=_CONFIG_WITH_LOCATION):
+            sess = Session()
+            sess.location_preferences = {"timezone": {}}
+        self.assertEqual(sess.location, {})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-SESSION-1 §3.5 closes `session.location` to exactly three optional keys: `lat` (decimal degrees, -90..90), `lon` (-180..180), and `tz` (an IANA zone id). Anything else — city, country, UTC offsets, DST — is derived out of band and has no wire slot on this field; an object carrying none of the three is wire-equivalent to an omitted `location` (§2.1) and a malformed key (wrong type, or `lat`/`lon` out of range) is dropped as if omitted while the rest of the object is kept.

`location`'s deployment default is itself a deployment-configured value — the mycroft.conf `location` block. OVOS-SESSION-1 §4.1 ("Default materialization") states a materialized default MUST NOT populate any field whose deployment default is a deployment-configured value, so `self.location` stores ONLY what the wire/caller actually provided, key-wise validated, possibly `{}`. `serialize()` omits `location` entirely whenever `self.location` is empty and never fills it from configuration; the deployment fallback is applied at READ time only, exactly the way `Session.timezone` already worked before this PR — it prefers `location['tz']`, else the configured timezone, without ever writing that fallback back into `self.location`. An earlier version of this PR violated §4.1 by materializing the configured location into `self.location` at construction time (a no-location carrier would come back out re-serialized with the deployment's own coordinates, permanently stamping the first HiveMind hop's location onto every session that passed through it); that has been corrected.

`Session.deserialize()`/`__init__` accept both the spec shape and the legacy nested mycroft.conf shape (`city`/`coordinate`/`timezone`) that pre-spec producers on this compatibility line still ship; the legacy shape is normalized to the three keys and logs a deprecation warning removed in bus-client 3.0.0 (computed from `VERSION_MAJOR`, matching the repo's existing pattern). `location_preferences` stays as a deprecated read/write view that reconstructs the nested shape from `self.location` plus deployment configuration at read time (never storing the result) — for `city`/`state`/`country`, which have no slot in the flat field. Consumers found across the ecosystem: `ovos-workshop/ovos_workshop/skills/ovos.py` (reads it), `ovos-skill-weather/__init__.py` (reads it), `ovoscope/ovoscope/__init__.py` (writes it in test harness setup), and `ovos-pydantic-models/ovos_pydantic_models/session.py` (has its own independent `location_preferences` field, unrelated to this class — not touched). None of these are edited by this PR; they continue to work through the deprecated view.

Two existing tests pinned behaviour this PR deliberately changes, each updated with an inline reason: `test_session_extra.py::test_timezone_none_when_missing` pinned an explicit-but-empty legacy location bypassing the config default by being stored as empty state — it now also asserts the fallback is read-time-only (`self.location` stays `{}` after the read); `test_session_extra.py::test_serialize_includes_all_keys` pinned `location` always being present, materialized from config — it now asserts `location` is omitted when the session never carried one.

Fail-before, two rounds, patch-revert only the source each time: (1) against clean `origin/dev`, reverting the fix failed 13/14 of the initial `test_session_location.py` cases with `AttributeError: 'Session' object has no attribute 'location'`; (2) after the §4.1 finding, reverting just the corrective source change (keeping the corrected tests) failed 10 cases — the no-location-carrier probe, both round-trip tests, and the two updated pre-existing tests — with `self.location`/the serialized dict showing the deployment's own coordinates instead of staying empty. Both rounds pass clean after restoring the fix. Full suite: 1044 passed, 6 skipped, 0 regressions vs clean `origin/dev`. `ovos_spec_tools` has no registered `location` field of its own (it's a bus-client-only overlay per the class docstring), so this PR does not touch `ovos-spec-tools` — if `location` is meant to move into the shared registry eventually, that would be a separate spec-tools PR.

Probe for the reviewer's no-location-carrier scenario (deserializing `{"session_id": "default"}` under a mocked deployment config with a real location): `sess.location == {}`, `"location" not in sess.serialize()`, `sess.timezone == "America/Chicago"` (read-time fallback to the mocked config), and `sess.location == {}` again after that read — the fallback never mutates stored state.