### PR TITLE
docs: async sender quirk names the reconnect backoff as the overflow path

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -9,7 +9,7 @@ This file resets at the next stable release. At that point its contents
 become upgrade notes for the `1.5.0 -> next-stable` jump, and a new, empty
 quirks log starts.
 
-## 2.11.14a1
+## 2.11.13a4
 
 `websocket.async_sender` (env `OVOS_BUS_ASYNC_SENDER`) is a new, off-by-default
 flag that moves outbound writes onto a single dedicated thread instead of the
@@ -21,6 +21,8 @@ on the same bounded queue, so one can be written while the other is silently
 dropped. A consumer that only understands the legacy topic can therefore miss
 a frame that a canonical-topic consumer received. Leave the flag off on any
 deployment that still depends on legacy topics under sustained load.
+
+The realistic production path into the overflow drop is a broker restart, because the client's reconnect backoff progressively waits 5, 10, 20, 40, and then 60 seconds (capped) between reconnection attempts. During this period, frames emitted with the queue on accumulate up to the 5000-frame limit and are then dropped and counted. With the queue off, those same periods block callers instead.
 
 ## 2.11.13a1 - 2.11.13a2
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

The new paragraph added to the 2.11.13a4 entry in docs/prerelease-quirks.md clarifies how overflow can occur in production: when a message broker restarts, the client's reconnect backoff mechanism waits progressively longer between reconnection attempts (5, 10, 20, 40, and then 60 seconds, capped), which can leave enough time for the 5000-frame queue to fill and drop frames if the broker outage persists.

The backoff values were verified by reading the reconnect logic in ovos_bus_client/client/client.py, specifically the initialization of `self.retry = 5` and the update logic `self.retry = min(self.retry * 2, 60)` in the on_error handler. The version header was also corrected from 2.11.14a1 to 2.11.13a4 to match the actual release tag.
