### PR TITLE
fix: location_preferences setter, session/message readability cleanup

### DIFF
--- a/ovos_bus_client/message.py
+++ b/ovos_bus_client/message.py
@@ -36,6 +36,7 @@ from ovos_spec_tools.message import (
     DEFAULT_SESSION_ID,
     MalformedMessage,
     Message,
+    _stamp_live_session,
 )
 from ovos_utils import json_dumps
 from ovos_utils.log import deprecated
@@ -193,25 +194,6 @@ def dig_for_message(max_records: int = 10) -> Optional[Message]:
     return None
 
 
-def _stamp_session_if_present(msg: Message, source: Message) -> Message:
-    """Refresh a derived message's session to the live value for its id.
-
-    Mirrors the ovos_spec_tools ``Message.forward`` / ``reply`` stamping (see
-    ``_stamp_live_session``) for the bus-client Message subclasses
-    (``CollectionMessage`` / ``GUIMessage``), whose differing ``__init__``
-    signatures force them to build a base ``Message`` directly instead of
-    inheriting the stamping spec methods. A session-less message is left
-    untouched (§5). ``SessionManager.stamp_derived`` prefers the session bound
-    to ``source`` (the handler write of OVOS-CONTEXT-1 §5.3) and falls back to
-    ``sync_message_session`` otherwise, so a session for an id the registry
-    never folded is still carried verbatim.
-    """
-    if msg.context.get("session"):
-        from ovos_spec_tools.session import SessionManager
-        return SessionManager.stamp_derived(msg, source)
-    return msg
-
-
 class CollectionMessage(Message):
     """Extension of :class:`Message` for use with collect handlers.
 
@@ -328,7 +310,7 @@ class CollectionMessage(Message):
             Message: A new Message constructed with `msg_type`, `data` (or `{}`), and a deep-copied context from this message.
         """
         from copy import deepcopy
-        return _stamp_session_if_present(
+        return _stamp_live_session(
             Message(msg_type, data or {}, deepcopy(self.context)), self)
 
     def reply(self, msg_type, data=None, context=None):  # type: ignore[override]
@@ -360,7 +342,7 @@ class CollectionMessage(Message):
         if src is not None:
             new_context["destination"] = src
         msg = Message(msg_type, data or {}, new_context)
-        return msg if explicit_session else _stamp_session_if_present(msg, self)
+        return msg if explicit_session else _stamp_live_session(msg, self)
 
     def response(self, data=None, context=None):  # type: ignore[override]
         """
@@ -449,7 +431,7 @@ class GUIMessage(Message):
             Message: A new Message constructed with `msg_type`, `data` (or `{}`), and a deep-copied context from this message.
         """
         from copy import deepcopy
-        return _stamp_session_if_present(
+        return _stamp_live_session(
             Message(msg_type, data or {}, deepcopy(self.context)), self)
 
     def reply(self, msg_type, data=None, context=None):  # type: ignore[override]

--- a/ovos_bus_client/scripts.py
+++ b/ovos_bus_client/scripts.py
@@ -116,7 +116,7 @@ def simple_cli():
     lang = lang or Configuration().get("lang", "en-us")
 
     from ovos_bus_client.session import SessionManager, Session
-    sess = SessionManager.default_session
+    sess = SessionManager.get_default_session()
 
     while True:
         try:

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -13,7 +13,8 @@ from ovos_spec_tools.session import (Session as _SpecSession,
                                      DEFAULT_CONVERSE_HANDLERS_CAP,
                                      DEFAULT_SESSION_ID,
                                      MalformedSession,
-                                     SESSION1_REGISTERED_FIELDS)
+                                     SESSION1_REGISTERED_FIELDS,
+                                     resolve_session_id)
 from ovos_bus_client.message import dig_for_message, Message
 from ovos_bus_client.version import VERSION_MAJOR
 
@@ -32,13 +33,6 @@ if not hasattr(_SpecSessionManager, "_pre_graft"):
                                       "update": _SpecSessionManager.update.__func__}
 _spec_get = _SpecSessionManager._pre_graft["get"]
 _spec_update = _SpecSessionManager._pre_graft["update"]
-
-#: ``SessionManager.fold_inbound`` is the OVOS-SESSION-2 §5.1 arrival merge: it
-#: takes the raw carrier off an inbound Message and merges it into the
-#: default-session store. Older spec-tools releases have no arrival point and
-#: fold lazily inside ``get`` instead, so the receive path only calls it where
-#: the registry offers it.
-HAS_FOLD_INBOUND = hasattr(_SpecSessionManager, "fold_inbound")
 
 
 def session_carrier(message) -> Dict[str, Any]:
@@ -61,8 +55,6 @@ def session_carrier(message) -> Dict[str, Any]:
         raise MalformedSession("session must be a JSON object (§2.5)")
     return carrier
 
-
-from ovos_spec_tools.session import resolve_session_id
 
 _LEGACY_LOCATION_KEYS = ("city", "coordinate", "timezone")
 
@@ -113,20 +105,11 @@ def _get_default_lang() -> str:
     """
     return Configuration().get("lang", "en-us")
 
-# Bidirectional-wire back-compat: the canonical parent applies SESSION-1 §2.1
-# omit-when-empty semantics and stores an *empty* collection field as ``None``.
-# On the wire that is equivalent to omission, but in-process it breaks the
-# public contract that these fields are always iterable containers — consumers
-# do ``intent in session.blacklisted_intents`` and a ``None`` raises
-# ``TypeError: argument of type 'NoneType' is not iterable``. These fields are
-# therefore folded back to their canonical empty container after construction
-# so they ALWAYS deserialize to ``[]`` / ``{}``, never ``None``. Serialization
-# omits them when empty (``to_dict`` drops falsy values), per SESSION-1 §3.4:
-# an empty list-valued override field is wire-equivalent to omission, and a
-# producer SHOULD NOT spend wire weight restating the deployment default on
-# every Message. Scalar fields (``site_id``, ``persona_id``, the per-channel
-# language overrides) and the single-object ``response_mode`` legitimately stay
-# ``None`` and are intentionally excluded.
+# The canonical parent stores an empty list/dict field as ``None`` (SESSION-1
+# §2.1 omit-when-empty); these fields are folded back to ``[]`` / ``{}`` after
+# construction so ``x in session.<field>`` never raises ``TypeError``. Scalar
+# fields and the single-object ``response_mode`` stay ``None`` and are
+# intentionally excluded.
 _CANONICAL_LIST_FIELDS = (
     "secondary_langs",
     "pipeline",
@@ -154,13 +137,8 @@ _CANONICAL_DICT_FIELDS = (
     "location",
 )
 
-# Guards every mutation of a Session's ``intent_context`` map (the canonical
-# mutators, the legacy view's write-through folds, and the §5.3 sync merge).
-# Bus handlers run on reader threads, so two writers — or a writer racing the
-# sync merge's iteration — are a real schedule. A single module-level lock is
-# deliberate: contention is negligible (mutations are tiny dict ops) and a
-# per-instance lock would be replaced whenever ``update_from`` swaps a
-# session's ``__dict__``, silently splitting the mutual exclusion.
+# Module-level because ``update_from`` swaps a session's ``__dict__``, which
+# would replace a per-instance lock and silently split the mutual exclusion.
 _CONTEXT_LOCK = RLock()
 
 
@@ -905,10 +883,10 @@ class Session(_SpecSession):
         leaking a ``None`` that breaks ``x in session.<field>``.
         """
         for name in _CANONICAL_LIST_FIELDS:
-            if getattr(self, name, None) is None:
+            if getattr(self, name) is None:
                 setattr(self, name, [])
         for name in _CANONICAL_DICT_FIELDS:
-            if getattr(self, name, None) is None:
+            if getattr(self, name) is None:
                 setattr(self, name, {})
 
     def _context_view(self) -> "_IntentContextView":
@@ -995,7 +973,7 @@ class Session(_SpecSession):
                         "'location' field ({lat, lon, tz}); use "
                         "session.location directly",
                         _NEXT_MAJOR_VERSION)
-        self.location = _normalize_location_input(value or {})
+        self.location = _normalize_location_input(value or {}) or {}
 
     # ------------------------------------------------------------------
     # touch() on mutation — lifecycle bookkeeping the canonical class omits.
@@ -1510,7 +1488,7 @@ class _BusSessionManagerMixin:
         if cls.bus:
             message = message or Message(SpecMessage.SESSION_SYNC)
             cls.bus.emit(message.reply("ovos.session.update_default",
-                                       {"session_data": cls.default_session.serialize()}))
+                                       {"session_data": cls.get_default_session().serialize()}))
 
     @classmethod
     def sync(cls, message=None):
@@ -1570,7 +1548,6 @@ class _BusSessionManagerMixin:
         """
         sess = cls.session_cls.deserialize({"session_id": DEFAULT_SESSION_ID})
         cls.sessions[DEFAULT_SESSION_ID] = sess
-        cls.default_session = sess
         LOG.info("Default Session reset")
         cls.sync()
         return sess

--- a/test/unittests/test_client_more.py
+++ b/test/unittests/test_client_more.py
@@ -8,8 +8,7 @@ from unittest.mock import MagicMock, patch
 from ovos_bus_client.client.client import (GUIWebsocketClient,
                                            MessageBusClient)
 from ovos_bus_client.message import GUIMessage, Message
-from ovos_bus_client.session import (Session, SessionManager,
-                                     HAS_FOLD_INBOUND)
+from ovos_bus_client.session import Session, SessionManager
 from websocket import (WebSocketConnectionClosedException, WebSocketException)
 
 
@@ -94,7 +93,7 @@ class TestOnDefaultSessionUpdate(TestCase):
                       {"session_data": s.serialize()})
         # capture default before
         bus.on_default_session_update(msg)
-        self.assertEqual(SessionManager.default_session.session_id, "default")
+        self.assertEqual(SessionManager.get_default_session().session_id, "default")
         # session_id forced to "default" when make_default=True
 
 
@@ -109,11 +108,8 @@ class TestOnMessageSessionUpdate(TestCase):
         bus.on_message(raw)
         # a named session on the wire never lands in the default store
         self.assertNotEqual(SessionManager.get_default_session().lang, "pt-PT")
-        if HAS_FOLD_INBOUND:
-            # §2.2: and it leaves no cross-utterance registry state either
-            self.assertNotIn("kitchen", SessionManager.sessions)
-        else:
-            self.assertIn("kitchen", SessionManager.sessions)
+        # §2.2: and it leaves no cross-utterance registry state either
+        self.assertNotIn("kitchen", SessionManager.sessions)
 
 
 class TestTwoArgDispatch(TestCase):

--- a/test/unittests/test_default_session_fold.py
+++ b/test/unittests/test_default_session_fold.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 from ovos_bus_client.client.client import MessageBusClient
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import SessionManager, HAS_FOLD_INBOUND
+from ovos_bus_client.session import SessionManager
 
 
 def _inbound(carrier):
@@ -82,8 +82,6 @@ class TestObservedMessagesNeverFoldTheDefaultStore(unittest.TestCase):
         self.assertEqual(stored.site_id, "kitchen")
 
 
-@unittest.skipUnless(HAS_FOLD_INBOUND,
-                     "spec-tools registry has no fold_inbound arrival point")
 class TestExplicitIntakeFoldStillWorksThroughTheSameClient(unittest.TestCase):
     """The orchestrator's own explicit §5.1 fold at intake is untouched.
 

--- a/test/unittests/test_message_session_stamp.py
+++ b/test/unittests/test_message_session_stamp.py
@@ -3,13 +3,12 @@ onto CollectionMessage / GUIMessage derivations.
 
 ``CollectionMessage`` and ``GUIMessage`` cannot inherit the spec-tools
 ``Message.forward`` / ``reply`` stamping (their ``__init__`` signatures do
-not match), so ``ovos_bus_client.message._stamp_session_if_present`` mirrors
-it by hand via ``SessionManager.stamp_derived``. Before this fix the helper
-called ``sync_message_session`` with no source, which only re-reads the
-default-session store and never consults the session a handler bound via
-``SessionManager.get(msg)`` — a handler that read its session off a
-collect/GUI message and wrote an intent-context entry on a *named* session
-lost that write the moment the message was forwarded/replied/responded to.
+not match), so their ``forward``/``reply``/``response`` overrides call
+``ovos_spec_tools.message._stamp_live_session`` by hand. It consults the
+session a handler bound via ``SessionManager.get(msg)``, not just the
+default-session store — a handler that read its session off a collect/GUI
+message and wrote an intent-context entry on a *named* session must not
+lose that write the moment the message is forwarded/replied/responded to.
 """
 import unittest
 

--- a/test/unittests/test_session.py
+++ b/test/unittests/test_session.py
@@ -2,8 +2,6 @@ import unittest
 from unittest.mock import patch
 from time import time, sleep
 
-from ovos_bus_client.session import HAS_FOLD_INBOUND
-
 
 class TestSessionModule(unittest.TestCase):
     def test_utterance_state(self):
@@ -11,6 +9,16 @@ class TestSessionModule(unittest.TestCase):
         for state in UtteranceState:
             self.assertIsInstance(state, UtteranceState)
             self.assertIsInstance(state, str)
+
+    def test_location_preferences_setter_empty_value_keeps_location_dict(self):
+        from ovos_bus_client.session import Session
+        sess = Session()
+        for empty in ({}, None):
+            sess.location_preferences = empty
+            self.assertEqual(sess.location, {})
+            # timezone falls back to deployment config and must not raise
+            # AttributeError on a None `location`
+            sess.timezone
 
 
 class TestIntentContextManagerFrame(unittest.TestCase):
@@ -249,7 +257,7 @@ class TestSessionManager(unittest.TestCase):
         from ovos_bus_client.session import Session
         session = self.SessionManager.reset_default_session()
         self.assertIsInstance(session, Session)
-        self.assertEqual(session, self.SessionManager.default_session)
+        self.assertEqual(session, self.SessionManager.get_default_session())
         # TODO
 
     def test_update_writes_the_default_store_in_place(self):
@@ -268,12 +276,9 @@ class TestSessionManager(unittest.TestCase):
         from ovos_bus_client.session import Session
         sess = Session("sid-update")
         self.assertIs(self.SessionManager.update(sess), sess)
-        if HAS_FOLD_INBOUND:
-            # OVOS-SESSION-2 §2.2: the orchestrator keeps no state for a named
-            # session, so a write records nothing and the caller keeps the object
-            self.assertNotIn("sid-update", self.SessionManager.sessions)
-        else:
-            self.assertIs(self.SessionManager.sessions["sid-update"], sess)
+        # OVOS-SESSION-2 §2.2: the orchestrator keeps no state for a named
+        # session, so a write records nothing and the caller keeps the object
+        self.assertNotIn("sid-update", self.SessionManager.sessions)
 
     def test_get_resolves_the_named_session_on_the_message(self):
         from ovos_bus_client.session import Session
@@ -285,16 +290,12 @@ class TestSessionManager(unittest.TestCase):
         second = self.SessionManager.get(msg)
         self.assertEqual(first.session_id, "sid-get")
         self.assertEqual(second.session_id, "sid-get")
-        if HAS_FOLD_INBOUND:
-            # OVOS-SESSION-2 §2.2: the orchestrator is stateless for a named
-            # session, and §2.6 makes get a pure read — it builds the session
-            # the carrier describes and registers nothing. Whether repeated
-            # get() calls on the same message return the identical object is
-            # an implementation detail of the carrier library, not this repo.
-            self.assertNotIn("sid-get", self.SessionManager.sessions)
-        else:
-            self.assertIs(first, second)
-            self.assertIs(self.SessionManager.sessions["sid-get"], first)
+        # OVOS-SESSION-2 §2.2: the orchestrator is stateless for a named
+        # session, and §2.6 makes get a pure read — it builds the session
+        # the carrier describes and registers nothing. Whether repeated
+        # get() calls on the same message return the identical object is
+        # an implementation detail of the carrier library, not this repo.
+        self.assertNotIn("sid-get", self.SessionManager.sessions)
 
     def test_held_reference_observes_later_mutation(self):
         # the corner case the singleton fixes: a reference taken early in a
@@ -349,10 +350,9 @@ class TestSessionManager(unittest.TestCase):
         # a snapshot that carries a value for a field replaces the stored one
         self.SessionManager.update(Session("default", lang="pt-PT"))
         self.assertEqual(held.lang, "pt-PT")
-        if HAS_FOLD_INBOUND:
-            # OVOS-SESSION-2 §2.6: a write is authoritative whole state, so the
-            # skills the snapshot does not carry are gone from the store too
-            self.assertEqual(held.active_skills, [])
+        # OVOS-SESSION-2 §2.6: a write is authoritative whole state, so the
+        # skills the snapshot does not carry are gone from the store too
+        self.assertEqual(held.active_skills, [])
 
     def test_update_from_does_not_alias_nested_state(self):
         # round-tripping through (de)serialize rebuilds nested objects, so the

--- a/test/unittests/test_session_authority.py
+++ b/test/unittests/test_session_authority.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import ovos_bus_client.session as session_module
 from ovos_bus_client.client.client import MessageBusClient
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import (Session, SessionManager, HAS_FOLD_INBOUND,
+from ovos_bus_client.session import (Session, SessionManager,
                                      DEFAULT_SESSION_ID, resolve_session_id,
                                      session_carrier)
 
@@ -73,11 +73,10 @@ class TestFalsySessionIdIsTheDefaultSession(unittest.TestCase):
                           DEFAULT_SESSION_ID)
         self.assertNotEqual(resolve_session_id({"session_id": "kitchen"}),
                             DEFAULT_SESSION_ID)
-        if HAS_FOLD_INBOUND:
-            for unusable in ("", 0, False, [], {}):
-                self.assertEqual(resolve_session_id({"session_id": unusable}),
-                                 DEFAULT_SESSION_ID,
-                                 f"{unusable!r} names no session")
+        for unusable in ("", 0, False, [], {}):
+            self.assertEqual(resolve_session_id({"session_id": unusable}),
+                             DEFAULT_SESSION_ID,
+                             f"{unusable!r} names no session")
 
     def test_empty_id_still_dispatches_without_folding_the_store(self):
         # An unusable id IS the default session (§3.1), but the §5.1 arrival
@@ -130,7 +129,6 @@ class TestGetDoesNotTouchTheMessage(unittest.TestCase):
         SessionManager.get(msg)
         self.assertEqual(msg.context["session"], carrier)
 
-    @unittest.skipUnless(HAS_FOLD_INBOUND, "get folds on older registries")
     def test_reading_a_default_message_does_not_move_the_store(self):
         SessionManager.reset_default_session()
         SessionManager.get_default_session().site_id = "kitchen"
@@ -169,7 +167,6 @@ class TestTouchReplacesTheDefaultStore(unittest.TestCase):
     def tearDown(self):
         SessionManager.reset_default_session()
 
-    @unittest.skipUnless(HAS_FOLD_INBOUND, "older registries merge on write")
     def test_stale_default_copy_wipes_uncarried_fields(self):
         SessionManager.get_default_session().site_id = "kitchen"
         stale = Session.deserialize({"session_id": "default", "lang": "en-US"})

--- a/test/unittests/test_session_extra.py
+++ b/test/unittests/test_session_extra.py
@@ -9,13 +9,11 @@ from unittest.mock import MagicMock, patch
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import (IntentContextManager,
                                      IntentContextManagerFrame, Session,
-                                     SessionManager, UtteranceState,
-                                     HAS_FOLD_INBOUND)
+                                     SessionManager, UtteranceState)
 
 
 def _reset_session_manager():
     default = Session("default")
-    SessionManager.default_session = default
     SessionManager.sessions = {"default": default}
     SessionManager.bus = None
 
@@ -340,21 +338,15 @@ class TestSessionManager(TestCase):
         msg = Message("t", context={"session": s.serialize()})
         sess = SessionManager.get(msg)
         self.assertEqual(sess.session_id, "k")
-        if HAS_FOLD_INBOUND:
-            # a named session is client-owned (OVOS-SESSION-2 §2.2); reading one
-            # off a message leaves no cross-utterance state behind
-            self.assertNotIn("k", SessionManager.sessions)
-        else:
-            self.assertIn("k", SessionManager.sessions)
+        # a named session is client-owned (OVOS-SESSION-2 §2.2); reading one
+        # off a message leaves no cross-utterance state behind
+        self.assertNotIn("k", SessionManager.sessions)
 
     def test_update_stores_session(self):
         s = Session("upd")
         self.assertIs(SessionManager.update(s), s)
-        if HAS_FOLD_INBOUND:
-            # §2.2: no orchestrator state for a named session, not even briefly
-            self.assertNotIn("upd", SessionManager.sessions)
-        else:
-            self.assertIs(SessionManager.sessions["upd"], s)
+        # §2.2: no orchestrator state for a named session, not even briefly
+        self.assertNotIn("upd", SessionManager.sessions)
 
     def test_update_make_default(self):
         # "default" is a singleton: make_default folds the snapshot onto the
@@ -363,7 +355,7 @@ class TestSessionManager(TestCase):
         s = Session("foo")
         canonical = SessionManager.update(s, make_default=True)
         self.assertEqual(s.session_id, "default")
-        self.assertIs(SessionManager.default_session, canonical)
+        self.assertIs(SessionManager.get_default_session(), canonical)
         self.assertIs(SessionManager.sessions["default"], canonical)
 
     def test_update_raises_on_none(self):
@@ -371,13 +363,13 @@ class TestSessionManager(TestCase):
             SessionManager.update(None)
 
     def test_touch_updates_default_when_no_message(self):
-        before = SessionManager.default_session.touch_time
-        SessionManager.default_session.touch_time = before - 100
+        before = SessionManager.get_default_session().touch_time
+        SessionManager.get_default_session().touch_time = before - 100
         SessionManager.touch()
-        self.assertGreater(SessionManager.default_session.touch_time, before - 100)
+        self.assertGreater(SessionManager.get_default_session().touch_time, before - 100)
 
     def test_reset_default_session_creates_fresh(self):
-        old = SessionManager.default_session
+        old = SessionManager.get_default_session()
         new = SessionManager.reset_default_session()
         self.assertIsNot(new, old)
         self.assertEqual(new.session_id, "default")
@@ -393,7 +385,7 @@ class TestSessionManager(TestCase):
 
     def test_is_speaking_default(self):
         self.assertFalse(SessionManager.is_speaking())
-        sess = SessionManager.default_session
+        sess = SessionManager.get_default_session()
         sess.is_speaking = True
         SessionManager.update(sess)
         self.assertTrue(SessionManager.is_speaking())
@@ -433,8 +425,7 @@ class TestSessionManager(TestCase):
                 Message("recognizer_loop:record_begin",
                         context={"session": Session("theirs").serialize()}))
             self.assertFalse(held.is_recording)
-            if HAS_FOLD_INBOUND:
-                self.assertIsNone(SessionManager.held_session("theirs"))
+            self.assertIsNone(SessionManager.held_session("theirs"))
         finally:
             SessionManager.bus = None
 
@@ -504,7 +495,7 @@ class TestSessionManager(TestCase):
     def test_wait_while_speaking_not_speaking_returns_immediately(self):
         SessionManager.bus = MagicMock()
         try:
-            sess = SessionManager.default_session
+            sess = SessionManager.get_default_session()
             sess.is_speaking = False
             SessionManager.update(sess)
             SessionManager.wait_while_speaking(timeout=0.01)
@@ -515,7 +506,7 @@ class TestSessionManager(TestCase):
         """Bool timeout triggers a warning branch — patch Event.wait so we
         don't actually block on the 15-second fallback."""
         SessionManager.bus = MagicMock()
-        sess = SessionManager.default_session
+        sess = SessionManager.get_default_session()
         sess.is_speaking = True
         SessionManager.update(sess)
         try:

--- a/test/unittests/test_session_handlers.py
+++ b/test/unittests/test_session_handlers.py
@@ -9,7 +9,6 @@ from ovos_bus_client.session import Session, SessionManager
 
 def _reset():
     default = Session("default")
-    SessionManager.default_session = default
     SessionManager.sessions = {"default": default}
     SessionManager.bus = None
 
@@ -21,7 +20,7 @@ class TestWaitWhileSpeakingPath(TestCase):
     def test_wait_while_speaking_registers_and_removes_listener(self):
         bus = MagicMock()
         SessionManager.bus = bus
-        sess = SessionManager.default_session
+        sess = SessionManager.get_default_session()
         sess.is_speaking = True
         SessionManager.update(sess)
         try:
@@ -39,7 +38,7 @@ class TestWaitWhileSpeakingPath(TestCase):
     def test_wait_while_recording_registers_and_removes_listener(self):
         bus = MagicMock()
         SessionManager.bus = bus
-        sess = SessionManager.default_session
+        sess = SessionManager.get_default_session()
         sess.is_recording = True
         SessionManager.update(sess)
         try:

--- a/test/unittests/test_session_intent_context_sync.py
+++ b/test/unittests/test_session_intent_context_sync.py
@@ -6,21 +6,17 @@ from types import SimpleNamespace
 import pytest
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import (Session, SessionManager,
-                                     HAS_FOLD_INBOUND)
+from ovos_bus_client.session import Session, SessionManager
 
 
 @pytest.fixture(autouse=True)
 def _reset_sessions():
     # isolate the singleton between tests
     saved = dict(SessionManager.sessions)
-    saved_default = SessionManager.default_session
     SessionManager.sessions = {"default": Session("default")}
-    SessionManager.default_session = SessionManager.sessions["default"]
     SessionManager.bus = None  # cls.sync() no-ops without a bus
     yield
     SessionManager.sessions = saved
-    SessionManager.default_session = saved_default
 
 
 def test_intent_context_roundtrips():
@@ -76,8 +72,7 @@ def test_handle_session_sync_ignores_another_clients_session():
         SessionManager.handle_session_sync(
             Message("ovos.session.sync", {}, {"session": snap.serialize()}))
         assert held.intent_context == {}
-        if HAS_FOLD_INBOUND:
-            assert "s2" not in SessionManager.sessions
+        assert "s2" not in SessionManager.sessions
     finally:
         SessionManager.bus = None
 

--- a/test/unittests/test_session_more.py
+++ b/test/unittests/test_session_more.py
@@ -88,7 +88,6 @@ class TestSessionExtra(TestCase):
 class TestSessionManagerExtra(TestCase):
     def setUp(self):
         default = Session("default")
-        SessionManager.default_session = default
         SessionManager.sessions = {"default": default}
         SessionManager.bus = None
 
@@ -98,6 +97,20 @@ class TestSessionManagerExtra(TestCase):
         try:
             SessionManager.handle_default_session_request(Message("ovos.session.sync"))
             # sync emits an update
+            self.assertTrue(bus.emit.called)
+        finally:
+            SessionManager.bus = None
+
+    def test_broadcast_default_session_without_mirror_attribute(self):
+        # a fresh process never wrote the `default_session` mirror -- the
+        # broadcast must read the store via get_default_session(), not raise
+        # AttributeError on a class attribute that was never set.
+        if hasattr(SessionManager, "default_session"):
+            delattr(SessionManager, "default_session")
+        bus = MagicMock()
+        SessionManager.bus = bus
+        try:
+            SessionManager._broadcast_default_session()
             self.assertTrue(bus.emit.called)
         finally:
             SessionManager.bus = None

--- a/test/unittests/test_session_sync_handler.py
+++ b/test/unittests/test_session_sync_handler.py
@@ -11,8 +11,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import (Session, SessionManager,
-                                     HAS_FOLD_INBOUND)
+from ovos_bus_client.session import Session, SessionManager
 
 
 def _sync_message(session_dict):
@@ -85,8 +84,7 @@ class TestHandleSessionSync(unittest.TestCase):
         SessionManager.handle_session_sync(_sync_message(
             {"session_id": "sync-new",
              "intent_context": {"person": {"value": "Bob"}}}))
-        if HAS_FOLD_INBOUND:
-            self.assertIsNone(SessionManager.sessions.get("sync-new"))
+        self.assertIsNone(SessionManager.sessions.get("sync-new"))
         self.assertIsNone(SessionManager.held_session("sync-new"))
 
     def test_removal_propagates_end_to_end(self):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

`Session.location_preferences`'s setter called `_normalize_location_input(value or {})` directly. That helper returns `None` for an empty or non-dict input, so an empty/`None` assignment installed `session.location = None`, breaking the "location is always a container" invariant `_normalize_empty_containers` exists to hold, and a later `session.location.get("tz")` (used by `timezone`) raised `AttributeError`. The fix falls back to `{}`, matching what the constructor already does for the same field. A regression test (`test_location_preferences_setter_empty_value_keeps_location_dict`) exercises `{}` and `None`; reverting only the fix line makes it fail with `AssertionError: None != {}`, and it passes with the fix restored.

The rest is readability cleanup of `session.py`/`message.py`: the `resolve_session_id` import that sat mid-module between two function definitions moved into the header import block; the `getattr(self, name, None)` default in `_normalize_empty_containers` was dropped since the fields it walks are always set by the constructor, and the default was masking a possible typo; the two essay-length comment blocks above `_CANONICAL_LIST_FIELDS` and `_CONTEXT_LOCK` were trimmed to the one constraint each protects. `message.py`'s `_stamp_session_if_present` was deleted and its three call sites now import `ovos_spec_tools.message._stamp_live_session` directly — the two implementations did the same job, but the bus-client copy only gated on `msg.context.get("session")` truthiness, silently skipping the carrier-less-but-source-bound named-session case that `_stamp_live_session` handles for `CollectionMessage`/`GUIMessage` derivations. `_stamp_live_session` is imported as a private name because ovos-spec-tools does not currently export a public equivalent; that is a follow-up for spec-tools, not addressed here.

`HAS_FOLD_INBOUND` is also removed. It was originally a feature-detect for whether the spec-tools `SessionManager` registry exposes `fold_inbound`, but the floor pin (`ovos-spec-tools>=1.10.5a1`) has carried that method unconditionally for a while, so every `skipUnless`/`if`-branch gated on it could never take the "older registry" path — those were skips-on-a-condition-that-can-never-be-false, which is the same failure mode as skipping on a missing dependency: a regression that broke `fold_inbound` at the pinned floor would go unnoticed instead of failing. The eight test files that imported and gated on it (`test_session.py`, `test_session_authority.py`, `test_session_extra.py`, `test_session_sync_handler.py`, `test_session_intent_context_sync.py`, `test_client_more.py`, `test_default_session_fold.py`) now run those assertions/tests unconditionally, with the "else" branches (which asserted the old-registry behavior) removed since that branch was equally unreachable.

A second bug in the same family: `SessionManager.default_session` is a per-class mirror of `sessions[DEFAULT_SESSION_ID]` that ovos-spec-tools is dropping as dead state (it is always re-synced from the dict, never itself authoritative). Bus-client read and wrote that mirror directly in two production spots — `_broadcast_default_session` (`cls.default_session.serialize()`) and `scripts.py`'s REPL entry point (`SessionManager.default_session`) — both of which only work correctly *after* something has called `get_default_session()` at least once to populate the mirror; broadcasting from a fresh process before that first sync raised `AttributeError: type object 'SessionManager' has no attribute 'default_session'`. Both now call `get_default_session()`, and the bus-client `reset_default_session` override no longer writes the mirror on `cls.default_session = sess`, since `cls.sessions[DEFAULT_SESSION_ID] = sess` is the real write. A regression test (`test_broadcast_default_session_without_mirror_attribute`) `delattr`s the mirror to simulate that fresh-process state and confirms the broadcast no longer raises; reverting only the fix makes it fail with the `AttributeError` above, and it passes with the fix restored. The test files that had been reading/writing `SessionManager.default_session` directly to seed or check fixture state (`test_session.py`, `test_session_extra.py`, `test_session_handlers.py`, `test_session_intent_context_sync.py`, `test_session_more.py`, `test_client_more.py`) now seed/read `sessions` and `get_default_session()` instead, which is the actual source of truth spec-tools already treats it as.

`session_carrier()` was not turned into a re-export because the installed `ovos_spec_tools.session.SessionManager` (>=1.10.5a1, the floor pin) only has a private `_carrier` staticmethod, not a public `session_carrier`/`bound`-style helper to re-export; promoting `_carrier` to a public name is a spec-tools change, not a bus-client one.

Full unit test suite: 1057 passed / 6 skipped originally, 1059 passed / 6 skipped now (two regression tests added across the two rounds of fixes). No other test's status changed, and none of the removed `HAS_FOLD_INBOUND` gates was actually causing a skip — the six remaining skips are all unrelated `pycryptodomex not installed` encryption-helper tests.