### PR TITLE
fix: never push the default session on connect (OVOS-SESSION-2 §2.7)

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1526,13 +1526,19 @@ class _BusSessionManagerMixin:
 
     @classmethod
     def connect_to_bus(cls, bus):
+        """Attach the registry to ``bus`` and subscribe its handlers.
+
+        Nothing is announced: no participant pushes a session at another
+        (OVOS-SESSION-2 §2.7). The default session is derived locally from
+        configuration and thereafter converges by adoption from observed
+        traffic.
+        """
         cls.bus = bus
         cls.bus.on("recognizer_loop:record_begin", cls.handle_recording_start)
         cls.bus.on("recognizer_loop:record_end", cls.handle_recording_end)
         cls.bus.on("recognizer_loop:audio_output_start", cls.handle_audio_output_start)
         cls.bus.on("recognizer_loop:audio_output_end", cls.handle_audio_output_end)
         cls.bus.on(SpecMessage.SESSION_SYNC, cls.handle_session_sync)
-        cls._broadcast_default_session()
 
     @classmethod
     def prune_sessions(cls):

--- a/test/unittests/test_no_connect_broadcast.py
+++ b/test/unittests/test_no_connect_broadcast.py
@@ -1,0 +1,62 @@
+"""OVOS-SESSION-2 §2.7 — connecting announces nothing.
+
+There is no topic on which a participant pushes its own session at another.
+A process joining a bus derives its default session from configuration and
+converges by adoption from the traffic it observes, so attaching the session
+registry to a bus must be silent. A connect-time broadcast would let any
+joining process overwrite the orchestrator's default-session store with a
+view built from its own configuration.
+"""
+import unittest
+
+from ovos_utils.fakebus import FakeBus
+
+from ovos_bus_client.session import SessionManager
+
+# every spelling the default-session push has ever travelled under
+BROADCAST_TOPICS = {"ovos.session.update_default",
+                    "mycroft.session.update_default",
+                    "ovos.session.sync",
+                    "mycroft.session.sync"}
+
+
+class TestConnectDoesNotBroadcast(unittest.TestCase):
+    def setUp(self):
+        self.bus = FakeBus()
+        self.emitted = []
+        self.bus.on("message", lambda m: self.emitted.append(m))
+
+    def tearDown(self):
+        SessionManager.bus = None
+        SessionManager.reset_default_session()
+
+    def test_connect_emits_nothing(self):
+        SessionManager.connect_to_bus(self.bus)
+        self.assertEqual([m for m in self.emitted
+                          if _msg_type(m) in BROADCAST_TOPICS], [])
+        self.assertEqual(self.emitted, [])
+
+    def test_default_session_still_resolves_locally(self):
+        SessionManager.connect_to_bus(self.bus)
+        sess = SessionManager.get_default_session()
+        self.assertEqual(sess.session_id, "default")
+        self.assertTrue(sess.lang)
+        self.assertEqual([], self.emitted)
+
+    def test_orchestrator_echo_is_still_consumable(self):
+        """The legacy request/echo path an orchestrator drives is untouched."""
+        SessionManager.connect_to_bus(self.bus)
+        SessionManager.handle_default_session_request(None)
+        self.assertEqual([_msg_type(m) for m in self.emitted],
+                         ["ovos.session.update_default"])
+
+
+def _msg_type(msg):
+    if isinstance(msg, str):
+        import json
+        return json.loads(msg).get("type")
+    return msg.msg_type
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_session_extra.py
+++ b/test/unittests/test_session_extra.py
@@ -488,7 +488,7 @@ class TestSessionManager(TestCase):
                 "ovos.session.sync",
             ]:
                 self.assertIn(event, registered)
-            self.assertTrue(bus.emit.called)
+            self.assertFalse(bus.emit.called)
         finally:
             SessionManager.bus = None
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 via Claude Code — NOT human-reviewed. Verify before acting.

Attaching the session registry to the bus used to announce something. `SessionManager.connect_to_bus` emitted `ovos.session.update_default` carrying this process's own default session, so any participant — a skill container, a satellite, anything linking bus-client — could overwrite the orchestrator's default-session store with a view built from its own configuration.

That is how a mixed-vintage bus dies silently. A process whose config spells the pipeline with plugin ids (`ovos-adapt-pipeline-plugin-high`) joins a bus whose core understands the short matcher ids (`adapt_high`). The core adopts the pushed session, resolves no pipeline at all, and every utterance that arrives without an explicit session ends in `complete_intent_failure` — the local mic answers "I don't understand" while named-session satellites keep working, and nothing logs an error. Re-injecting an update with the legacy spelling restores matching, which pins the cause on the pushed payload rather than on the pipeline plumbing.

OVOS-SESSION-2 §2.7 rules this out by construction: there is no topic on which a session is pushed at another participant. Co-located processes derive the default session from the same deployment configuration, so their views agree without a handshake, and they converge thereafter by adopting the session of the messages they act on. The orchestrator is the only writer of the default store. So the connect-time broadcast was a spec violation as well as a compatibility hazard, and the fix is simply to drop it: `connect_to_bus` now only subscribes handlers.

Everything else that still emits `ovos.session.update_default` is request-driven and stays. A bare `ovos.session.sync` is a legacy *request* for the current default session and is still echoed, and `SessionManager.sync` (which `reset_default_session` goes through) remains the deprecated explicit call an orchestrator makes about its own store. ovos-core drives both of those itself — `intent_services/service.py` and `converse_service.py` call `SessionManager.sync(message)` on its own default session, which is the orchestrator writing as the orchestrator. No ovos-core caller depended on the connect-time emission.

A new test asserts that connecting to a `FakeBus` emits nothing at all (checked against every spelling the push has travelled under, including the mycroft-namespace twins), that the default session still resolves locally from configuration, and that the orchestrator's echo path is unchanged. Reverting only the source change fails four tests, three new plus the existing `connect_to_bus` test that had asserted an emit; all pass with the fix. Full suite: 1057 passed, 6 skipped, against a 1054/6 baseline on `dev`.
