### PR TITLE
fix: restore pre-spec EventScheduler surface, dual-emit topics, nested location and async-client compat twins

### DIFF
--- a/ovos_bus_client/apis/events.py
+++ b/ovos_bus_client/apis/events.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from typing import Callable, Optional, Union
 
 from ovos_utils.events import create_basic_wrapper
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_config.locale import get_config_tz
 from ovos_utils.time import now_local
 
@@ -167,6 +167,15 @@ class EventSchedulerInterface(SchedulerClient):
         }
         message = self._get_source_message()
         self.bus.emit(message.forward(topics.LEGACY_UPDATE, data))
+        # #222 fixed the topic to the spelling the scheduler actually
+        # listens on (mycroft.scheduler.update_event, above); the misspelled
+        # mycroft.schedule.update_event is emitted alongside it for one
+        # stable cycle in case anything still listens on the typo directly
+        log_deprecation(
+            "mycroft.schedule.update_event is a misspelling of "
+            "mycroft.scheduler.update_event and will stop being emitted",
+            LEGACY_REMOVAL_VERSION)
+        self.bus.emit(message.forward("mycroft.schedule.update_event", data))
 
     def cancel_scheduled_event(self, name: str):
         """
@@ -207,8 +216,10 @@ class EventSchedulerInterface(SchedulerClient):
 
         if not status or not status.data.get("schedule"):
             raise Exception("Event Status Messagebus Timeout")
-        # the reply carries the schedule under a key: the wire refuses a
-        # list-shaped payload, which is what this used to answer with
+        # the reply carries the schedule under a key: MSG-1 §2.2 forbids a
+        # list-shaped Message.data on this wire, so the pre-specification
+        # bare-list callback payload cannot reach here from a real bus --
+        # the callback shape is object-only, there is nothing to shim
         event_time = int(status.data["schedule"][0])
         return event_time - int(time.time())
 

--- a/ovos_bus_client/client/async_client.py
+++ b/ovos_bus_client/client/async_client.py
@@ -31,11 +31,15 @@ except ImportError:
     ConnectionClosedError = OSError  # type: ignore
     ConnectionClosedOK = OSError  # type: ignore
 
+from ovos_spec_tools.intent_topics import canonical_intent_topic, is_intent_topic
 from ovos_spec_tools.messages import NamespaceTranslator
 
 from ovos_bus_client.client.client import (_bus_flag,
                                            _compute_legacy_intent_twin,
-                                           _compute_legacy_namespace_twin)
+                                           _compute_legacy_namespace_twin,
+                                           _verbatim_copy,
+                                           INTENT_COMPAT_TWIN_KEY,
+                                           NAMESPACE_COMPAT_TWIN_KEY)
 from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf
 from ovos_bus_client.message import Message, CollectionMessage
 from ovos_bus_client.session import (SessionManager, Session, DEFAULT_SESSION_ID,
@@ -317,8 +321,37 @@ class AsyncMessageBusClient:
             sess = Session.from_message(parsed)
             if sess.session_id != DEFAULT_SESSION_ID:
                 SessionManager.update(sess)
-        self.emitter.emit("message", raw)
-        self.emitter.emit(parsed.msg_type, parsed)
+        # see MessageBusClient.on_message -- pop both compat markers before
+        # any local dispatch so they never survive onto a forwarded/replied
+        # descendant frame.
+        is_intent_twin = parsed.context.pop(INTENT_COMPAT_TWIN_KEY, False)
+        is_namespace_twin = parsed.context.pop(NAMESPACE_COMPAT_TWIN_KEY, False)
+        # one logical dispatch yields one firehose event -- see
+        # MessageBusClient.on_message for why each marker gates it
+        if not is_namespace_twin and not is_intent_twin:
+            self.emitter.emit("message", raw)
+        if not is_namespace_twin:
+            self.emitter.emit(parsed.msg_type, parsed)
+            # namespace migration bridge: mirror the emit to LOCAL listeners
+            # on the counterpart topic(s), same as MessageBusClient.on_message
+            for topic in self._translator.counterpart_topics(parsed.msg_type):
+                translated = self._translator.translate_payload(
+                    from_topic=parsed.msg_type, to_topic=topic, data=parsed.data)
+                self.emitter.emit(topic, parsed.forward(topic, translated))
+        self._modernize_intent_topic(parsed, is_twin=is_intent_twin)
+
+    def _modernize_intent_topic(self, message: Message, is_twin: bool = False):
+        """RULE 2 receive-side bridge -- see MessageBusClient._modernize_intent_topic."""
+        if not self._translator.modernize:
+            return
+        if is_twin:
+            return
+        if not is_intent_topic(message.msg_type):
+            return
+        canonical = canonical_intent_topic(message.msg_type)
+        if canonical == message.msg_type:
+            return
+        self.emitter.emit(canonical, _verbatim_copy(message, canonical))
 
     def _on_default_session_update(self, message: Message):
         new_session = message.data["session_data"]

--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -521,19 +521,22 @@ class MessageBusClient:
         # forward()/reply()).
         is_namespace_twin = parsed_message.context.pop(NAMESPACE_COMPAT_TWIN_KEY, False)
         # The 'message' firehose is the raw wire-capture stream a modern
-        # receiver's wildcard/logging listeners see. A marked NAMESPACE twin
-        # is the SAME logical dispatch as the canonical frame that preceded
-        # it on the wire -- firing the firehose for it too would double-count
-        # every migrated topic for any modern listener bound to it, breaking
-        # the one-frame-per-logical-emit invariant conformance captures
-        # (ovoscope/busmon) rely on. An old client has no notion of "twin"
-        # and legitimately sees both raw frames off the wire -- that
-        # asymmetry is inherent to wire visibility, and is already true
-        # (and accepted) for the pre-existing intent-topic twin, which this
-        # gate deliberately leaves untouched to stay within this fix's scope.
+        # receiver's wildcard/logging listeners see. A marked NAMESPACE or
+        # INTENT twin is the SAME logical dispatch as the canonical frame
+        # that preceded it on the wire -- firing the firehose for it too
+        # would double-count every migrated topic for any modern listener
+        # bound to it, breaking the one-frame-per-logical-emit invariant
+        # conformance captures (ovoscope/busmon) rely on. An old client has
+        # no notion of "twin" and legitimately sees both raw frames off the
+        # wire -- that asymmetry is inherent to wire visibility. The intent
+        # twin still needs its own direct dispatch below (a listener bound
+        # to the suffixed spelling is only ever served from this frame, RULE
+        # 2 does not translate canonical -> suffixed) -- only the firehose
+        # double-count is what this gate closes.
         try:
-            if not is_namespace_twin:
+            if not is_namespace_twin and not is_intent_twin:
                 self.emitter.emit('message', message)
+            if not is_namespace_twin:
                 self.emitter.emit(parsed_message.msg_type, parsed_message)
                 # namespace migration bridge: also dispatch the counterpart topic(s) to
                 # LOCAL listeners so a handler on either namespace receives the event

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -1309,7 +1309,19 @@ class Session(_SpecSession):
         # OVOS-SESSION-1 §3.5/§2.1: the three-key location object, omitted
         # entirely when none of lat/lon/tz is set (equivalent to omission).
         if self.location:
-            data["location"] = dict(self.location)
+            location = dict(self.location)
+            # the pre-spec nested mycroft.conf shape (city/coordinate/
+            # timezone) is projected alongside the flat keys for one stable
+            # cycle, so a reader still keyed on ``location.timezone.code``
+            # keeps working; _normalize_location_input on the read side
+            # already accepts either shape under the same "location" key
+            if "tz" in location:
+                log_deprecation(
+                    "session.location.timezone.code is a legacy nested "
+                    "mycroft.conf projection; read location.tz instead",
+                    _NEXT_MAJOR_VERSION)
+                location["timezone"] = {"code": location["tz"]}
+            data["location"] = location
         else:
             data.pop("location", None)
         return data

--- a/ovos_bus_client/util/scheduler.py
+++ b/ovos_bus_client/util/scheduler.py
@@ -21,10 +21,13 @@ service offered. New code talks the SCHEDULER-1 protocol instead, through
 """
 import os
 import time
-from typing import Optional
+from typing import Dict, List, Optional, Tuple
+
+from ovos_utils.log import log_deprecation
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.util.scheduled_events import topics
+from ovos_bus_client.util.scheduled_events.legacy import LEGACY_REMOVAL_VERSION
 from ovos_bus_client.util.scheduled_events.service import ScheduledEventService
 from ovos_bus_client.util.scheduled_events.store import default_store_path
 
@@ -99,3 +102,115 @@ class EventScheduler(ScheduledEventService):
     def store(self):
         """Write the schedule to disk."""
         self._persist()
+
+    # --- pre-SCHEDULER-1 public surface, kept for one stable cycle --------
+    #
+    # PR #311 dropped these along with the ``events``/``event_lock``
+    # attributes when the epoch-float scheduler became this class. Every
+    # caller below is a thin delegate onto the bus handlers or state the
+    # SCHEDULER-1 service already keeps.
+
+    @property
+    def events(self) -> Dict[str, List[Tuple[float, Optional[float], dict, dict]]]:
+        """A snapshot in the pre-specification ``name -> [(time, repeat,
+        data, context), ...]`` shape. Read-only: mutating the old dict in
+        place scheduled nothing, so there is nothing to delegate a write to.
+        """
+        log_deprecation(
+            "EventScheduler.events is a read-only snapshot of the "
+            "SCHEDULER-1 schedules; use EventScheduler.schedules instead.",
+            LEGACY_REMOVAL_VERSION)
+        view = {}
+        with self.lock:
+            for (owner, schedule_id), schedule in self.schedules.items():
+                entry = self.legacy._entry(schedule)
+                view.setdefault(schedule.record["event"], []).append(tuple(entry))
+        return view
+
+    @property
+    def event_lock(self):
+        """The lock guarding ``schedules``, under its historical name."""
+        log_deprecation(
+            "EventScheduler.event_lock is the SCHEDULER-1 store lock; use "
+            "EventScheduler.lock instead.", LEGACY_REMOVAL_VERSION)
+        return self.lock
+
+    def handle_schedule_event(self, message: Message):
+        """Bus handler for ``mycroft.scheduler.schedule_event``."""
+        log_deprecation(
+            "EventScheduler.handle_schedule_event speaks the "
+            "pre-specification protocol; schedule() instead.",
+            LEGACY_REMOVAL_VERSION)
+        self.legacy.handle_schedule(message)
+
+    def handle_remove_event(self, message: Message):
+        """Bus handler for ``mycroft.scheduler.remove_event``."""
+        log_deprecation(
+            "EventScheduler.handle_remove_event speaks the "
+            "pre-specification protocol; cancel() instead.",
+            LEGACY_REMOVAL_VERSION)
+        self.legacy.handle_remove(message)
+
+    def handle_update_event(self, message: Message):
+        """Bus handler for ``mycroft.scheduler.update_event``."""
+        log_deprecation(
+            "EventScheduler.handle_update_event speaks the "
+            "pre-specification protocol; schedule() instead.",
+            LEGACY_REMOVAL_VERSION)
+        self.legacy.handle_update(message)
+
+    def handle_get_event(self, message: Message):
+        """Bus handler for ``mycroft.scheduler.get_event``.
+
+        Answers with the object shape ``{"event", "schedule"}``, not the
+        bare list this used to reply with; the wire refuses a list-shaped
+        payload (SCHEDULER-1 §4).
+        """
+        log_deprecation(
+            "EventScheduler.handle_get_event speaks the pre-specification "
+            "protocol; get() instead.", LEGACY_REMOVAL_VERSION)
+        self.legacy.handle_get(message)
+
+    def handle_list_events(self, message: Message):
+        """Bus handler for ``mycroft.scheduler.list_events``."""
+        log_deprecation(
+            "EventScheduler.handle_list_events speaks the "
+            "pre-specification protocol; list() instead.",
+            LEGACY_REMOVAL_VERSION)
+        self.legacy.handle_list(message)
+
+    def handle_system_clock_sync(self, message: Message):
+        """Bus handler for ``system.clock.synced``, emitted by raspOVOS."""
+        log_deprecation(
+            "EventScheduler.handle_system_clock_sync is served by "
+            "handle_clock_synced now.", LEGACY_REMOVAL_VERSION)
+        self.handle_clock_synced(message)
+
+    def clear_repeating(self):
+        """Drop every repeating schedule, under its historical name."""
+        log_deprecation(
+            "EventScheduler.clear_repeating drops repeating schedules; "
+            "there is no SCHEDULER-1 replacement, cancel() them by id "
+            "instead.", LEGACY_REMOVAL_VERSION)
+        with self.lock:
+            repeating = [key for key, schedule in self.schedules.items()
+                        if "every" in schedule.record]
+            for key in repeating:
+                self.schedules.pop(key, None)
+
+    def clear_empty(self):
+        """No-op: a SCHEDULER-1 schedule is dropped the instant it is spent,
+        so there is never an empty entry left behind to clear.
+        """
+        log_deprecation(
+            "EventScheduler.clear_empty is a no-op: SCHEDULER-1 schedules "
+            "are dropped as soon as they are spent.", LEGACY_REMOVAL_VERSION)
+
+    def load(self):
+        """Load the store into memory, under its historical name."""
+        log_deprecation(
+            "EventScheduler.load is served by the constructor now; call "
+            "it only to re-read a store changed on disk.",
+            LEGACY_REMOVAL_VERSION)
+        with self.lock:
+            self.schedules.update(self.schedule_store.load())

--- a/test/unittests/test_async_client_receive_twin.py
+++ b/test/unittests/test_async_client_receive_twin.py
@@ -1,0 +1,94 @@
+"""Receive-side compat-twin parity between AsyncMessageBusClient and
+MessageBusClient.
+
+Confirmed defect: AsyncMessageBusClient._on_message() neither popped the
+intent/namespace compat-twin markers nor ran the RULE 1 namespace
+counterpart dispatch / RULE 2 intent modernization that MessageBusClient.
+on_message() does, so a listener on an async client saw both the intent twin
+and its canonical frame fire the 'message' firehose, and a namespace-mapped
+topic never reached a listener bound to its counterpart spelling.
+"""
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from pyee.asyncio import AsyncIOEventEmitter
+
+from ovos_bus_client.client.async_client import AsyncMessageBusClient
+from ovos_bus_client.message import Message
+from ovos_spec_tools import NamespaceTranslator
+
+CANONICAL_INTENT = "skill-food.jarbas:food.order"
+LEGACY_INTENT = "skill-food.jarbas:food.order.intent"
+CANONICAL_NS = "ovos.utterance.speak"
+LEGACY_NS = "speak"
+
+
+def _async_client() -> AsyncMessageBusClient:
+    bus = AsyncMessageBusClient.__new__(AsyncMessageBusClient)
+    bus.emitter = AsyncIOEventEmitter()
+    bus._ws = AsyncMock()
+    bus._ws.send = AsyncMock()
+    bus._translator = NamespaceTranslator(modernize=True, emit_legacy=True)
+    bus._wire_legacy_twins = True
+    bus.session_id = "default"
+    return bus
+
+
+def _deliver(bus, msg_type, data=None, context=None):
+    asyncio.run(bus._on_message(
+        Message(msg_type, data or {}, context or {}).serialize()))
+
+
+class TestIntentTwinFirehoseDedup(unittest.TestCase):
+    def test_a_canonical_emit_relayed_as_both_wire_frames_fires_the_firehose_once(self):
+        bus = _async_client()
+        firehose = []
+        bus.emitter.on("message", lambda m: firehose.append(m))
+        got_canonical = []
+        bus.emitter.on(CANONICAL_INTENT, lambda m: got_canonical.append(m))
+        got_legacy = []
+        bus.emitter.on(LEGACY_INTENT, lambda m: got_legacy.append(m))
+
+        _deliver(bus, CANONICAL_INTENT, data={"a": 1})
+        _deliver(bus, LEGACY_INTENT, data={"a": 1},
+                context={"_intent_compat_twin": True})
+
+        self.assertEqual(len(firehose), 1)
+        self.assertEqual(len(got_canonical), 1)
+        self.assertEqual(len(got_legacy), 1)
+
+    def test_the_twin_marker_does_not_survive_onto_the_dispatched_message(self):
+        bus = _async_client()
+        seen = []
+        bus.emitter.on(LEGACY_INTENT, lambda m: seen.append(m))
+        _deliver(bus, LEGACY_INTENT, data={"a": 1},
+                context={"_intent_compat_twin": True})
+        self.assertNotIn("_intent_compat_twin", seen[0].context)
+
+
+class TestNamespaceTwinCounterpartDispatch(unittest.TestCase):
+    def test_a_legacy_namespace_emit_is_locally_mirrored_to_the_counterpart(self):
+        bus = _async_client()
+        got_canonical = []
+        bus.emitter.on(CANONICAL_NS, lambda m: got_canonical.append(m))
+        _deliver(bus, LEGACY_NS, data={"utterance": "hi"})
+        self.assertEqual(len(got_canonical), 1)
+
+    def test_a_marked_namespace_twin_is_not_re_dispatched_or_re_mirrored(self):
+        bus = _async_client()
+        firehose = []
+        bus.emitter.on("message", lambda m: firehose.append(m))
+        got_legacy = []
+        bus.emitter.on(LEGACY_NS, lambda m: got_legacy.append(m))
+        _deliver(bus, CANONICAL_NS, data={"utterance": "hi"})
+        _deliver(bus, LEGACY_NS, data={"utterance": "hi"},
+                context={"_namespace_compat_twin": True})
+        self.assertEqual(len(firehose), 1)
+        # the counterpart dispatch off the canonical frame already delivered
+        # the legacy spelling locally once; the twin's own arrival adds none
+        self.assertEqual(len(got_legacy), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -4,9 +4,11 @@ These exercise the epoch-float API and the ``mycroft.scheduler.*`` topics the
 rest of the stack still speaks.
 """
 import os
+import re
 import tempfile
 import time
 import unittest
+from unittest.mock import patch
 
 from ovos_utils.fakebus import FakeBus
 
@@ -108,6 +110,132 @@ class TestEventScheduler(unittest.TestCase):
     def test_the_store_is_written_on_every_mutation(self):
         self.scheduler.schedule_event("skill:test", time.time() + 3600)
         self.assertTrue(os.path.isfile(self.store))
+
+
+class TestPreSpecPublicSurface(unittest.TestCase):
+    """PR #311 dropped these nine public methods and two attributes when
+    the epoch-float scheduler became this class. They are restored as
+    deprecated delegates onto the SCHEDULER-1 implementation for one stable
+    cycle.
+    """
+
+    def setUp(self):
+        self.bus = FakeBus()
+        self.emitted = []
+        self.bus.on("message", self._record)
+        handle, self.store = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        os.unlink(self.store)
+        self.scheduler = EventScheduler(self.bus, self.store, autostart=False)
+
+    def tearDown(self):
+        self.scheduler.shutdown()
+        for path in (self.store, f"{self.store}.tmp"):
+            if os.path.isfile(path):
+                os.unlink(path)
+
+    def _record(self, message):
+        if isinstance(message, str):
+            message = Message.deserialize(message)
+        self.emitted.append(message)
+
+    def _assert_deprecation_names_a_removal_version(self, mock_warn):
+        mock_warn.assert_called()
+        version = mock_warn.call_args[0][1]
+        self.assertRegex(version, r"^\d+\.0\.0$")
+
+    def test_handle_schedule_event_schedules(self):
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.handle_schedule_event(
+                Message(topics.LEGACY_SCHEDULE,
+                        {"event": "skill:test", "time": time.time() + 3600}))
+        self.assertIn(("skill", "skill:test"), self.scheduler.schedules)
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_handle_remove_event_removes(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.handle_remove_event(
+                Message(topics.LEGACY_REMOVE, {"event": "skill:test"}))
+        self.assertNotIn(("skill", "skill:test"), self.scheduler.schedules)
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_handle_update_event_updates_data(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600,
+                                      data={"a": 1})
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.handle_update_event(
+                Message(topics.LEGACY_UPDATE,
+                        {"event": "skill:test", "data": {"a": 2}}))
+        self.assertEqual(
+            self.scheduler.schedules["skill", "skill:test"].record["data"],
+            {"a": 2})
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_handle_get_event_answers_with_the_object_shape(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.handle_get_event(
+                Message(topics.LEGACY_GET, {"name": "skill:test"}))
+        answers = [m for m in self.emitted
+                  if m.msg_type.startswith(topics.LEGACY_GET_REPLY_PREFIX)]
+        self.assertEqual(answers[-1].data["event"], "skill:test")
+        self.assertIsNotNone(answers[-1].data["schedule"])
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_handle_list_events_answers_with_every_schedule(self):
+        self.scheduler.schedule_event("skill:one", time.time() + 3600)
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.handle_list_events(
+                Message(topics.LEGACY_LIST, {},
+                        {"source": ["a"], "destination": ["b"]}))
+        answers = [m for m in self.emitted if "scheduled_events" in m.data]
+        self.assertIn("skill:one", answers[-1].data["scheduled_events"])
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_handle_system_clock_sync_delegates(self):
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.handle_system_clock_sync(
+                Message(topics.CLOCK_SYNCED, {}))
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_clear_repeating_drops_only_repeating_schedules(self):
+        self.scheduler.schedule_event("skill:once", time.time() + 3600)
+        self.scheduler.schedule_event("skill:tick", time.time() + 3600, repeat=60)
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.clear_repeating()
+        self.assertIn(("skill", "skill:once"), self.scheduler.schedules)
+        self.assertNotIn(("skill", "skill:tick"), self.scheduler.schedules)
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_clear_empty_is_a_documented_no_op(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.clear_empty()
+        self.assertIn(("skill", "skill:test"), self.scheduler.schedules)
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_load_reads_the_store_into_memory(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600)
+        self.scheduler.schedules.clear()
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.scheduler.load()
+        self.assertIn(("skill", "skill:test"), self.scheduler.schedules)
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_events_attribute_snapshots_the_schedules(self):
+        self.scheduler.schedule_event("skill:test", time.time() + 3600,
+                                      data={"a": 1})
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            snapshot = self.scheduler.events
+        self.assertIn("skill:test", snapshot)
+        self.assertEqual(snapshot["skill:test"][0][2], {"a": 1})
+        self._assert_deprecation_names_a_removal_version(warn)
+
+    def test_event_lock_is_the_schedules_lock(self):
+        with patch("ovos_bus_client.util.scheduler.log_deprecation") as warn:
+            self.assertIs(self.scheduler.event_lock, self.scheduler.lock)
+        self._assert_deprecation_names_a_removal_version(warn)
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_events_api.py
+++ b/test/unittests/test_events_api.py
@@ -111,10 +111,16 @@ class TestUpdateAndCancel(TestCase):
 
     def test_update_scheduled_event(self):
         self.api.update_scheduled_event("t1", data={"new": True})
-        emitted = self.bus.emit.call_args[0][0]
-        self.assertEqual(emitted.msg_type, "mycroft.scheduler.update_event")
-        self.assertEqual(emitted.data["event"], "my.skill:t1")
-        self.assertEqual(emitted.data["data"], {"new": True})
+        # #222's fix (mycroft.scheduler.update_event) is emitted, plus the
+        # misspelled mycroft.schedule.update_event for one stable cycle in
+        # case anything still listens on the typo directly
+        emitted = [c.args[0] for c in self.bus.emit.call_args_list]
+        self.assertEqual([m.msg_type for m in emitted],
+                         ["mycroft.scheduler.update_event",
+                          "mycroft.schedule.update_event"])
+        for message in emitted:
+            self.assertEqual(message.data["event"], "my.skill:t1")
+            self.assertEqual(message.data["data"], {"new": True})
 
     def test_cancel_existing_repeating_event(self):
         self.api.schedule_repeating_event(

--- a/test/unittests/test_intent_legacy_reemit.py
+++ b/test/unittests/test_intent_legacy_reemit.py
@@ -679,5 +679,32 @@ class TestRegistrationIdempotency(unittest.TestCase):
         self.assertEqual(len(calls), 1)
 
 
+class TestFirehoseIsNotDoubledByTheIntentTwin(unittest.TestCase):
+    """The intent-topic twin is the SAME logical dispatch as the canonical
+    frame that preceded it on the wire, so the 'message' firehose a modern
+    receiver's wildcard/logging listeners see must fire exactly once per
+    logical emit, same as the namespace twin (test_namespace_wire_twin.py).
+    """
+
+    def test_firehose_sees_exactly_one_frame_per_logical_emit(self):
+        core, sat = _client(), _client()
+        firehose = []
+        sat.emitter.on("message", lambda m: firehose.append(m))
+        core.emit(Message(CANONICAL, {"a": 1}))
+        self.assertEqual(_sent(core), [CANONICAL, LEGACY])
+        _relay(core, sat)
+        self.assertEqual(len(firehose), 1)
+
+    def test_direct_dispatch_on_the_suffixed_spelling_still_fires(self):
+        # the twin is only skipped for the firehose -- a listener bound
+        # directly to the suffixed spelling has no other way to hear it,
+        # since RULE 2 only bridges suffixed -> canonical, not the reverse
+        core, sat = _client(), _client()
+        got = _received(sat, LEGACY)
+        core.emit(Message(CANONICAL, {"a": 1}))
+        _relay(core, sat)
+        self.assertEqual(len(got), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_session_location.py
+++ b/test/unittests/test_session_location.py
@@ -75,13 +75,17 @@ class TestRoundTrip(unittest.TestCase):
     def test_partial_object_round_trips_byte_stable(self):
         sess = Session.deserialize({"location": {"tz": "Asia/Tokyo"}})
         data = sess.serialize()
-        self.assertEqual(data["location"], {"tz": "Asia/Tokyo"})
+        # the legacy nested mycroft.conf projection (location.timezone.code)
+        # is emitted alongside the flat keys for one stable cycle
+        self.assertEqual(data["location"],
+                         {"tz": "Asia/Tokyo", "timezone": {"code": "Asia/Tokyo"}})
 
     def test_full_object_round_trips_byte_stable(self):
         sess = Session.deserialize({"location": {"lat": 1.5, "lon": -2.5,
                                                   "tz": "Europe/Lisbon"}})
         self.assertEqual(sess.serialize()["location"],
-                         {"lat": 1.5, "lon": -2.5, "tz": "Europe/Lisbon"})
+                         {"lat": 1.5, "lon": -2.5, "tz": "Europe/Lisbon",
+                          "timezone": {"code": "Europe/Lisbon"}})
 
 
 class TestLocationIngest(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

PR #311 dropped nine public `EventScheduler` methods (`handle_schedule_event`, `handle_remove_event`, `handle_update_event`, `handle_get_event`, `handle_list_events`, `handle_system_clock_sync`, `clear_repeating`, `clear_empty`, `load`) plus the `events`/`event_lock` attributes when the epoch-float scheduler became a thin wrapper around `ScheduledEventService`. They come back as deprecated delegates onto the SCHEDULER-1 implementation (`LegacyAdapter` and the service's own store/lock), so a caller still bound to the old names keeps working for one stable cycle. Each delegate logs once via `log_deprecation`, naming a removal version computed as `VERSION_MAJOR + 1`.

`EventSchedulerInterface.get_scheduled_event_status()` keeps reading the `{"event", "schedule"}` object the current `LegacyAdapter` answers with; no bare-list read fallback was added. A bare-list callback payload — the pre-specification wire shape — cannot reach this code on a real bus: MSG-1 §2.2 forbids a list-shaped `Message.data`, so both `Message()` construction and `Message.deserialize()` reject it with `MalformedMessage` before it ever gets near this read. There is no reachable legacy shape left to shim for this item; the callback payload is object-only.

`update_scheduled_event()` emits both `mycroft.scheduler.update_event` (the correct spelling since #222) and the misspelled `mycroft.schedule.update_event`, deprecated, for one stable cycle, in case anything still listens on the typo directly.

`Session.serialize()` projects the pre-spec nested mycroft.conf location shape (`location.timezone.code`) alongside the flat `{lat, lon, tz}` keys for one stable cycle. The read side already accepted either shape under the same `"location"` key before this change; now the shape a reader still keyed on the nested form expects is actually there on emit too.

`AsyncMessageBusClient._on_message()` previously neither popped the intent/namespace compat-twin markers nor ran the counterpart dispatch `MessageBusClient.on_message()` does, so listener delivery differed between the two clients and a twin frame double-fired the `message` firehose. It now mirrors the sync client exactly. `MessageBusClient.on_message()` also now gates the intent twin out of the firehose the same way the namespace twin already was, so one logical dispatch yields one firehose event on either client; the twin's own direct dispatch under its suffixed spelling is kept, since RULE 2 only bridges suffixed topics to their canonical spelling, never the reverse.

Fail-before: 19 new/updated assertions across `test_event_scheduler.py`, `test_events_api.py`, `test_intent_legacy_reemit.py`, `test_session_location.py` and the new `test_async_client_receive_twin.py` all fail against the unfixed source (checked with a source-only patch revert) and pass with the fix applied. Full suite: 1080 passed, 6 skipped, no failures.