### PR TITLE
fix: async client survives a malformed session carrier

### DIFF
--- a/ovos_bus_client/client/async_client.py
+++ b/ovos_bus_client/client/async_client.py
@@ -43,8 +43,8 @@ from ovos_bus_client.client.client import (_bus_flag,
 from ovos_bus_client.conf import load_message_bus_config, MessageBusClientConf
 from ovos_bus_client.message import Message, CollectionMessage
 from ovos_bus_client.session import (SessionManager, Session, DEFAULT_SESSION_ID,
-                                     resolve_session_id, session_carrier,
-                                     _NEXT_MAJOR_VERSION)
+                                     MalformedSession, resolve_session_id,
+                                     session_carrier, _NEXT_MAJOR_VERSION)
 
 
 class AsyncMessageWaiter:
@@ -316,7 +316,15 @@ class AsyncMessageBusClient:
         parsed = Message.deserialize(raw)
         # see MessageBusClient._take_inbound_session -- the §5.1 arrival fold
         # is orchestrator-intake-only; this client only tracks named sessions.
-        carrier = session_carrier(parsed)
+        try:
+            carrier = session_carrier(parsed)
+        except MalformedSession as e:
+            # A non-object session carrier is a per-message producer fault, not
+            # a transport fault (SESSION-1 §2.5): drop this one message and
+            # keep the connection. Letting it propagate would reach the recv
+            # loop's exception handler, which tears the socket down.
+            LOG.warning("discarding bus message with malformed session: %s", e)
+            return
         if resolve_session_id(carrier) != DEFAULT_SESSION_ID:
             sess = Session.from_message(parsed)
             if sess.session_id != DEFAULT_SESSION_ID:

--- a/test/unittests/test_async_client.py
+++ b/test/unittests/test_async_client.py
@@ -220,6 +220,20 @@ class TestOnMessage(unittest.IsolatedAsyncioTestCase):
             called_sess = mock_update.call_args[0][0]
             self.assertEqual(called_sess.session_id, "kitchen-sat")
 
+    async def test_on_message_discards_malformed_session(self):
+        """SESSION-1 §2.5: a non-object session carrier is dropped, not
+        raised -- letting it escape would reach the recv loop's exception
+        handler, which tears the connection down."""
+        bus = _make_bus()
+        received = []
+        bus.on("ovos.test", lambda m: received.append(m))
+        raw = json.dumps({"type": "ovos.test", "data": {},
+                          "context": {"session": "oops"}})
+        # must not raise
+        await bus._on_message(raw)
+        await asyncio.sleep(0)
+        self.assertEqual(received, [])
+
 
 # ---------------------------------------------------------------------------
 # Event registration tests


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-SESSION-1 §2.5 defines a malformed carrier as a `context.session` value that is present but not a JSON object — a string, number, array, or boolean. The first consumer that sees such a Message MUST drop it and MUST NOT crash or tear down the transport: a malformed carrier is a per-message producer fault, never a transport fault, so a client that drops its bus connection over one bad message can be held offline indefinitely by a single misbehaving producer.

`MessageBusClient.on_message` already honours this via a `try/except MalformedSession` around `_take_inbound_session`. `AsyncMessageBusClient._on_message` did not: it called `session_carrier()` unguarded, and a malformed carrier raised `MalformedSession` straight out of `_on_message` into the recv loop's own exception handler, which clears the connection and fires a `close` event — exactly the transport teardown the spec forbids for a per-message fault.

This PR wraps the async client's carrier read in the same try/except pattern the sync client already uses: on `MalformedSession` it logs and returns without dispatching the message, leaving the connection alive for the next one. Broadcasting an `ovos.session.rejected` notification for the drop was dropped from an earlier version of this PR on maintainer guidance — on a real bus every client observes the same echoed malformed frame, so per-client emission would multiply into N rejections for one dropped message; that responsibility belongs to the messagebus server, which is being addressed separately.

Reverting only `ovos_bus_client/client/async_client.py` (keeping the new test) makes `test_async_client.py::test_on_message_discards_malformed_session` fail with `ovos_spec_tools.session.MalformedSession` raised out of `_on_message`, confirming the bug independently of the test's own assumptions. Restoring the fix turns it green. The full unit suite passes 1083/1083 with 6 pre-existing skips on the rebased branch, unchanged by this PR.