### PR TITLE
fix: use spec-tools session resolver and stamp bound sessions on Collection/GUI derivations

### DIFF
--- a/ovos_bus_client/client/async_client.py
+++ b/ovos_bus_client/client/async_client.py
@@ -40,7 +40,7 @@ from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf
 from ovos_bus_client.message import Message, CollectionMessage
 from ovos_bus_client.session import (SessionManager, Session,
                                      DEFAULT_SESSION_ID, HAS_FOLD_INBOUND,
-                                     names_the_default, session_carrier)
+                                     resolve_session_id, session_carrier)
 
 
 class AsyncMessageWaiter:
@@ -295,7 +295,7 @@ class AsyncMessageBusClient:
         parsed = Message.deserialize(raw)
         # see MessageBusClient._take_inbound_session
         carrier = session_carrier(parsed)
-        if HAS_FOLD_INBOUND and names_the_default(carrier):
+        if HAS_FOLD_INBOUND and resolve_session_id(carrier) == DEFAULT_SESSION_ID:
             SessionManager.fold_inbound(parsed)
         else:
             sess = Session.from_message(parsed)

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -27,7 +27,7 @@ from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import (SessionManager, Session, MalformedSession,
                                      DEFAULT_SESSION_ID, HAS_FOLD_INBOUND,
-                                     names_the_default, session_carrier)
+                                     resolve_session_id, session_carrier)
 from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
 
 # --- legacy intent-topic compat (non-normative migration tooling) ----------
@@ -612,7 +612,7 @@ class MessageBusClient:
         @raises MalformedSession: the message carries a non-object session
         """
         carrier = session_carrier(message)
-        if HAS_FOLD_INBOUND and names_the_default(carrier):
+        if HAS_FOLD_INBOUND and resolve_session_id(carrier) == DEFAULT_SESSION_ID:
             SessionManager.fold_inbound(message)
             return
         sess = Session.from_message(message)

--- a/ovos_bus_client/message.py
+++ b/ovos_bus_client/message.py
@@ -193,19 +193,22 @@ def dig_for_message(max_records: int = 10) -> Optional[Message]:
     return None
 
 
-def _stamp_session_if_present(msg: Message) -> Message:
+def _stamp_session_if_present(msg: Message, source: Message) -> Message:
     """Refresh a derived message's session to the live value for its id.
 
-    Mirrors the ovos_spec_tools ``Message.forward`` / ``reply`` stamping for the
-    bus-client Message subclasses (``CollectionMessage`` / ``GUIMessage``), whose
-    differing ``__init__`` signatures force them to build a base ``Message``
-    directly instead of inheriting the stamping spec methods. A session-less
-    message is left untouched (§5); a session for an id the registry never folded
-    is carried verbatim (handled inside ``sync_message_session``).
+    Mirrors the ovos_spec_tools ``Message.forward`` / ``reply`` stamping (see
+    ``_stamp_live_session``) for the bus-client Message subclasses
+    (``CollectionMessage`` / ``GUIMessage``), whose differing ``__init__``
+    signatures force them to build a base ``Message`` directly instead of
+    inheriting the stamping spec methods. A session-less message is left
+    untouched (§5). ``SessionManager.stamp_derived`` prefers the session bound
+    to ``source`` (the handler write of OVOS-CONTEXT-1 §5.3) and falls back to
+    ``sync_message_session`` otherwise, so a session for an id the registry
+    never folded is still carried verbatim.
     """
     if msg.context.get("session"):
         from ovos_spec_tools.session import SessionManager
-        return SessionManager.sync_message_session(msg)
+        return SessionManager.stamp_derived(msg, source)
     return msg
 
 
@@ -326,7 +329,7 @@ class CollectionMessage(Message):
         """
         from copy import deepcopy
         return _stamp_session_if_present(
-            Message(msg_type, data or {}, deepcopy(self.context)))
+            Message(msg_type, data or {}, deepcopy(self.context)), self)
 
     def reply(self, msg_type, data=None, context=None):  # type: ignore[override]
         """
@@ -357,7 +360,7 @@ class CollectionMessage(Message):
         if src is not None:
             new_context["destination"] = src
         msg = Message(msg_type, data or {}, new_context)
-        return msg if explicit_session else _stamp_session_if_present(msg)
+        return msg if explicit_session else _stamp_session_if_present(msg, self)
 
     def response(self, data=None, context=None):  # type: ignore[override]
         """
@@ -447,7 +450,7 @@ class GUIMessage(Message):
         """
         from copy import deepcopy
         return _stamp_session_if_present(
-            Message(msg_type, data or {}, deepcopy(self.context)))
+            Message(msg_type, data or {}, deepcopy(self.context)), self)
 
     def reply(self, msg_type, data=None, context=None):  # type: ignore[override]
         """

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -62,34 +62,7 @@ def session_carrier(message) -> Dict[str, Any]:
     return carrier
 
 
-try:
-    from ovos_spec_tools.session import resolve_session_id
-except ImportError:
-    def resolve_session_id(carrier: Dict[str, Any]) -> str:
-        """Resolve the session id a raw carrier names.
-
-        SESSION-1 §3.1: an omitted ``session_id`` names the default session.
-        §6 requires a non-empty string when the field is set, so an empty or
-        wrong-typed value reads as omitted rather than as a session no
-        message can name.
-
-        @param carrier: the raw session carrier off a Message
-        @return: the session id the carrier names, or the default session id
-        """
-        session_id = carrier.get("session_id")
-        if isinstance(session_id, str) and session_id:
-            return session_id
-        return DEFAULT_SESSION_ID
-
-
-def names_the_default(carrier: Dict[str, Any]) -> bool:
-    """Whether a raw session carrier names the reserved default session.
-
-    Thin wrapper around ``resolve_session_id`` for callers that only need the
-    boolean.
-    """
-    return resolve_session_id(carrier) == DEFAULT_SESSION_ID
-
+from ovos_spec_tools.session import resolve_session_id
 
 _LEGACY_LOCATION_KEYS = ("city", "coordinate", "timezone")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "ovos-config>=1.0.0,<4.0.0",
     "ovos-utils>=0.8.2,<1.0.0",
-    "ovos-spec-tools[langcodes]>=1.7.0a1",  # narrowed is_intent_topic + intent-pair mirror guard
+    "ovos-spec-tools[langcodes]>=1.10.3a1",  # public resolve_session_id + SessionManager.stamp_derived
     "websocket-client>=0.54.0",
     "pyee>=8.1.0,<13.0.0",
 ]

--- a/test/unittests/test_message_session_stamp.py
+++ b/test/unittests/test_message_session_stamp.py
@@ -1,0 +1,138 @@
+"""OVOS-CONTEXT-1 §5.3 / OVOS-MSG-1 §5 — a bound-session write must survive
+onto CollectionMessage / GUIMessage derivations.
+
+``CollectionMessage`` and ``GUIMessage`` cannot inherit the spec-tools
+``Message.forward`` / ``reply`` stamping (their ``__init__`` signatures do
+not match), so ``ovos_bus_client.message._stamp_session_if_present`` mirrors
+it by hand via ``SessionManager.stamp_derived``. Before this fix the helper
+called ``sync_message_session`` with no source, which only re-reads the
+default-session store and never consults the session a handler bound via
+``SessionManager.get(msg)`` — a handler that read its session off a
+collect/GUI message and wrote an intent-context entry on a *named* session
+lost that write the moment the message was forwarded/replied/responded to.
+"""
+import unittest
+
+from ovos_bus_client.message import CollectionMessage, GUIMessage, Message
+from ovos_bus_client.session import Session, SessionManager
+
+
+def _named_context(session_id="kitchen-sat"):
+    return {"session": {"session_id": session_id, "lang": "en-US"}}
+
+
+class TestCollectionMessageCarriesBoundSessionWrites(unittest.TestCase):
+
+    def setUp(self):
+        SessionManager.reset_default_session()
+
+    def tearDown(self):
+        SessionManager.reset_default_session()
+        SessionManager.sessions.pop("kitchen-sat", None)
+
+    def _bind_and_mutate(self, msg):
+        sess = SessionManager.get(msg)
+        sess.set_intent_context("k", "v", scope="shared")
+        return sess
+
+    def test_forward_carries_the_bound_write(self):
+        msg = CollectionMessage("q", "h1", "q1", {}, _named_context())
+        self._bind_and_mutate(msg)
+
+        fwd = msg.forward("q.forwarded", {})
+
+        stamped = Session.deserialize(fwd.context["session"])
+        self.assertIn("k", stamped.intent_context)
+
+    def test_reply_carries_the_bound_write(self):
+        msg = CollectionMessage("q", "h1", "q1", {}, _named_context())
+        self._bind_and_mutate(msg)
+
+        rep = msg.reply("q.reply", {})
+
+        stamped = Session.deserialize(rep.context["session"])
+        self.assertIn("k", stamped.intent_context)
+
+    def test_response_carries_the_bound_write(self):
+        msg = CollectionMessage("q", "h1", "q1", {}, _named_context())
+        self._bind_and_mutate(msg)
+
+        resp = msg.response({})
+
+        stamped = Session.deserialize(resp.context["session"])
+        self.assertIn("k", stamped.intent_context)
+
+    def test_explicit_session_in_reply_context_still_wins(self):
+        msg = CollectionMessage("q", "h1", "q1", {}, _named_context())
+        self._bind_and_mutate(msg)
+
+        explicit = {"session_id": "kitchen-sat", "lang": "pt-PT"}
+        rep = msg.reply("q.reply", {}, context={"session": explicit})
+
+        # the caller-supplied session is honoured verbatim, not overwritten
+        # with the live bound session's stamp
+        self.assertEqual(rep.context["session"], explicit)
+        self.assertNotIn("intent_context", rep.context["session"])
+
+
+class TestGUIMessageCarriesBoundSessionWrites(unittest.TestCase):
+
+    def setUp(self):
+        SessionManager.reset_default_session()
+
+    def tearDown(self):
+        SessionManager.reset_default_session()
+        SessionManager.sessions.pop("kitchen-sat", None)
+
+    def _gui_message_with_context(self, msg_type="gui.show"):
+        # GUIMessage.__init__ only accepts kwargs -> data, so build the
+        # context by hand as forward()/reply() do internally.
+        msg = GUIMessage(msg_type)
+        msg.context = _named_context()
+        return msg
+
+    def _bind_and_mutate(self, msg):
+        sess = SessionManager.get(msg)
+        sess.set_intent_context("k", "v", scope="shared")
+        return sess
+
+    def test_forward_carries_the_bound_write(self):
+        msg = self._gui_message_with_context()
+        self._bind_and_mutate(msg)
+
+        fwd = msg.forward("gui.forwarded", {})
+
+        stamped = Session.deserialize(fwd.context["session"])
+        self.assertIn("k", stamped.intent_context)
+
+    def test_reply_carries_the_bound_write(self):
+        msg = self._gui_message_with_context()
+        self._bind_and_mutate(msg)
+
+        rep = msg.reply("gui.reply", {})
+
+        stamped = Session.deserialize(rep.context["session"])
+        self.assertIn("k", stamped.intent_context)
+
+    def test_response_carries_the_bound_write(self):
+        msg = self._gui_message_with_context()
+        self._bind_and_mutate(msg)
+
+        resp = msg.response({})
+
+        stamped = Session.deserialize(resp.context["session"])
+        self.assertIn("k", stamped.intent_context)
+
+    def test_explicit_session_in_reply_context_still_wins(self):
+        msg = self._gui_message_with_context()
+        self._bind_and_mutate(msg)
+
+        explicit = {"session_id": "kitchen-sat", "lang": "pt-PT"}
+        rep = msg.reply("gui.reply", {}, context={"session": explicit})
+
+        self.assertEqual(rep.context["session"], explicit)
+        self.assertNotIn("intent_context", rep.context["session"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_session_authority.py
+++ b/test/unittests/test_session_authority.py
@@ -14,7 +14,8 @@ import ovos_bus_client.session as session_module
 from ovos_bus_client.client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import (Session, SessionManager, HAS_FOLD_INBOUND,
-                                     names_the_default, session_carrier)
+                                     DEFAULT_SESSION_ID, resolve_session_id,
+                                     session_carrier)
 
 
 def _client(session=None):
@@ -67,13 +68,16 @@ class TestFalsySessionIdIsTheDefaultSession(unittest.TestCase):
         SessionManager.reset_default_session()
 
     def test_predicate_reads_unusable_ids_as_the_default(self):
-        self.assertTrue(names_the_default({}))
-        self.assertTrue(names_the_default({"session_id": "default"}))
-        self.assertFalse(names_the_default({"session_id": "kitchen"}))
+        self.assertEqual(resolve_session_id({}), DEFAULT_SESSION_ID)
+        self.assertEqual(resolve_session_id({"session_id": "default"}),
+                          DEFAULT_SESSION_ID)
+        self.assertNotEqual(resolve_session_id({"session_id": "kitchen"}),
+                            DEFAULT_SESSION_ID)
         if HAS_FOLD_INBOUND:
             for unusable in ("", 0, False, [], {}):
-                self.assertTrue(names_the_default({"session_id": unusable}),
-                                f"{unusable!r} names no session")
+                self.assertEqual(resolve_session_id({"session_id": unusable}),
+                                 DEFAULT_SESSION_ID,
+                                 f"{unusable!r} names no session")
 
     @unittest.skipUnless(HAS_FOLD_INBOUND, "no §3.1 predicate in the registry")
     def test_empty_id_folds_into_the_store_and_still_dispatches(self):

--- a/test/unittests/test_session_id_resolution.py
+++ b/test/unittests/test_session_id_resolution.py
@@ -1,10 +1,9 @@
 """SESSION-1 §2/§3.1/§6 — resolving a raw carrier's ``session_id`` locally.
 
-``resolve_session_id`` and ``names_the_default`` must not reach into
-``ovos_spec_tools.session.SessionManager._names_the_default`` (a private that
-package is removing) and must apply the same non-empty-string rule §6
-requires: a wrong-typed value is malformed and reads as omitted (§2.1), and
-an omitted id names the default session (§3.1).
+``resolve_session_id`` is the public ``ovos_spec_tools.session`` resolver and
+must apply the non-empty-string rule §6 requires: a wrong-typed value is
+malformed and reads as omitted (§2.1), and an omitted id names the default
+session (§3.1).
 """
 import unittest
 from unittest.mock import MagicMock
@@ -12,7 +11,7 @@ from unittest.mock import MagicMock
 from ovos_bus_client.client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import (DEFAULT_SESSION_ID, SessionManager,
-                                     names_the_default, resolve_session_id)
+                                     resolve_session_id)
 
 
 class TestResolveSessionId(unittest.TestCase):
@@ -27,11 +26,6 @@ class TestResolveSessionId(unittest.TestCase):
 
     def test_a_named_string_id_resolves_to_itself(self):
         self.assertEqual(resolve_session_id({"session_id": "abc"}), "abc")
-
-    def test_names_the_default_agrees_with_resolve_session_id(self):
-        for carrier in ({}, {"session_id": 123}, {"session_id": "kitchen"}):
-            self.assertEqual(names_the_default(carrier),
-                              resolve_session_id(carrier) == DEFAULT_SESSION_ID)
 
 
 class TestWrongTypedIdOnTheWireIsTheDefaultSession(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The ovos-spec-tools floor moves to >=1.10.3a1 so `session.py` can drop its local `resolve_session_id` fallback and the `try/except ImportError` guarding it: the public resolver has now shipped for two releases, and the private `SessionManager._names_the_default` it used to fall back to is being removed upstream. `names_the_default()` is deleted outright with no alias — its two callers in `client.py` and `async_client.py` now compare `resolve_session_id(carrier) == DEFAULT_SESSION_ID` directly, and the existing tests that pinned the wrapper (`test_names_the_default_agrees_with_resolve_session_id` in `test_session_id_resolution.py`, plus the `names_the_default` calls in `test_session_authority.py`) were rewritten against the public resolver; the former is dropped outright since it only existed to compare the wrapper against the thing it wrapped.

`_stamp_session_if_present(msg)` in `message.py` called `SessionManager.sync_message_session(msg)` with no source message, so it never consulted a session a handler had bound via `SessionManager.get(msg)`. That helper exists because `CollectionMessage` and `GUIMessage` can't inherit the spec-tools `Message.forward`/`reply` stamping (their `__init__` signatures don't match the base class), so they hand-roll the same behavior. In practice: a handler that reads its session off a collect-protocol or GUI message and writes an OVOS-CONTEXT-1 intent-context entry on a *named* session loses that write the instant the message is forwarded, replied to, or turned into a `.response` — the derived message carries the stale snapshot instead. The fix threads the source message through and calls `SessionManager.stamp_derived(derived, source)`, mirroring `ovos_spec_tools.message._stamp_live_session` exactly; the existing explicit-session early return in `reply()` is untouched.

New tests in `test_message_session_stamp.py` bind a session via `SessionManager.get(msg)`, write an intent-context entry, and assert it survives `forward()`/`reply()`/`response()` on both `CollectionMessage` and `GUIMessage`, plus a pair of tests confirming an explicit session passed into `reply()`'s context still wins verbatim. All six positive assertions fail against a revert of the `message.py` change alone (`AssertionError: 'k' not found in {}`) and pass once it's restored. Full suite: 1044 passed / 6 skipped on the rebased `origin/dev` base (4aaf3ad), 1051 passed / 6 skipped on this branch — net +7 (8 new tests minus the one dropped wrapper-pin test), no other test's status changed. `pr_hygiene_lint.py --base origin/dev` reports clean (8 files, 1 commit).