### PR TITLE
test: stop pinning repeated SessionManager.get identity

### DIFF
--- a/test/unittests/test_session.py
+++ b/test/unittests/test_session.py
@@ -288,8 +288,9 @@ class TestSessionManager(unittest.TestCase):
         if HAS_FOLD_INBOUND:
             # OVOS-SESSION-2 §2.2: the orchestrator is stateless for a named
             # session, and §2.6 makes get a pure read — it builds the session
-            # the carrier describes and registers nothing
-            self.assertIsNot(first, second)
+            # the carrier describes and registers nothing. Whether repeated
+            # get() calls on the same message return the identical object is
+            # an implementation detail of the carrier library, not this repo.
             self.assertNotIn("sid-get", self.SessionManager.sessions)
         else:
             self.assertIs(first, second)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`test_get_resolves_the_named_session_on_the_message` asserted `assertIsNot(first, second)` for two `SessionManager.get(msg)` calls on the same message, pinning that the carrier builds a fresh object per call. OVOS-SPEC-TOOLS pending PR #121 changes this: `get(message)` will return the same bound Session object across repeated calls on one message, since OVOS-CONTEXT-1 §5.3's handler-write path requires mutations made through one call to be visible to a later call on that same message. Whether the returned object is identical or merely equal across calls is a property of the spec-tools carrier implementation, not a contract this repo's test suite should pin either way, so the assertion is dropped rather than flipped to `assertIs`. Every other assertion in the test (the resolved fields and `assertNotIn("sid-get", SessionManager.sessions)`) is untouched, and a grep of the whole test tree found no other assertion that depends on `get()` returning distinct objects across repeated calls on the same message — `test_session_extra.py`'s `assertIsNot(new, old)` in `test_reset_default_session_creates_fresh` is checking that `reset_default_session()` swaps in a genuinely new default session, an unrelated guarantee this repo owns itself.

The full suite (1026 passed, 6 skipped) was run twice in the same throwaway venv: once against the released `ovos-spec-tools==1.10.2a1` and once with `ovos-spec-tools` reinstalled from the `fix/session-bound-to-message` branch head that implements #121. Both runs are green with this change, so the pin no longer breaks bus-client the moment the spec-tools fix ships.