### PR TITLE
docs: point manual links at OpenVoiceOS/beta-technical-manual

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -146,7 +146,7 @@ details and the multi-handler `collect_responses` flow.
 further failure up to a 60-second cap, and resets to 5 seconds after a
 successful reconnect. You do not need to wrap construction in your own retry
 loop for this. See the manual's
-[Bus Service: reconnect behavior](https://tigregotico.github.io/ovos-technical-manual/bus-service/#bus-restart-reconnect-behavior)
+[Bus Service: reconnect behavior](https://openvoiceos.github.io/beta-technical-manual/bus-service/#bus-restart-reconnect-behavior)
 for the full backoff details, including what happens to in-flight calls and
 messages sent during an outage.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,7 +10,7 @@ writes on it, and it has no authentication or authorisation. Treat it as
 private to the device. Never expose the bus port outside the device; use
 [HiveMind](https://github.com/JarbasHiveMind) for remote access instead.
 
-See the manual's [Bus Service](https://tigregotico.github.io/ovos-technical-manual/bus-service/)
+See the manual's [Bus Service](https://openvoiceos.github.io/beta-technical-manual/bus-service/)
 page for the full security callout and the shipped `127.0.0.1` default.
 
 ## The bus is a JSON-over-WebSocket pub/sub
@@ -48,7 +48,7 @@ m = Message(
 )
 ```
 
-See the manual's [Bus Service: Message Structure](https://tigregotico.github.io/ovos-technical-manual/bus-service/#message-structure)
+See the manual's [Bus Service: Message Structure](https://openvoiceos.github.io/beta-technical-manual/bus-service/#message-structure)
 page for the field table, the wire JSON example, and the colon-vs-dot topic-naming note.
 
 ## Message types are by convention, not declaration


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The OVOS technical manual moved from TigreGotico to OpenVoiceOS/beta-technical-manual and now serves at https://openvoiceos.github.io/beta-technical-manual/. The old tigregotico.github.io URLs no longer serve it. This repoints the three manual links in docs/client.md and docs/concepts.md to the new host, keeping the unchanged chapter slugs.

Replaced links, all verified HTTP 200 after the change:
- https://openvoiceos.github.io/beta-technical-manual/bus-service/#bus-restart-reconnect-behavior (200)
- https://openvoiceos.github.io/beta-technical-manual/bus-service/ (200)
- https://openvoiceos.github.io/beta-technical-manual/bus-service/#message-structure (200)

No other links were touched.