### PR TITLE
fix: honour the SESSION-2 §2.7 data carrier in the ovos.session.sync shim

### DIFF
--- a/ovos_bus_client/session.py
+++ b/ovos_bus_client/session.py
@@ -13,6 +13,7 @@ from ovos_spec_tools.session import (Session as _SpecSession,
                                      DEFAULT_CONVERSE_HANDLERS_CAP,
                                      DEFAULT_SESSION_ID,
                                      MalformedSession,
+                                     parse_session_payload,
                                      SESSION1_REGISTERED_FIELDS,
                                      resolve_session_id)
 from ovos_bus_client.message import dig_for_message, Message
@@ -1844,30 +1845,56 @@ class _BusSessionManagerMixin:
 
         ``ovos.session.sync`` is a pre-spec surface: OVOS-SESSION-2 §7
         defines no bus topic, and appendix/divergences.md §5.2.1 marks it
-        retired. It is kept for one release cycle for two reasons that are
-        NOT the same protocol:
+        retired. It is kept for one release cycle for reasons that are NOT
+        the same protocol:
 
-        - a **carried** request (``Message.context.session`` present) is
-          used, in practice, to move an ``intent_context`` snapshot between
-          processes. The merge itself -- set + null-delete, entry-by-entry,
-          §5.3 -- is OVOS-CONTEXT-1's in-place mutation semantics, which
-          defines no topic either; this handler is just where that merge
-          happens to be reachable from the bus today;
-        - a **bare** request (no session carrier) is the legacy
+        - pre-spec emitters (skills, satellites, the legacy
+          :meth:`SessionManager.sync`) carry the **whole** session, not just
+          ``intent_context`` -- in ``message.data["session"]`` when the
+          producer built the request that way, or in
+          ``message.context.session`` otherwise. When that carried session
+          names the **default** session (no id, or ``"default"``), it is
+          folded onto the default session with the same field-by-field
+          merge the intake fold (:meth:`fold_inbound`, backed by
+          ``_merge_into_default``/``merge_carrier``) uses for every other
+          inbound snapshot -- lang, pipeline, ``intent_context``, and any
+          other modelled field travel together, an omitted field leaves the
+          stored value unchanged, and ``intent_context`` merges entry by
+          entry per OVOS-CONTEXT-1 §5.3, exactly as a normally-received
+          message would fold;
+        - a carried **named** session is OVOS-SESSION-2 §2.2 territory: this
+          process is never pushed someone else's session, so the only named
+          session honoured here is the one it already holds
+          (:meth:`held_session`), and only for the OVOS-CONTEXT-1 §5.3
+          ``intent_context`` set + null-delete entry-by-entry merge -- an
+          unheld named session is another client's state and is ignored;
+        - a **bare** request (no session carrier at all) is the legacy
           default-session echo and logs a deprecation warning.
 
-        The singleton resolves the target session and merges the snapshot's
-        ``intent_context`` entry-by-entry onto it, keeping the managed
-        session the authoritative owner of intent context. The merge
-        mutates the working map **in place**: the map object every live
-        view holds keeps its identity, and it stays a dict -- never
-        ``None`` -- per the in-process SESSION-1 §2.1 normalization.
+        The ``intent_context`` merge mutates the working map **in place**:
+        the map object every live view holds keeps its identity, and it
+        stays a dict -- never ``None`` -- per the in-process SESSION-1 §2.1
+        normalization.
         """
-        carried = message is not None and \
-            isinstance(getattr(message, "context", None), dict) and \
-            "session" in message.context
-        if carried:
-            inbound = Session.from_message(message)
+        raw = None
+        if message is not None:
+            data = getattr(message, "data", None)
+            if isinstance(data, dict) and data.get("session") is not None:
+                raw = data["session"]
+            else:
+                ctx = getattr(message, "context", None)
+                if isinstance(ctx, dict) and "session" in ctx:
+                    raw = ctx["session"]
+        if raw is not None:
+            try:
+                inbound = cls.session_cls.deserialize(raw)
+            except MalformedSession as e:
+                LOG.warning(f"ignoring malformed ovos.session.sync payload: {e}")
+                inbound = None
+            if inbound and inbound.session_id in (None, "", DEFAULT_SESSION_ID):
+                cls._merge_into_default(parse_session_payload(raw))
+                LOG.debug("merged ovos.session.sync default-session payload")
+                return
             if inbound:
                 sess = cls.held_session(inbound.session_id)
                 payload = inbound.intent_context

--- a/test/unittests/test_session_intent_context_sync.py
+++ b/test/unittests/test_session_intent_context_sync.py
@@ -80,3 +80,66 @@ def test_handle_session_sync_ignores_another_clients_session():
 def test_handle_bare_sync_request_does_not_crash():
     # a bare request (no session carrier) just echoes; must not raise
     SessionManager.handle_session_sync(Message("ovos.session.sync"))
+
+
+def test_handle_session_sync_data_carrier_folds_full_default_session():
+    # pre-spec emitters (skills, SessionManager.sync()) carry the whole
+    # session in message.data["session"], not just intent_context -- the
+    # default-session payload must fold every modelled field (lang here),
+    # not just intent_context, onto the default session singleton
+    snap = Session("default")
+    snap.lang = "pt-PT"
+    SessionManager.handle_session_sync(
+        Message("ovos.session.sync", {"session": snap.serialize()}))
+    assert SessionManager.get_default_session().lang == "pt-PT"
+
+
+def test_handle_session_sync_context_carrier_folds_full_default_session():
+    # the same full-field fold applies when the default-session payload
+    # arrives on the context carrier instead of message.data
+    snap = Session("default")
+    snap.lang = "pt-PT"
+    SessionManager.handle_session_sync(
+        Message("ovos.session.sync", {}, {"session": snap.serialize()}))
+    assert SessionManager.get_default_session().lang == "pt-PT"
+
+
+def test_handle_session_sync_default_session_omitted_field_survives():
+    # OVOS-SESSION-2 §5.1: "An omitted inbound field leaves the stored field
+    # unchanged" -- a sync payload that only carries `lang` must not reset a
+    # previously diverged `pipeline` to the deployment default
+    stored = SessionManager.get_default_session()
+    stored.pipeline = ["custom-pipeline-plugin"]
+    # a raw wire payload that only carries `lang` -- constructing this via
+    # `Session(...).serialize()` would materialize the deployment-default
+    # pipeline onto the wire and make it indistinguishable from an explicit
+    # carry, so the payload is built by hand instead
+    payload = {"session_id": "default", "lang": "pt-PT"}
+    SessionManager.handle_session_sync(
+        Message("ovos.session.sync", {"session": payload}))
+    assert SessionManager.get_default_session().lang == "pt-PT"
+    assert SessionManager.get_default_session().pipeline == ["custom-pipeline-plugin"]
+
+
+def test_handle_session_sync_default_session_intent_context_entry_merge():
+    # OVOS-CONTEXT-1 §5.3 applies to the default-session branch too: a
+    # payload that only nulls one entry must leave sibling entries alone and
+    # must remove the nulled key rather than writing a literal None
+    stored = SessionManager.get_default_session()
+    stored.intent_context = {"keepA": {"value": 1}, "delB": {"value": 2}}
+    snap = Session("default")
+    snap.intent_context = {"delB": None}
+    SessionManager.handle_session_sync(
+        Message("ovos.session.sync", {"session": snap.serialize()}))
+    merged = SessionManager.get_default_session().intent_context
+    assert merged == {"keepA": {"value": 1}}
+
+
+def test_handle_session_sync_data_carrier_named_session_untouched():
+    # OVOS-SESSION-2 §2.2: a named session this process does not hold is
+    # never adopted, whether it arrives via message.data or message.context
+    snap = Session("s9")
+    snap.intent_context = {"k": {"value": 9}}
+    SessionManager.handle_session_sync(
+        Message("ovos.session.sync", {"session": snap.serialize()}))
+    assert "s9" not in SessionManager.sessions


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

`ovos.session.sync` is retired (OVOS-SESSION-2 §2.7 defines no push topic); the one-cycle backcompat shim lives only in `SessionManager.handle_session_sync` here. That handler read exclusively from `Message.context["session"]`, so a session carried in `Message.data["session"]` was invisible to it entirely. Pre-spec emitters that still exist in the wild — skills, satellites, and the legacy `SessionManager.sync()` — carry the whole session snapshot in `Message.data["session"]` per §2.7, and a push landing only there fell through to the bare-request branch: no field on the default session moved and no `intent_context` entry merged, regardless of what a producer sent. Even a context-carried push only ever merged `intent_context`, never `lang`, `pipeline`, or any other modelled field.

`handle_session_sync` now prefers `message.data["session"]`, falling back to `message.context["session"]` when the data carrier is absent, matching the wire priority §2.7 specifies. When the resolved payload names the default session (no id, or `"default"`), it is folded onto the store with the OVOS-SESSION-2 §5.1 field-by-field merge — `SessionManager._merge_into_default` / `merge_carrier`, the same merge `fold_inbound` applies to every other inbound snapshot. A present field replaces the stored value, an omitted field is left unchanged, and `intent_context` merges entry-by-entry per OVOS-CONTEXT-1 §5.3, where a `null` entry removes its key rather than being written as a literal `None`. A carried named session keeps its existing, narrower OVOS-CONTEXT-1 §5.3 behaviour unchanged: the intent_context entry-by-entry set/null-delete merge, applied only when this process already holds that session id, and silently ignored when it does not (an unheld named session is another client's state per §2.2/§2.5).

Fail-before: reverting the source change only (tests kept), all four default-session tests fail. The two carrier tests show `get_default_session()` staying at `"en-US"` for a data-carried push, because the unfixed handler never reads `message.data["session"]` and falls through to the bare-request echo instead. Two added regression tests show the same gap from the other side: a pre-seeded non-default `pipeline` and a pre-seeded `intent_context` entry that a sync is meant to delete are both left completely untouched, because a data-carried default-session push was never merged at all. Restoring the fix makes all four pass, along with the existing named-session and bare-request tests.

Full suite: 1088 passed, 6 skipped (up from a baseline of 1086 passed, 6 skipped, plus the two tests this revision adds — no regressions).

I also drove ovos-core's `test/unittests/test_intent_context.py` (dev, unmodified) against this branch to check the six `_NEEDS_BUS_CLIENT_278` strict-xfail markers it carries for this exact gap. Two of them (`test_data_carrier_is_honoured`, `test_data_carrier_wins_over_context_carrier`) exercise the data-carrier preference this PR fixes, but all six remain XFAIL rather than XPASS: their shared `_tracked()`/setup helper seeds a named session via `SessionManager.update(sess)` and expects it to land in `SessionManager.sessions[sess.session_id]`. Against the ovos-spec-tools version this repo's floor pin already resolves to (`>=1.10.5a1`, latest alpha `1.10.8a1`), `SessionManager.update()` deliberately no longer persists named sessions at all — "a named session is returned unchanged and nothing is recorded" is the current spec-tools contract, a design change unrelated to the data-carrier gap this PR closes. That looks like a separate, real incompatibility between ovos-bus-client's own singleton `sessions` registry (which several of its own tests still populate via direct dict writes rather than `update()`) and the newer spec-tools session model, and is out of scope for this fix.
