### PR TITLE
fix: own the pre-spec session shims bus-client grafts onto spec-tools

### DIFF
--- a/ovos_bus_client/client/client.py
+++ b/ovos_bus_client/client/client.py
@@ -26,10 +26,10 @@ from ovos_bus_client.message import (Message, CollectionMessage, GUIMessage,
                                      MalformedMessage,
                                      encrypt_as_dict, decrypt_from_dict)
 from ovos_bus_client.session import (SessionManager, Session, MalformedSession,
-                                     DEFAULT_SESSION_ID,
+                                     DEFAULT_SESSION_ID, LEGACY_SESSION_SYNC,
                                      resolve_session_id, session_carrier,
                                      _NEXT_MAJOR_VERSION)
-from ovos_spec_tools.messages import NamespaceTranslator, SpecMessage
+from ovos_spec_tools.messages import NamespaceTranslator
 
 # --- legacy intent-topic compat (non-normative migration tooling) ----------
 #
@@ -405,7 +405,7 @@ class MessageBusClient:
                         "pre-spec surface retired by OVOS-SESSION-2 §2.7 "
                         "and will stop being sent",
                         _NEXT_MAJOR_VERSION)
-        self.emit(Message(SpecMessage.SESSION_SYNC))  # request default session update
+        self.emit(Message(LEGACY_SESSION_SYNC))  # request default session update
 
     def on_close(self, *args):
         """

--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from ovos_config.config import Configuration
 from ovos_utils.log import LOG, log_deprecation
-from ovos_spec_tools import standardize_lang, SpecMessage
+from ovos_spec_tools import standardize_lang
 from ovos_spec_tools.context import resolve_key
 from ovos_spec_tools.session import (Session as _SpecSession,
                                      SessionManager as _SpecSessionManager,
@@ -33,6 +33,15 @@ if not hasattr(_SpecSessionManager, "_pre_graft"):
                                       "update": _SpecSessionManager.update.__func__}
 _spec_get = _SpecSessionManager._pre_graft["get"]
 _spec_update = _SpecSessionManager._pre_graft["update"]
+
+# ovos-spec-tools implements only the spec; every public-API compatibility
+# shim for a pre-spec topic lives here instead. ``ovos.session.sync`` and
+# ``ovos.session.update_default`` are not OVOS-SESSION-2 topics (no
+# SpecMessage enum member is minted for a topic that isn't in a spec), so
+# they are local string constants, not spec-tools imports. Removed at
+# _NEXT_MAJOR_VERSION.
+LEGACY_SESSION_SYNC = "ovos.session.sync"
+LEGACY_SESSION_UPDATE_DEFAULT = "ovos.session.update_default"
 
 
 def session_carrier(message) -> Dict[str, Any]:
@@ -1481,13 +1490,34 @@ class _BusSessionManagerMixin:
     the spec-tools registry's.
     """
     bus = None
+    #: Kept for readers of the pre-spec attribute; the registry (``sessions``)
+    #: is authoritative and this is only ever written to mirror it, never
+    #: read internally. Removed in <_NEXT_MAJOR_VERSION>. Defined here (not
+    #: read off the spec-tools base) so the mirror keeps working once
+    #: spec-tools drops its own copy.
+    default_session: Optional[Session] = None
+
+    @classmethod
+    def get_default_session(cls) -> Session:
+        """Return (materializing once) the singleton for the reserved default id.
+
+        The shared ``sessions`` dict is the single source of truth. The
+        pre-spec ``default_session`` class attribute is mirrored here as a
+        compatibility shim -- see the attribute's own docstring.
+        """
+        sess = cls.sessions.get(DEFAULT_SESSION_ID)
+        if sess is None:
+            sess = cls.session_cls.deserialize({"session_id": DEFAULT_SESSION_ID})
+            cls.sessions[DEFAULT_SESSION_ID] = sess
+        cls.default_session = sess
+        return sess
 
     @classmethod
     def _broadcast_default_session(cls, message=None):
         """Emit the legacy ``ovos.session.update_default`` default-session echo."""
         if cls.bus:
-            message = message or Message(SpecMessage.SESSION_SYNC)
-            cls.bus.emit(message.reply("ovos.session.update_default",
+            message = message or Message(LEGACY_SESSION_SYNC)
+            cls.bus.emit(message.reply(LEGACY_SESSION_UPDATE_DEFAULT,
                                        {"session_data": cls.get_default_session().serialize()}))
 
     @classmethod
@@ -1518,7 +1548,7 @@ class _BusSessionManagerMixin:
         cls.bus.on("recognizer_loop:record_end", cls.handle_recording_end)
         cls.bus.on("recognizer_loop:audio_output_start", cls.handle_audio_output_start)
         cls.bus.on("recognizer_loop:audio_output_end", cls.handle_audio_output_end)
-        cls.bus.on(SpecMessage.SESSION_SYNC, cls.handle_session_sync)
+        cls.bus.on(LEGACY_SESSION_SYNC, cls.handle_session_sync)
 
     @classmethod
     def prune_sessions(cls):
@@ -1548,6 +1578,7 @@ class _BusSessionManagerMixin:
         """
         sess = cls.session_cls.deserialize({"session_id": DEFAULT_SESSION_ID})
         cls.sessions[DEFAULT_SESSION_ID] = sess
+        cls.default_session = sess
         LOG.info("Default Session reset")
         cls.sync()
         return sess

--- a/test/unittests/test_session_more.py
+++ b/test/unittests/test_session_more.py
@@ -115,6 +115,21 @@ class TestSessionManagerExtra(TestCase):
         finally:
             SessionManager.bus = None
 
+    def test_default_session_mirror_owned_by_bus_client(self):
+        # ovos-bus-client owns this pre-spec `default_session` mirror -- it
+        # must keep tracking the registry through get/reset even if the
+        # spec-tools base this grafts onto no longer defines the attribute
+        # at all (simulated here by deleting it before each call).
+        if hasattr(SessionManager, "default_session"):
+            delattr(SessionManager, "default_session")
+        sess = SessionManager.get_default_session()
+        self.assertIs(SessionManager.default_session, sess)
+
+        delattr(SessionManager, "default_session")
+        new_sess = SessionManager.reset_default_session()
+        self.assertIs(SessionManager.default_session, new_sess)
+        self.assertIsNot(new_sess, sess)
+
 
 class TestFromMessageLangFallback(TestCase):
     def test_from_message_merges_lang_from_context(self):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-spec-tools implements only the spec, and every public-API compatibility shim for a topic that is not in a spec belongs on the bus-client graft, not on the spec-tools SessionManager it grafts onto. This PR moves two remaining shims from spec-tools reliance to bus-client ownership so ovos-spec-tools can eventually drop them without breaking ovos-bus-client.

The pre-spec `SessionManager.default_session` mirror is a class attribute kept only for readers of the old attribute; the registry (`sessions`) is the actual source of truth. It was previously written only by spec-tools' own `get_default_session()`, while the bus-client override of `reset_default_session()` never wrote it. Both `get_default_session()` and `reset_default_session()` are now overridden on the bus-client graft, each writing the mirror, so it keeps tracking the registry whether or not the spec-tools base still carries its own copy.

`ovos.session.sync` and `ovos.session.update_default` are pre-spec topics that OVOS-SESSION-2 §7 explicitly retires and never registers, so no `SpecMessage` enum constant should exist for them. They were nonetheless referenced via `SpecMessage.SESSION_SYNC` in a few places in ovos-bus-client. These are now local `LEGACY_SESSION_SYNC` / `LEGACY_SESSION_UPDATE_DEFAULT` string constants defined in `ovos_bus_client/session.py`, used everywhere the bus emits, subscribes to, or handles that topic (session.py's connect/broadcast/sync path and client.py's connect-time request).

No behavior changes beyond ownership: the deprecation logs, the sync semantics, and the mirror's value are unchanged, only where the constants and the write live.

Tests: a new regression test deletes the `default_session` attribute from the shared `SessionManager` class between calls and asserts both `get_default_session()` and `reset_default_session()` rewrite it. Reverting only the source change made that test fail with `AttributeError: type object 'SessionManager' has no attribute 'default_session'` on the post-reset assertion; restoring the fix makes it pass. A grep confirms no reference to `SpecMessage.SESSION_SYNC` / `SESSION_UPDATE_DEFAULT` remains in ovos-bus-client. The full suite passes at 1065 passed, 6 skipped, unchanged before and after the fix (no `test_no_lang_in_message` failure was observed on this checkout).