### PR TITLE
fix: retire ovos.session.update_default / ovos.session.sync push topics

### DIFF
--- a/ovos_bus_client/client/async_client.py
+++ b/ovos_bus_client/client/async_client.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, List, Optional, Union
 from uuid import uuid4
 
 from ovos_utils import json_dumps
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 
 try:
     from pyee.asyncio import AsyncIOEventEmitter
@@ -39,7 +39,8 @@ from ovos_bus_client.client.client import (_bus_flag,
 from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf
 from ovos_bus_client.message import Message, CollectionMessage
 from ovos_bus_client.session import (SessionManager, Session, DEFAULT_SESSION_ID,
-                                     resolve_session_id, session_carrier)
+                                     resolve_session_id, session_carrier,
+                                     _NEXT_MAJOR_VERSION)
 
 
 class AsyncMessageWaiter:
@@ -224,6 +225,16 @@ class AsyncMessageBusClient:
         # client the authority on a named session it was built with
         self.session = session
         self.session_id = session.session_id
+        # DEPRECATED: ovos.session.update_default is a pre-spec surface
+        # OVOS-SESSION-2 §2.7 retires (see session.py's _broadcast_default_
+        # session / sync()). Symmetric with the sync MessageBusClient's own
+        # kept listener -- the audit's objection to #200 was a NEW
+        # subscriber added with no removal version, not the listener as
+        # such -- so this one is kept one cycle, deprecated the same way.
+        log_deprecation("subscribing to ovos.session.update_default is a "
+                        "pre-spec surface retired by OVOS-SESSION-2 §2.7 "
+                        "and will stop being served",
+                        _NEXT_MAJOR_VERSION)
         self.on("ovos.session.update_default", self._on_default_session_update)
 
     @staticmethod
@@ -268,6 +279,13 @@ class AsyncMessageBusClient:
                 self._connected.set()
                 LOG.debug("AsyncMessageBusClient connected to %s", self.url)
                 self.emitter.emit("open")
+                # DEPRECATED: see MessageBusClient.on_open -- kept one cycle
+                # so a fresh client still learns a pre-spec-tools core's
+                # (e.g. stable 1.3.1) default session on connect.
+                log_deprecation("the connect-time ovos.session.sync request "
+                                "is a pre-spec surface retired by "
+                                "OVOS-SESSION-2 §2.7 and will stop being sent",
+                                _NEXT_MAJOR_VERSION)
                 await self.emit(Message("ovos.session.sync"))
                 self._listen_task = asyncio.ensure_future(self._recv_loop())
                 return

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -9,7 +9,7 @@ from threading import Event, Thread
 from typing import Union, Callable, Any, List, Optional
 from uuid import uuid4
 
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 try:
     from pyee import ExecutorEventEmitter
 except (ImportError, ModuleNotFoundError):
@@ -27,7 +27,8 @@ from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import (SessionManager, Session, MalformedSession,
                                      DEFAULT_SESSION_ID,
-                                     resolve_session_id, session_carrier)
+                                     resolve_session_id, session_carrier,
+                                     _NEXT_MAJOR_VERSION)
 from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
 
 # --- legacy intent-topic compat (non-normative migration tooling) ----------
@@ -393,7 +394,18 @@ class MessageBusClient:
             return
         # Restore reconnect timer to 5 seconds on sucessful connect
         self.retry = 5
-        self.emit(Message(SpecMessage.SESSION_SYNC)) # request default session update
+        # DEPRECATED: ovos.session.sync's bare-request/echo round trip is a
+        # pre-spec surface OVOS-SESSION-2 §2.7/§7 retires. It is still the
+        # only way a pre-spec-tools core (e.g. stable 1.3.1) ever answers
+        # with its default session, so a freshly-connected client kept one
+        # cycle behind: without this, it never learns a long-running old
+        # core's default session (lang, etc) and is stuck on its own
+        # config-derived default.
+        log_deprecation("the connect-time ovos.session.sync request is a "
+                        "pre-spec surface retired by OVOS-SESSION-2 §2.7 "
+                        "and will stop being sent",
+                        _NEXT_MAJOR_VERSION)
+        self.emit(Message(SpecMessage.SESSION_SYNC))  # request default session update
 
     def on_close(self, *args):
         """

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1797,20 +1797,28 @@ class _BusSessionManagerMixin:
 
     @classmethod
     def handle_session_sync(cls, message=None):
-        """OVOS-CONTEXT-1 §5.3 — handle an ``ovos.session.sync`` request.
+        """Handle an ``ovos.session.sync`` request.
 
-        The sync carries the emitter's updated session snapshot in
-        ``Message.context.session`` (the standard session carrier). The
-        singleton resolves the target session and merges the snapshot's
-        ``intent_context`` entry-by-entry onto it (set + null-delete, §5.3),
-        keeping the managed session the authoritative owner of intent
-        context. The merge mutates the working map **in place**: the map
-        object every live view holds keeps its identity, and it stays a dict
-        — never ``None`` — per the in-process SESSION-1 §2.1 normalization.
+        ``ovos.session.sync`` is a pre-spec surface: OVOS-SESSION-2 §7
+        defines no bus topic, and appendix/divergences.md §5.2.1 marks it
+        retired. It is kept for one release cycle for two reasons that are
+        NOT the same protocol:
 
-        The legacy default-session echo is emitted only for a **bare**
-        request (no session carrier on the message): a spec-conformant §5.3
-        sync is not a default-session request and triggers no echo.
+        - a **carried** request (``Message.context.session`` present) is
+          used, in practice, to move an ``intent_context`` snapshot between
+          processes. The merge itself -- set + null-delete, entry-by-entry,
+          §5.3 -- is OVOS-CONTEXT-1's in-place mutation semantics, which
+          defines no topic either; this handler is just where that merge
+          happens to be reachable from the bus today;
+        - a **bare** request (no session carrier) is the legacy
+          default-session echo and logs a deprecation warning.
+
+        The singleton resolves the target session and merges the snapshot's
+        ``intent_context`` entry-by-entry onto it, keeping the managed
+        session the authoritative owner of intent context. The merge
+        mutates the working map **in place**: the map object every live
+        view holds keeps its identity, and it stays a dict -- never
+        ``None`` -- per the in-process SESSION-1 §2.1 normalization.
         """
         carried = message is not None and \
             isinstance(getattr(message, "context", None), dict) and \
@@ -1838,6 +1846,10 @@ class _BusSessionManagerMixin:
         else:
             # legacy: a bare ``ovos.session.sync`` *requests* the current
             # default session; echo it back.
+            log_deprecation("ovos.session.sync (bare default-session request) "
+                            "is a pre-spec surface retired by OVOS-SESSION-2 "
+                            "§2.7 and will stop being served",
+                            _NEXT_MAJOR_VERSION)
             cls._broadcast_default_session(message)
 
     # legacy alias — ``ovos.session.sync`` historically routed here to echo

--- a/test/unittests/test_client_extra.py
+++ b/test/unittests/test_client_extra.py
@@ -222,14 +222,20 @@ class TestLifecycle(TestCase):
         t = client.run_in_thread()
         self.assertTrue(t.daemon)
 
-    def test_on_open_sets_connected_and_syncs(self):
+    def test_on_open_sets_connected_and_requests_default_session(self):
+        """The connect-time default-session PUSH (OVOS-SESSION-2 §2.7) stays
+        removed (#328). The connect-time ``ovos.session.sync`` REQUEST is a
+        deprecated, one-cycle-only shim: a pre-spec-tools core (stable
+        1.3.1) only ever answers ``ovos.session.update_default`` when asked,
+        so on_open still sends exactly one request."""
         client = MessageBusClient()
         client.client = MagicMock()
         client.client.send = MagicMock()
         client.on_open()
         self.assertTrue(client.connected_event.is_set())
-        # ovos.session.sync emit
-        self.assertTrue(client.client.send.called)
+        self.assertEqual(client.client.send.call_count, 1)
+        sent = json.loads(client.client.send.call_args[0][0])
+        self.assertEqual(sent["type"], "ovos.session.sync")
 
     def test_on_close_emits_close_event(self):
         client = MessageBusClient()

--- a/test/unittests/test_session_retirement.py
+++ b/test/unittests/test_session_retirement.py
@@ -1,0 +1,134 @@
+"""OVOS-SESSION-2 §2.7/§7 — retirement of the session-push topics.
+
+§2.7: "This specification defines no topic on which any participant pushes
+a session at another." §7: "defines no bus topic." appendix/divergences.md
+§5.2.1 and §5.5 mark ``ovos.session.update_default`` and
+``ovos.session.sync`` retired; the owner ruling is to retire them with a
+one-cycle deprecation shim rather than a hard break.
+
+Live-testing against a real messagebus with a pre-spec-tools core (stable
+1.3.1) showed that core answers ``ovos.session.update_default`` ONLY when
+asked with ``ovos.session.sync`` -- there is no unsolicited push. Dropping
+the connect-time REQUEST therefore leaves a fresh client attached to a
+long-running old core stuck on its own config-derived default session
+forever (it never learns the core's lang, etc). The shim keeps both halves
+of the round trip for one cycle:
+
+- both clients still send exactly one deprecated ``ovos.session.sync``
+  request on connect, and log a deprecation notice naming the removal
+  version;
+- the async client keeps its ``ovos.session.update_default`` listener
+  (symmetric with the sync client's own long-kept listener) -- the audit's
+  objection to #200 was a NEW subscriber shipped with no removal version,
+  not the listener as such -- deprecated the same way.
+
+The one surface removed outright is the async client's bare subscriber as
+it existed before this change: it now carries a deprecation notice like
+every other pre-spec surface in this module, and there is still no
+connect-time default-session PUSH (that half was correctly retired by
+#328 and stays retired).
+"""
+import asyncio
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+from ovos_bus_client.client.async_client import AsyncMessageBusClient
+from ovos_bus_client.client.client import MessageBusClient
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import SessionManager
+
+
+class TestAsyncClientHasUpdateDefaultListener(unittest.TestCase):
+    def test_listener_present_and_deprecated(self):
+        with patch("ovos_bus_client.client.async_client.load_message_bus_config") as mock_cfg, \
+             patch("ovos_bus_client.client.async_client.log_deprecation") as mock_warn:
+            mock_cfg.return_value = MagicMock(host="localhost", port=8181,
+                                              route="/core", ssl=False)
+            bus = AsyncMessageBusClient()
+        listeners = bus.emitter.listeners("ovos.session.update_default")
+        self.assertEqual(len(listeners), 1)
+        self.assertTrue(mock_warn.called)
+        self.assertIn("ovos.session.update_default", mock_warn.call_args.args[0])
+
+    def test_handler_method_present(self):
+        self.assertTrue(hasattr(AsyncMessageBusClient, "_on_default_session_update"))
+
+
+class TestAsyncClientConnectRequestsDefaultSession(unittest.IsolatedAsyncioTestCase):
+    async def test_connect_emits_exactly_one_session_sync_and_warns(self):
+        with patch("ovos_bus_client.client.async_client.load_message_bus_config") as mock_cfg:
+            mock_cfg.return_value = MagicMock(host="localhost", port=8181,
+                                              route="/core", ssl=False)
+            bus = AsyncMessageBusClient()
+
+        ws_mock = AsyncMock()
+        ws_mock.send = AsyncMock()
+        ws_mock.__aiter__.return_value = iter([])  # empty recv loop
+
+        with patch("ovos_bus_client.client.async_client.websockets.connect",
+                   AsyncMock(return_value=ws_mock)), \
+             patch("ovos_bus_client.client.async_client.log_deprecation") as mock_warn:
+            await bus.connect(retry=False)
+
+        ws_mock.send.assert_awaited_once()
+        sent = json.loads(ws_mock.send.await_args.args[0])
+        self.assertEqual(sent["type"], "ovos.session.sync")
+        connect_warnings = [c for c in mock_warn.call_args_list
+                           if "ovos.session.sync request" in c.args[0]]
+        self.assertEqual(len(connect_warnings), 1)
+
+
+class TestSyncClientConnectRequestsDefaultSession(unittest.TestCase):
+    def test_on_open_sends_exactly_one_session_sync_and_warns(self):
+        client = MessageBusClient()
+        client.client = MagicMock()
+        client.client.send = MagicMock()
+        with patch("ovos_bus_client.client.client.log_deprecation") as mock_warn:
+            client.on_open()
+        self.assertEqual(client.client.send.call_count, 1)
+        sent = json.loads(client.client.send.call_args[0][0])
+        self.assertEqual(sent["type"], "ovos.session.sync")
+        connect_warnings = [c for c in mock_warn.call_args_list
+                           if "ovos.session.sync request" in c.args[0]]
+        self.assertEqual(len(connect_warnings), 1)
+
+
+class TestBareSessionSyncDeprecation(unittest.TestCase):
+    def setUp(self):
+        self._sessions = dict(SessionManager.sessions)
+        self._bus = SessionManager.bus
+        SessionManager.bus = None
+
+    def tearDown(self):
+        SessionManager.sessions.clear()
+        SessionManager.sessions.update(self._sessions)
+        SessionManager.bus = self._bus
+
+    def test_bare_sync_still_echoes_and_warns_every_call(self):
+        emitted = []
+
+        class FakeBus:
+            def emit(self, msg):
+                emitted.append(msg)
+
+        SessionManager.bus = FakeBus()
+        with patch("ovos_bus_client.session.log_deprecation") as mock_warn:
+            SessionManager.handle_session_sync(Message("ovos.session.sync"))
+            SessionManager.handle_session_sync(Message("ovos.session.sync"))
+        # the echo still fires -- pre-spec surface kept for one cycle
+        self.assertEqual([m.msg_type for m in emitted],
+                         ["ovos.session.update_default",
+                          "ovos.session.update_default"])
+        # mocking log_deprecation bypasses ovos_utils' own real-process
+        # once-per-caller dedup, so both calls here are observed directly;
+        # the assertion is on the exact count (not just "called"), and every
+        # call names the removal version.
+        self.assertEqual(mock_warn.call_count, 2)
+        for c in mock_warn.call_args_list:
+            self.assertIn("ovos.session.sync", c.args[0])
+            self.assertRegex(c.args[1], r"^\d+\.0\.0$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-SESSION-2 §2.7 states that the specification "defines no topic on which any participant pushes a session at another," and §7 says the same of the sync request itself: it "defines no bus topic." appendix/divergences.md §5.2.1 marks `ovos.session.update_default` retired, and §5.5 named the connect-time broadcast in `connect_to_bus` as the last bridging behavior the spec still tolerated — that call site was already removed by #328. The owner ruling on the remaining surfaces is to retire them with a one-cycle deprecation shim rather than a hard break, and both halves of any remaining round trip stay for that same one cycle.

Live-testing against a real messagebus with a pre-spec-tools core (stable 1.3.1) as the old peer showed that core answers `ovos.session.update_default` only when asked with `ovos.session.sync` — there is no unsolicited push from it. An earlier version of this change dropped the connect-time request entirely, which stranded a freshly-connected client on its own config-derived default session forever: it never learned a long-running old core's actual default (lang, etc). Both clients now keep that request for one cycle. `MessageBusClient.on_open` and `AsyncMessageBusClient.connect` each still send exactly one `ovos.session.sync` request on connect, behind a deprecation log naming the removal version; the connect-time default-session *push* stays removed, since #328 was correct about that half. The async client also keeps its `ovos.session.update_default` listener, deprecated the same way and symmetric with the sync client's own long-kept listener — the audit's objection to #200 was a brand-new subscriber shipped with no removal version, not the listener as such.

What's kept for one cycle without needing a live-test finding is `SessionManager.sync()`, the bare-sync echo, and the `ovos.session.sync` subscription itself in `SessionManager.connect_to_bus`. These are pre-spec surfaces with real deployed consumers — an orchestrator driving this same request/echo pattern — so they log a deprecation warning naming the removal version computed from `version.py` (`VERSION_MAJOR + 1`), the same pattern `util/scheduled_events/legacy.py` already uses for `LEGACY_REMOVAL_VERSION`.

Separately, `handle_session_sync`'s docstring cited OVOS-CONTEXT-1 §5.3 as authority for the `ovos.session.sync` bus topic. §5.3 defines an in-place `intent_context` merge, not a topic — it says nothing about how that snapshot arrives on the bus. The docstring now separates the two: the merge semantics genuinely come from §5.3, while the topic that carries the snapshot is a pre-spec surface kept for one release cycle, not a spec-conformant one.

Fail-before: reverting the deprecation-guarded emit/listener restorations in `client.py`/`async_client.py` while keeping the tests made all 5 tests asserting the connect-time request, the async listener, and their deprecation logs fail (zero sends observed; an `AttributeError` patching a `log_deprecation` call that did not yet exist). Restoring the fix made them all pass. The full suite passed 1064/1070 (6 skipped), versus 1059/6 on `dev` before this change — 5 net new passing tests, no regressions.