### PR TITLE
fix: scheduler identifies the owning component by context skill_id (OVOS-SCHEDULER-1)

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -66,7 +66,7 @@ your restarts and the scheduler's.
 
 ## Identity and replacement
 
-A schedule is identified by the pair (owner, id). Scheduling the same
+A schedule is identified by the pair (skill_id, id). Scheduling the same
 identity again replaces it atomically — there is no update request, and there
 are no duplicates. If you do not pass `schedule_id`, the client derives one
 from the event name alone. That means a component keeps one schedule per
@@ -93,13 +93,13 @@ The client owns the handler it registers. `cancel(schedule_id)` removes the
 handler that `schedule` put in place, and re-scheduling the same id with a
 handler replaces the old one instead of leaving a second subscription behind.
 
-An administrative component can read or cancel across every owner by sending
-`owner: "*"`, but only when its component id appears in the
-`scheduler.admins` allowlist in the configuration, which is empty by default.
-No schedule can be created under `*`. The allowlist is a misconfiguration
-guard, not a security boundary: on an unauthenticated bus any process can
-claim any component id, so it stops an honest component reaching across
-owners by accident and nothing more.
+A component allowlisted in `scheduler.admins`, which is empty by default, is
+granted the scope `*` for `list` and `cancel`: those two requests then reach
+every owner's schedules instead of only the caller's own. No schedule can be
+created or read under `*`; the grant does not extend to `schedule` or `get`.
+The allowlist is a misconfiguration guard, not a security boundary: on an
+unauthenticated bus any process can claim any `skill_id`, so it stops an
+honest component reaching across owners by accident and nothing more.
 
 Read schedules back with `events.get(schedule_id)` and `events.list()`. Both
 return the stored record alongside computed state: the next occurrence, the
@@ -134,14 +134,14 @@ The message the scheduler emits carries the record's `data`, and the context
 of the request that created the schedule, unchanged, with one block added:
 
 ```python
-message.context["scheduler"]  # {"id", "owner", "due", "fired", "remaining"}
+message.context["scheduler"]  # {"id", "skill_id", "due", "fired", "remaining"}
 ```
 
 The context comes back whole because it is routing you already wrote — where
 the request came from, where its answers go, which session it belongs to. A
 handler that speaks when the alarm rings speaks to the right device without
 doing anything, and a schedule made outside any request fires with nothing
-but its owner and the scheduler block: nothing is invented for it.
+but its owning `skill_id` and the scheduler block: nothing is invented for it.
 
 Whether that routing is still good is your business, not the scheduler's. A
 session captured when the alarm was set may be long finished by the time it
@@ -213,7 +213,7 @@ The `mycroft.scheduler.*` topics and the `schedule_event`,
 `cancel_scheduled_event` and `get_scheduled_event_status` client methods
 still work and are answered by the same service, which maps an epoch float to
 an instant, `repeat` to a fixed period, and the `skill_id:` prefix of the
-event name to an owner. They emit a deprecation notice naming the release
+event name to the owning `skill_id`. They emit a deprecation notice naming the release
 that drops them. New code uses the methods above.
 
 A schedule created this way fires with the context its request carried, whole

--- a/ovos_bus_client/apis/scheduler.py
+++ b/ovos_bus_client/apis/scheduler.py
@@ -246,8 +246,7 @@ class SchedulerClient:
     def _request(self, topic: str, data: dict,
                  timeout: float = DEFAULT_TIMEOUT,
                  context: Optional[dict] = None) -> dict:
-        message = self._get_source_message(context).forward(
-            topic, dict(data, owner=self.skill_id))
+        message = self._get_source_message(context).forward(topic, data)
         answer = self.bus.wait_for_response(message,
                                             reply_type=f"{topic}.response",
                                             timeout=timeout)

--- a/ovos_bus_client/util/scheduled_events/legacy.py
+++ b/ovos_bus_client/util/scheduled_events/legacy.py
@@ -68,14 +68,13 @@ def legacy_record(name: str, when: float, repeat: Optional[float],
     specified protocol.
     """
     instant = format_instant(datetime.fromtimestamp(when, timezone.utc))
-    record = {"id": name, "owner": legacy_owner(name), "event": name,
-              "data": data or {}}
+    record = {"id": name, "event": name, "data": data or {}}
     if repeat:
         record["every"] = {"seconds": repeat, "start": instant}
     else:
         record["at"] = instant
     record["context"] = context or {}
-    return validate_record(record, namespaced=False)
+    return validate_record(record, skill_id=legacy_owner(name), namespaced=False)
 
 
 def pending_migration_path() -> Optional[str]:

--- a/ovos_bus_client/util/scheduled_events/schedules.py
+++ b/ovos_bus_client/util/scheduled_events/schedules.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 
 from ovos_bus_client.util.scheduled_events.records import (
-    format_instant, parse_instant)
+    ScheduleError, format_instant, parse_instant)
 from ovos_bus_client.util.scheduled_events.timing import next_occurrence
 
 #: instants reported in one missed message, and the length of the missed
@@ -50,8 +50,8 @@ class Schedule:
 
     @property
     def key(self) -> Tuple[str, str]:
-        """The (owner, id) pair a schedule is identified by (§3.3)."""
-        return self.record["owner"], self.record["id"]
+        """The (skill_id, id) pair a schedule is identified by (§3.3)."""
+        return self.record["skill_id"], self.record["id"]
 
     @property
     def is_one_shot(self) -> bool:
@@ -175,10 +175,22 @@ class Schedule:
 
         A relative delay comes back without its monotonic deadline: across a
         restart it is an ``at`` on the estimate that was written (§3.4.3).
+
+        A record written by a release that still keyed identity by ``owner``
+        is read as ``skill_id`` at this one boundary (§9.4, §5.1: a store the
+        service cannot honour outright is set aside, never fatal), so every
+        reader past this point sees one field name.
         """
+        record = dict(entry["record"])
+        if "skill_id" not in record:
+            if "owner" not in record:
+                raise ScheduleError(
+                    "invalid_record", "stored record carries neither "
+                    "skill_id nor owner")
+            record["skill_id"] = record.pop("owner")
         last_fired = entry.get("last_fired")
         estimate = entry.get("estimate")
-        return cls(entry["record"],
+        return cls(record,
                    cursor=parse_instant(entry["cursor"], "cursor"),
                    consumed=entry.get("consumed", 0),
                    anchored=entry.get("anchored", True),

--- a/ovos_bus_client/util/scheduled_events/service.py
+++ b/ovos_bus_client/util/scheduled_events/service.py
@@ -192,11 +192,11 @@ class ScheduledEventService(Thread):
     def handle_schedule(self, message: Message):
         """Create or replace a schedule (§4.1)."""
         try:
-            owner = self._authorized_owner(message, message.data.get("owner"))
+            skill_id = self._owning_skill_id(message)
             with self.lock:
-                previous = self.schedules.get((owner, message.data.get("id")))
+                previous = self.schedules.get((skill_id, message.data.get("id")))
                 record = validate_record(
-                    dict(message.data, context=message.context),
+                    dict(message.data, context=message.context), skill_id,
                     previous=previous.record if previous else None)
                 schedule = self._continuing(record, previous)
                 self._put_schedule(schedule, previous)
@@ -205,53 +205,74 @@ class ScheduledEventService(Thread):
             return self._refuse(message, err)
         except OSError as err:
             return self._refuse(message, _unwritable_store(err))
-        self._answer(message, {"ok": True, "id": record["id"], "owner": owner,
+        self._answer(message, {"ok": True, "id": record["id"],
+                               "skill_id": skill_id,
                                "next": format_instant(upcoming) if upcoming else None,
                                "replaced": previous is not None})
 
     def handle_cancel(self, message: Message):
-        """Delete a schedule. Cancelling one that does not exist is not an
-        error; the answer simply says it did not exist (§4.1)."""
+        """Delete a schedule. Cancelling one that does not exist under the
+        caller's scope is not an error; the answer simply says it did not
+        exist (§4.1). One that exists under another skill_id is outside that
+        scope and is refused, not reported as absent (§6.2)."""
         try:
-            owner = self._authorized_owner(message, message.data.get("owner"),
-                                           wildcard=True)
+            skill_id = self._scoped_skill_id(message, wildcard=True)
             schedule_id = _required_id(message)
             with self.lock:
-                existed = self._drop_matching(owner, schedule_id)
+                existed = self._drop_matching(skill_id, schedule_id)
+                if not existed:
+                    self._reject_if_out_of_scope(schedule_id, skill_id)
         except ScheduleError as err:
             return self._refuse(message, err)
         except OSError as err:
             return self._refuse(message, _unwritable_store(err))
-        self._answer(message, {"ok": True, "id": schedule_id, "owner": owner,
-                               "existed": existed})
+        self._answer(message, {"ok": True, "id": schedule_id,
+                               "skill_id": skill_id, "existed": existed})
 
     def handle_get(self, message: Message):
-        """Read one schedule as stored, plus its computed state (§4.1)."""
+        """Read one schedule as stored, plus its computed state (§4.1). One
+        that exists under another skill_id is outside the caller's scope and
+        is refused, not reported as absent (§6.2)."""
         try:
-            owner = self._authorized_owner(message, message.data.get("owner"))
+            skill_id = self._owning_skill_id(message)
             schedule_id = _required_id(message)
             with self.lock:
-                schedule = self.schedules.get((owner, schedule_id))
+                schedule = self.schedules.get((skill_id, schedule_id))
+                if schedule is None:
+                    self._reject_if_out_of_scope(schedule_id, skill_id)
                 view = self._view(schedule) if schedule else None
         except ScheduleError as err:
             return self._refuse(message, err)
-        self._answer(message, {"ok": True, "id": schedule_id, "owner": owner,
+        self._answer(message, {"ok": True, "id": schedule_id,
+                               "skill_id": skill_id,
                                "existed": view is not None,
                                "record": view["record"] if view else None,
                                "state": view["state"] if view else None})
 
+    def _reject_if_out_of_scope(self, schedule_id: str, skill_id: str):
+        """Refuse with skill_id_mismatch when ``schedule_id`` names a
+        schedule that exists, but under a different owner (§6.2); an id
+        that exists nowhere stays a plain not-found answer."""
+        if skill_id == "*":
+            return
+        if any(key[1] == schedule_id and key[0] != skill_id
+              for key in self.schedules):
+            raise ScheduleError(
+                "skill_id_mismatch",
+                f"{schedule_id} does not belong to {skill_id}")
+
     def handle_list(self, message: Message):
         """Read the caller's schedules, or every schedule under ``*``."""
         try:
-            owner = self._authorized_owner(message, message.data.get("owner"),
-                                           wildcard=True)
+            skill_id = self._scoped_skill_id(message, wildcard=True)
             with self.lock:
                 views = [self._view(schedule)
                          for key, schedule in self.schedules.items()
-                         if owner == "*" or key[0] == owner]
+                         if skill_id == "*" or key[0] == skill_id]
         except ScheduleError as err:
             return self._refuse(message, err)
-        self._answer(message, {"ok": True, "owner": owner, "schedules": views})
+        self._answer(message, {"ok": True, "skill_id": skill_id,
+                               "schedules": views})
 
     def _view(self, schedule: Schedule) -> dict:
         return {"record": dict(schedule.record),
@@ -267,35 +288,43 @@ class ScheduledEventService(Thread):
 
     # --- ownership --------------------------------------------------------
 
-    def _authorized_owner(self, message: Message, owner,
-                          wildcard: bool = False) -> str:
-        """The owner a request may act as, or a refusal (§6.2).
-
-        Where the bus carries an authenticated component identity, it must
-        match the request's owner. Where it does not, the owner field still
-        scopes the request, so that a component cannot reach another
-        component's schedules by omission.
-        """
-        if not isinstance(owner, str) or not owner:
-            raise ScheduleError("invalid_record", "owner is required")
+    def _requesting_skill_id(self, message: Message) -> str:
+        """The caller's identity, taken from ``context["skill_id"]`` alone
+        (§3.1). A request that carries none is invalid: the scheduler has
+        nothing to own or scope it by."""
         identity = message.context.get("skill_id")
-        if owner == "*":
-            return self._authorized_administrator(identity, wildcard)
-        if identity and identity != owner:
-            raise ScheduleError("not_owner",
-                                f"{identity} may not act on schedules of {owner}")
-        return owner
+        if not isinstance(identity, str) or not identity:
+            raise ScheduleError("invalid_record",
+                                "the request carries no context[\"skill_id\"]")
+        return identity
 
-    def _authorized_administrator(self, identity, wildcard: bool) -> str:
-        if not wildcard:
-            raise ScheduleError("not_owner",
+    def _owning_skill_id(self, message: Message) -> str:
+        """The skill_id a ``schedule`` or ``get`` request acts as.
+
+        ``*`` is a scope granted for ``list``/``cancel`` only (§6.2); it owns
+        no schedule of its own.
+        """
+        identity = self._requesting_skill_id(message)
+        if identity == "*":
+            raise ScheduleError("skill_id_mismatch",
                                 "* is not an owner a schedule can belong to")
-        if not identity or identity not in self.admins:
-            raise ScheduleError(
-                "not_owner",
-                f"{identity or 'an anonymous caller'} is not allowed to act "
-                f"across every owner")
-        return "*"
+        return identity
+
+    def _scoped_skill_id(self, message: Message, wildcard: bool = False) -> str:
+        """The skill_id that scopes a ``list`` or ``cancel`` request.
+
+        A component allowlisted in ``scheduler.admins`` is granted the
+        pseudo value ``*`` (§6.2), which reaches every owner's schedules; how
+        that grant is made beyond the allowlist is a deployment matter this
+        service does not police further.
+        """
+        identity = self._requesting_skill_id(message)
+        if identity == "*":
+            raise ScheduleError("skill_id_mismatch",
+                                "* is a granted scope, not a caller identity")
+        if wildcard and identity in self.admins:
+            return "*"
+        return identity
 
     # --- the schedules the scheduler holds --------------------------------
 
@@ -310,7 +339,7 @@ class ScheduledEventService(Thread):
     def replace_schedule(self, record: dict) -> Schedule:
         """Put a validated record in place of whatever shares its identity."""
         with self.lock:
-            previous = self.schedules.get((record["owner"], record["id"]))
+            previous = self.schedules.get((record["skill_id"], record["id"]))
             schedule = self._continuing(record, previous)
             self._put_schedule(schedule, previous)
             return schedule
@@ -378,13 +407,13 @@ class ScheduledEventService(Thread):
                 self.schedules.pop(key, None)
             raise
 
-    def _drop_matching(self, owner: str, schedule_id: str) -> bool:
-        """Remove the schedules an owner and id name, rolling back on a failed
-        write. Under ``*`` that is the id under every owner."""
-        if owner == "*":
+    def _drop_matching(self, skill_id: str, schedule_id: str) -> bool:
+        """Remove the schedules a skill_id and id name, rolling back on a
+        failed write. Under ``*`` that is the id under every owner."""
+        if skill_id == "*":
             keys = [key for key in self.schedules if key[1] == schedule_id]
         else:
-            keys = [(owner, schedule_id)] if (owner, schedule_id) in self.schedules else []
+            keys = [(skill_id, schedule_id)] if (skill_id, schedule_id) in self.schedules else []
         if not keys:
             return False
         dropped = {key: self.schedules.pop(key) for key in keys}
@@ -518,7 +547,7 @@ class ScheduledEventService(Thread):
         upcoming = self._next_occurrence_after(batch)
         self.bus.emit(Message(topics.SCHEDULER_MISSED, {
             "id": schedule.record["id"],
-            "owner": schedule.record["owner"],
+            "skill_id": schedule.record["skill_id"],
             "missed": [format_instant(when)
                        for when in batch.to_report[:MAX_REPORTED]],
             "fired_late": [format_instant(when)
@@ -580,7 +609,7 @@ class ScheduledEventService(Thread):
         record = schedule.record
         context = dict(record.get("context") or {})
         context["scheduler"] = {"id": record["id"],
-                                "owner": record["owner"],
+                                "skill_id": record["skill_id"],
                                 "due": format_instant(due),
                                 "fired": format_instant(self.now()),
                                 "remaining": schedule.remaining()}

--- a/ovos_bus_client/util/scheduled_events/validation.py
+++ b/ovos_bus_client/util/scheduled_events/validation.py
@@ -14,14 +14,16 @@ from ovos_bus_client.util.scheduled_events.records import (
 from ovos_bus_client.util.scheduled_events.timing import next_occurrence
 
 
-def validate_record(request: dict, namespaced: bool = True,
+def validate_record(request: dict, skill_id: str, namespaced: bool = True,
                     previous: Optional[dict] = None) -> dict:
     """Check a request against §3.1 and return the record to store.
 
-    ``namespaced`` is false only for the legacy adapter, whose event names
-    predate the ``<owner>.<name>`` rule. ``previous`` is the stored record of
-    the same identity, if any; it is what lets an unchanged recurrence keep
-    its anchor.
+    ``skill_id`` is the owning component, taken by the caller from the
+    request message's ``context["skill_id"]`` (§3.1); it is never read from
+    the request body. ``namespaced`` is false only for the legacy adapter,
+    whose event names predate the ``<skill_id>.<name>`` rule. ``previous`` is
+    the stored record of the same identity, if any; it is what lets an
+    unchanged recurrence keep its anchor.
 
     The requesting message's ``context`` is kept as it arrived (§3.5), so
     that the occurrence can be emitted with it. It is not part of the
@@ -31,10 +33,9 @@ def validate_record(request: dict, namespaced: bool = True,
     if not isinstance(request, dict):
         raise ScheduleError("invalid_record", "request data must be an object")
 
-    owner = _required_name(request.get("owner"), "owner")
     record = {"id": _required_name(request.get("id"), "id"),
-              "owner": owner,
-              "event": _validated_event(request.get("event"), owner, namespaced),
+              "skill_id": skill_id,
+              "event": _validated_event(request.get("event"), skill_id, namespaced),
               "data": _validated_payload(request.get("data"))}
 
     context = _validated_context(request.get("context"))
@@ -78,10 +79,10 @@ def _required_name(value, field: str) -> str:
     return value
 
 
-def _validated_event(event, owner: str, namespaced: bool) -> str:
+def _validated_event(event, skill_id: str, namespaced: bool) -> str:
     """The message type each occurrence fires (§6.1).
 
-    The ``<owner>.<name>`` shape makes a fired event attributable to its
+    The ``<skill_id>.<name>`` shape makes a fired event attributable to its
     owner, and the ban on ``:`` keeps it clear of the dispatch shape of
     MSG-1 §2.1.1, so a schedule can never address another component's
     registered handler.
@@ -90,13 +91,13 @@ def _validated_event(event, owner: str, namespaced: bool) -> str:
         raise ScheduleError("bad_event", "event is required")
     if not namespaced:
         return event
-    prefix = f"{owner}."
+    prefix = f"{skill_id}."
     name = event[len(prefix):] if event.startswith(prefix) else ""
     if not name or ":" in name:
         raise ScheduleError(
             "bad_event",
-            f"event must be <owner>.<name> for owner {owner}, with a "
-            f"non-empty name free of ':'; got {event}")
+            f"event must be <skill_id>.<name> for skill_id {skill_id}, with "
+            f"a non-empty name free of ':'; got {event}")
     return event
 
 

--- a/test/unittests/test_scheduler_client.py
+++ b/test/unittests/test_scheduler_client.py
@@ -100,7 +100,7 @@ class TestSchedulingAndReading(ClientTestCase):
         when = self.in_an_hour()
         self.client.schedule("ring", at=when)
         self.make_client("skill.b").schedule("ring", at=when)
-        self.assertEqual([s["record"]["owner"] for s in self.client.list()],
+        self.assertEqual([s["record"]["skill_id"] for s in self.client.list()],
                          ["skill.a"])
 
 

--- a/test/unittests/test_scheduler_conformance.py
+++ b/test/unittests/test_scheduler_conformance.py
@@ -18,6 +18,7 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.util.scheduled_events import (
     LEGACY_REMOVAL_VERSION, MAX_DATA_BYTES, MAX_REPORTED, Schedule,
     ScheduledEventService, format_instant, topics, validate_record)
+from ovos_bus_client.util.scheduled_events.store import STORE_VERSION
 
 
 def iso(when: datetime) -> str:
@@ -65,16 +66,23 @@ class SchedulerTestCase(unittest.TestCase):
             if os.path.isfile(path):
                 os.unlink(path)
 
-    def request(self, topic, data, context=None):
-        """Deliver a request to the scheduler and return its answer."""
-        self.bus.emit(Message(topic, data, context or {}))
+    def request(self, topic, data, context=None, skill_id="skill.a"):
+        """Deliver a request to the scheduler and return its answer.
+
+        ``skill_id`` becomes ``context["skill_id"]`` (§3.1); pass ``None`` to
+        send a request with no owning identity at all.
+        """
+        request_context = dict(context or {})
+        if skill_id is not None:
+            request_context.setdefault("skill_id", skill_id)
+        self.bus.emit(Message(topic, data, request_context))
         return self.recorder.last(f"{topic}.response")
 
-    def schedule(self, request_context=None, **data):
-        data.setdefault("owner", "skill.a")
+    def schedule(self, request_context=None, owner="skill.a", **data):
         data.setdefault("id", "one")
-        data.setdefault("event", "skill.a.ring")
-        return self.request(topics.SCHEDULER_SCHEDULE, data, request_context)
+        data.setdefault("event", f"{owner}.ring" if owner else "skill.a.ring")
+        return self.request(topics.SCHEDULER_SCHEDULE, data, request_context,
+                            skill_id=owner)
 
     def new_scheduler(self):
         """A second scheduler over the same store, as a restart would be."""
@@ -95,7 +103,7 @@ class TestValidationAndAnswers(SchedulerTestCase):
         self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
         self.assertEqual(
             len(self.recorder.of(topics.SCHEDULER_SCHEDULE_RESPONSE)), 1)
-        self.request(topics.SCHEDULER_GET, {"owner": "skill.a", "id": "one"})
+        self.request(topics.SCHEDULER_GET, {"id": "one"}, skill_id="skill.a")
         self.assertEqual(len(self.recorder.of(topics.SCHEDULER_GET_RESPONSE)), 1)
 
     def test_naive_instant_is_rejected(self):
@@ -167,7 +175,7 @@ class TestValidationAndAnswers(SchedulerTestCase):
 
     def test_cancelling_an_absent_schedule_is_not_an_error(self):
         answer = self.request(topics.SCHEDULER_CANCEL,
-                              {"owner": "skill.a", "id": "nope"})
+                              {"id": "nope"}, skill_id="skill.a")
         self.assertTrue(answer.data["ok"])
         self.assertFalse(answer.data["existed"])
 
@@ -178,20 +186,20 @@ class TestValidationAndAnswers(SchedulerTestCase):
         self.assertEqual(created.data["next"], iso(when))
 
         read = self.request(topics.SCHEDULER_GET,
-                            {"owner": "skill.a", "id": "one"})
+                            {"id": "one"}, skill_id="skill.a")
         self.assertEqual(read.data["record"]["event"], "skill.a.ring")
         self.assertEqual(read.data["state"]["next"], iso(when))
         self.assertIsNone(read.data["state"]["last_fired"])
         self.assertEqual(read.data["state"]["missed"], [])
 
-        listed = self.request(topics.SCHEDULER_LIST, {"owner": "skill.a"})
+        listed = self.request(topics.SCHEDULER_LIST, {}, skill_id="skill.a")
         self.assertEqual(
             [s["record"]["id"] for s in listed.data["schedules"]], ["one"])
 
         cancelled = self.request(topics.SCHEDULER_CANCEL,
-                                 {"owner": "skill.a", "id": "one"})
+                                 {"id": "one"}, skill_id="skill.a")
         self.assertTrue(cancelled.data["existed"])
-        listed = self.request(topics.SCHEDULER_LIST, {"owner": "skill.a"})
+        listed = self.request(topics.SCHEDULER_LIST, {}, skill_id="skill.a")
         self.assertEqual(listed.data["schedules"], [])
 
 
@@ -255,12 +263,12 @@ class TestPersistence(SchedulerTestCase):
         self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
         with patch("os.replace", side_effect=OSError("read-only")):
             answer = self.request(topics.SCHEDULER_CANCEL,
-                                  {"owner": "skill.a", "id": "one"})
+                                  {"id": "one"}, skill_id="skill.a")
         self.assertEqual(answer.data["error"], "internal")
         self.assertIn(("skill.a", "one"), self.service.schedules)
         # and it is still cancellable once the store is writable again
         self.assertTrue(self.request(topics.SCHEDULER_CANCEL,
-                                     {"owner": "skill.a", "id": "one"}
+                                     {"id": "one"}, skill_id="skill.a"
                                      ).data["existed"])
 
     def test_an_unstorable_wildcard_cancel_keeps_every_schedule(self):
@@ -270,7 +278,7 @@ class TestPersistence(SchedulerTestCase):
         self.service.admins = ["admin.panel"]
         with patch("os.replace", side_effect=OSError("read-only")):
             answer = self.request(topics.SCHEDULER_CANCEL,
-                                  {"owner": "*", "id": "one"},
+                                  {"id": "one"}, skill_id="*",
                                   context={"skill_id": "admin.panel"})
         self.assertEqual(answer.data["error"], "internal")
         self.assertEqual(len(self.service.schedules), 2)
@@ -350,7 +358,7 @@ class TestPersistence(SchedulerTestCase):
 
         # and the scheduler is a working one, writing a store of its own
         revived.replace_schedule(
-            {"id": "two", "owner": "skill.a", "event": "skill.a.ring",
+            {"id": "two", "skill_id": "skill.a", "event": "skill.a.ring",
              "data": {}, "at": iso(datetime.now(timezone.utc) +
                                    timedelta(hours=1)),
              "misfire": "late", "grace_s": 60, "ephemeral": False})
@@ -412,6 +420,50 @@ class TestPersistence(SchedulerTestCase):
             ["kept"])
         self.assertEqual([key[1] for key in self.new_scheduler().schedules],
                          ["kept"])
+
+
+class TestUpgradeFromOwnerKeyedStore(SchedulerTestCase):
+    """§9.4 / §5.1 — a persisted store is read on start; entries the
+    service cannot honour are set aside, never fatal.
+
+    A store written by ovos-bus-client 2.11.13a5 or earlier keys a record's
+    identity by ``owner``, not ``skill_id``. Starting over such a store must
+    not be fatal to the whole service.
+    """
+
+    def write_raw_store(self, schedules: list):
+        with open(self.store, "w") as handle:
+            json.dump({"version": STORE_VERSION,
+                       "written_at": iso(datetime.now(timezone.utc)),
+                       "schedules": schedules}, handle)
+
+    def owner_keyed_entry(self, record_fields: dict, **entry_fields) -> dict:
+        record = {"id": "one", "owner": "skill.a", "event": "skill.a.ring",
+                  "data": {}, "misfire": "late", "grace_s": 60,
+                  "ephemeral": False}
+        record.update(record_fields)
+        entry = {"record": record, "cursor": iso(datetime.now(timezone.utc)),
+                 "consumed": 0, "anchored": True, "missed": [],
+                 "estimate": None, "last_fired": None}
+        entry.update(entry_fields)
+        return entry
+
+    def test_an_owner_keyed_entry_is_read_as_skill_id(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.write_raw_store([self.owner_keyed_entry({"at": when})])
+        revived = self.new_scheduler()
+        self.assertIn(("skill.a", "one"), revived.schedules)
+        self.assertEqual(revived.schedules["skill.a", "one"].record["skill_id"],
+                         "skill.a")
+        self.assertNotIn("owner", revived.schedules["skill.a", "one"].record)
+
+    def test_a_record_with_neither_key_is_set_aside_not_fatal(self):
+        when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
+        entry = self.owner_keyed_entry({"at": when})
+        del entry["record"]["owner"]
+        self.write_raw_store([entry])
+        revived = self.new_scheduler()
+        self.assertEqual(revived.schedules, {})
 
 
 class TestIdempotency(SchedulerTestCase):
@@ -613,11 +665,11 @@ class TestReplay(SchedulerTestCase):
     def _persist_and_restart(self, **record_fields):
         """Store one schedule, then start a fresh scheduler over that store."""
         record = validate_record(dict(
-            {"id": "one", "owner": "skill.a", "event": "skill.a.ring"},
-            **record_fields))
+            {"id": "one", "event": "skill.a.ring"},
+            **record_fields), skill_id="skill.a")
         writer = ScheduledEventService(self.bus, store_path=self.store,
                                        autostart=False)
-        writer.schedules[record["owner"], record["id"]] = Schedule(record)
+        writer.schedules[record["skill_id"], record["id"]] = Schedule(record)
         writer._persist()
         writer.shutdown()
         self.recorder.messages.clear()
@@ -674,8 +726,8 @@ class TestReplay(SchedulerTestCase):
                                        autostart=False)
         for name, when in (("overdue", now - timedelta(minutes=30)),
                            ("later", now + timedelta(hours=1))):
-            record = validate_record({"id": name, "owner": "skill.a",
-                                      "event": "skill.a.ring", "at": iso(when)})
+            record = validate_record({"id": name, "event": "skill.a.ring",
+                                      "at": iso(when)}, skill_id="skill.a")
             writer.schedules["skill.a", name] = Schedule(record)
         writer._persist()
         writer.shutdown()
@@ -724,17 +776,20 @@ class TestFiredMessage(SchedulerTestCase):
         fired = self.recorder.last("skill.a.ring")
         self.assertEqual(set(fired.context) - set(given), {"scheduler"})
         self.assertEqual(fired.context["scheduler"]["id"], "one")
-        self.assertEqual(fired.context["scheduler"]["owner"], "skill.a")
+        self.assertEqual(fired.context["scheduler"]["skill_id"], "skill.a")
         self.assertEqual(fired.context["scheduler"]["due"], iso(due))
 
     def test_a_request_with_no_context_fires_with_none_invented(self):
+        # a request must carry context["skill_id"] to be accepted at all
+        # (§3.1); "no context" beyond that fires with nothing invented
         due = datetime.now(timezone.utc) - timedelta(seconds=1)
         self.schedule(at=iso(due))
         self.service._evaluate()
         fired = self.recorder.last("skill.a.ring")
-        # only the scheduler block, and the default session the bus stamps on
-        # any message that names none
-        self.assertEqual(set(fired.context) - {"session"}, {"scheduler"})
+        # the requester's skill_id, the scheduler block, and the default
+        # session the bus stamps on any message that names none
+        self.assertEqual(set(fired.context) - {"session"},
+                         {"skill_id", "scheduler"})
 
     def test_the_context_survives_a_restart_with_the_store(self):
         given = self.requested_with()
@@ -792,8 +847,8 @@ class TestRecurrence(SchedulerTestCase):
     @staticmethod
     def _schedule(**record_fields):
         return Schedule(validate_record(
-            dict({"id": "x", "owner": "skill.a", "event": "skill.a.x"},
-                 **record_fields)))
+            dict({"id": "x", "event": "skill.a.x"}, **record_fields),
+            skill_id="skill.a"))
 
     def test_a_late_fire_does_not_shift_the_following_occurrences(self):
         start = datetime(2031, 1, 1, 0, 0, tzinfo=timezone.utc)
@@ -853,45 +908,87 @@ class TestRecurrence(SchedulerTestCase):
 
 
 class TestOwnership(SchedulerTestCase):
-    """§9.8 — the event namespace and owner scoping."""
+    """§9.8 and item 14 (SCHEDULER-1, merged) — the owning ``skill_id`` comes
+    from the request's ``context["skill_id"]`` alone, never the body."""
 
     def test_an_event_outside_the_owner_namespace_is_rejected(self):
         answer = self.schedule(event="mycroft.stop",
                                at=iso(datetime.now(timezone.utc)))
         self.assertEqual(answer.data["error"], "bad_event")
 
-    def test_an_authenticated_identity_may_not_act_for_another_owner(self):
+    def test_a_request_with_no_context_skill_id_is_invalid(self):
         answer = self.request(
             topics.SCHEDULER_SCHEDULE,
-            {"owner": "skill.a", "id": "one", "event": "skill.a.ring",
+            {"id": "one", "event": "skill.a.ring",
              "at": iso(datetime.now(timezone.utc) + timedelta(hours=1))},
-            context={"skill_id": "skill.b"})
-        self.assertEqual(answer.data["error"], "not_owner")
+            skill_id=None)
+        self.assertEqual(answer.data["error"], "invalid_record")
 
-    def test_cancel_and_get_are_scoped_by_owner(self):
+    def test_a_body_owner_field_is_not_the_owning_identity(self):
+        # §3.1: the owning component is not a field of the body; a body
+        # "owner" that disagrees with context["skill_id"] changes nothing
+        answer = self.request(
+            topics.SCHEDULER_SCHEDULE,
+            {"id": "one", "owner": "skill.b", "event": "skill.a.ring",
+             "at": iso(datetime.now(timezone.utc) + timedelta(hours=1))},
+            skill_id="skill.a")
+        self.assertTrue(answer.data["ok"])
+        self.assertEqual(answer.data["skill_id"], "skill.a")
+        self.assertIn(("skill.a", "one"), self.service.schedules)
+        self.assertNotIn(("skill.b", "one"), self.service.schedules)
+
+    def test_an_unknown_id_is_not_found_not_refused(self):
         self.schedule(at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
         cancelled = self.request(topics.SCHEDULER_CANCEL,
-                                 {"owner": "skill.b", "id": "one"})
+                                 {"id": "nope"}, skill_id="skill.b")
+        self.assertTrue(cancelled.data["ok"])
         self.assertFalse(cancelled.data["existed"])
-        self.assertIn(("skill.a", "one"), self.service.schedules)
 
         read = self.request(topics.SCHEDULER_GET,
-                            {"owner": "skill.b", "id": "one"})
+                            {"id": "nope"}, skill_id="skill.b")
+        self.assertTrue(read.data["ok"])
         self.assertIsNone(read.data["record"])
         self.assertFalse(read.data["existed"])
+
+    def test_cancelling_across_scope_is_refused_not_reported_absent(self):
+        # §6.2: a request that names a schedule outside its scope is refused
+        # with skill_id_mismatch, not answered as though it did not exist
+        when = iso(datetime.now(timezone.utc) - timedelta(seconds=1))
+        self.schedule(owner="skill.a", event="skill.a.ring", at=when)
+        cancelled = self.request(topics.SCHEDULER_CANCEL,
+                                 {"id": "one"}, skill_id="skill.b")
+        self.assertFalse(cancelled.data["ok"])
+        self.assertEqual(cancelled.data["error"], "skill_id_mismatch")
+        self.assertNotIn("record", cancelled.data)
+        # the refusal did not touch skill.a's schedule: it still fires
+        self.assertIn(("skill.a", "one"), self.service.schedules)
+        self.service._evaluate()
+        self.assertEqual(len(self.recorder.of("skill.a.ring")), 1)
+
+    def test_getting_across_scope_is_refused_not_reported_absent(self):
+        self.schedule(owner="skill.a", event="skill.a.ring",
+                      at=iso(datetime.now(timezone.utc) + timedelta(hours=1)))
+        read = self.request(topics.SCHEDULER_GET,
+                            {"id": "one"}, skill_id="skill.b")
+        self.assertFalse(read.data["ok"])
+        self.assertEqual(read.data["error"], "skill_id_mismatch")
+        self.assertNotIn("record", read.data)
+        self.assertIn(("skill.a", "one"), self.service.schedules)
 
     def test_list_shows_only_the_callers_schedules(self):
         when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
         self.schedule(owner="skill.a", event="skill.a.ring", at=when)
         self.schedule(owner="skill.b", event="skill.b.ring", at=when)
-        listed = self.request(topics.SCHEDULER_LIST, {"owner": "skill.b"})
+        listed = self.request(topics.SCHEDULER_LIST, {}, skill_id="skill.b")
         self.assertEqual(
-            [s["record"]["owner"] for s in listed.data["schedules"]],
+            [s["record"]["skill_id"] for s in listed.data["schedules"]],
             ["skill.b"])
 
 
 class TestAdministrativeOwner(SchedulerTestCase):
-    """``*`` reaches every owner, and only for a configured administrator."""
+    """``*`` reaches every owner, and only for a configured administrator
+    (§6.2). The scope comes from allowlist membership of the caller's own
+    ``context["skill_id"]``; there is no body field to ask for it."""
 
     def populate(self):
         when = iso(datetime.now(timezone.utc) + timedelta(hours=1))
@@ -901,44 +998,60 @@ class TestAdministrativeOwner(SchedulerTestCase):
     def test_the_allowlist_is_empty_unless_configured(self):
         self.assertEqual(self.service.admins, [])
 
-    def test_an_anonymous_caller_may_not_use_the_wildcard(self):
+    def test_an_unlisted_caller_only_reaches_its_own_schedules(self):
         self.populate()
-        listed = self.request(topics.SCHEDULER_LIST, {"owner": "*"})
-        self.assertEqual(listed.data["error"], "not_owner")
+        listed = self.request(topics.SCHEDULER_LIST, {}, skill_id="skill.a")
+        self.assertEqual(
+            [s["record"]["id"] for s in listed.data["schedules"]], ["one"])
         cancelled = self.request(topics.SCHEDULER_CANCEL,
-                                 {"owner": "*", "id": "one"})
-        self.assertEqual(cancelled.data["error"], "not_owner")
+                                 {"id": "nope"}, skill_id="skill.b")
+        self.assertFalse(cancelled.data["existed"])
+        self.assertIn(("skill.a", "one"), self.service.schedules)
         self.assertEqual(len(self.service.schedules), 2)
 
-    def test_an_identified_caller_outside_the_allowlist_may_not_either(self):
+    def test_the_literal_wildcard_identity_is_refused(self):
+        # "*" is a scope granted through the allowlist, never a caller's own
+        # claimed identity
         self.populate()
-        listed = self.request(topics.SCHEDULER_LIST, {"owner": "*"},
-                              context={"skill_id": "skill.a"})
-        self.assertEqual(listed.data["error"], "not_owner")
+        listed = self.request(topics.SCHEDULER_LIST, {}, skill_id="*")
+        self.assertEqual(listed.data["error"], "skill_id_mismatch")
+        cancelled = self.request(topics.SCHEDULER_CANCEL,
+                                 {"id": "one"}, skill_id="*")
+        self.assertEqual(cancelled.data["error"], "skill_id_mismatch")
+        self.assertEqual(len(self.service.schedules), 2)
 
     def test_an_allowlisted_administrator_lists_and_cancels_everything(self):
         self.populate()
         self.service.admins = ["admin.panel"]
-        listed = self.request(topics.SCHEDULER_LIST, {"owner": "*"},
-                              context={"skill_id": "admin.panel"})
+        listed = self.request(topics.SCHEDULER_LIST, {}, skill_id="admin.panel")
         self.assertEqual(len(listed.data["schedules"]), 2)
-        self.request(topics.SCHEDULER_CANCEL, {"owner": "*", "id": "one"},
-                     context={"skill_id": "admin.panel"})
+        self.request(topics.SCHEDULER_CANCEL, {"id": "one"},
+                     skill_id="admin.panel")
         self.assertEqual(self.service.schedules, {})
+
+    def test_an_administrator_still_only_reads_its_own_schedules_through_get(self):
+        # the grant of §6.2 names list and cancel only; "one" exists under
+        # skill.a and skill.b, neither of which is admin.panel's own scope
+        self.populate()
+        self.service.admins = ["admin.panel"]
+        read = self.request(topics.SCHEDULER_GET, {"id": "one"},
+                            skill_id="admin.panel")
+        self.assertFalse(read.data["ok"])
+        self.assertEqual(read.data["error"], "skill_id_mismatch")
 
     def test_no_schedule_may_be_created_under_the_wildcard(self):
         answer = self.schedule(owner="*", event="*.ring",
                                at=iso(datetime.now(timezone.utc)))
-        self.assertEqual(answer.data["error"], "not_owner")
+        self.assertEqual(answer.data["error"], "skill_id_mismatch")
 
     def test_an_administrator_may_not_create_under_the_wildcard_either(self):
         self.service.admins = ["admin.panel"]
         answer = self.request(
             topics.SCHEDULER_SCHEDULE,
-            {"owner": "*", "id": "one", "event": "*.ring",
+            {"id": "one", "event": "*.ring",
              "at": iso(datetime.now(timezone.utc) + timedelta(hours=1))},
-            context={"skill_id": "admin.panel"})
-        self.assertEqual(answer.data["error"], "not_owner")
+            skill_id="*")
+        self.assertEqual(answer.data["error"], "skill_id_mismatch")
 
 
 class TestClock(SchedulerTestCase):
@@ -1084,7 +1197,7 @@ class TestMisfireBounds(SchedulerTestCase):
                       every={"seconds": 86400, "start": iso(due)})
         self.service._evaluate()
         read = self.request(topics.SCHEDULER_GET,
-                            {"owner": "skill.a", "id": "tick"})
+                            {"id": "tick"}, skill_id="skill.a")
         self.assertEqual(read.data["state"]["missed"], [iso(due)])
 
     def test_a_fire_clears_the_missed_dues_that_precede_it(self):
@@ -1093,7 +1206,7 @@ class TestMisfireBounds(SchedulerTestCase):
                       grace_s=0, every={"seconds": 10, "start": iso(start)})
         self.service._evaluate()
         read = self.request(topics.SCHEDULER_GET,
-                            {"owner": "skill.a", "id": "tick"})
+                            {"id": "tick"}, skill_id="skill.a")
         self.assertEqual(read.data["state"]["missed"], [])
         self.assertEqual(read.data["state"]["last_fired"],
                          iso(start + timedelta(seconds=20)))
@@ -1296,8 +1409,8 @@ class TestInstants(unittest.TestCase):
         self.assertEqual(format_instant(when), "2031-03-29T07:30:00+00:00")
 
     def test_a_zulu_suffix_is_accepted(self):
-        record = validate_record({"id": "x", "owner": "s", "event": "s.e",
-                                  "at": "2031-03-29T07:30:00Z"})
+        record = validate_record({"id": "x", "event": "s.e",
+                                  "at": "2031-03-29T07:30:00Z"}, skill_id="s")
         self.assertEqual(record["at"], "2031-03-29T07:30:00+00:00")
 
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

Governing clauses (OpenVoiceOS/architecture, `scheduler-1.md`, OVOS-SCHEDULER-1, `origin/dev` @ `5da386ab0b219bc834baafe68a99210eb67297ff`):

> §3.1: "The owning component is not a field of the body. The scheduler MUST take the owning `skill_id` from the request message's `context["skill_id"]` (INTENT-4 §3.2), and MUST reject with `invalid_record` a request that carries none."
> §3.3: "A schedule is identified by the pair (`skill_id`, `id`). The scheduler MUST treat two requests with the same pair as the same schedule (§5.2)."
> §6.1: "The `event` of a schedule MUST have the form `<skill_id>.<name>`."
> §6.2: "`ovos.scheduler.schedule`, `ovos.scheduler.cancel`, `ovos.scheduler.get`, and `ovos.scheduler.list` act only on schedules whose `skill_id` equals the request's `context["skill_id"]`. A request that names a schedule outside that scope is refused with `skill_id_mismatch`. ... A privileged administrative component MAY be granted the pseudo value `*` for `ovos.scheduler.list` and `ovos.scheduler.cancel`."
> §4.1–§4.3: request and response payloads carry `skill_id` where they carried `owner`, including `ovos.scheduler.schedule.response`, `ovos.scheduler.get.response`, `ovos.scheduler.list.response`, the fired event's `context.scheduler` block, and `ovos.scheduler.missed`.
> §9.4 / §5.1: "the scheduler MUST first load every persisted schedule ... on start" and "an unreadable entry is reported and skipped: a scheduler that refuses to start because one record went bad is worse than one that starts without it" — a persisted store is read on start, and entries the service cannot honour are set aside, never fatal.

## What was wrong

`ovos_bus_client/util/scheduled_events/validation.py` read a required `owner` field from the request **body** and used it as the schedule's identity. `service.py`'s `_authorized_owner` only compared that body `owner` against `context["skill_id"]` when the context key happened to be present; when it was absent, any caller-supplied `owner` was accepted unchecked. That is the ownership model inverted relative to the spec (code-gaps.md item 14 of the architecture design review).

## What changed

`validate_record()` now takes `skill_id` as an explicit parameter, sourced by the caller from `message.context["skill_id"]`, never from the body. Every `ovos.scheduler.*` handler resolves `skill_id` the same way and refuses with `invalid_record` when the context carries none. A literal `context["skill_id"] == "*"` is refused with `skill_id_mismatch` (the spec's error table has no `not_owner` code, so that string is retired). An allowlisted administrative `skill_id` (`scheduler.admins` config) is granted the `*` scope automatically for `list` and `cancel` only, matching §6.2's carve-out — `schedule` and `get` never see `*`. Every wire field, the stored record, and the fired event's `context.scheduler` block rename `owner` to `skill_id`.

## Cross-scope cancel/get were not refused

`handle_cancel` and `handle_get` did a plain `(skill_id, id)` lookup and, when it missed, answered `{"ok": True, "existed": False}` — a not-found shape, with `ok: True`, on a request that names another skill_id's schedule. Both handlers now check, only when the caller's own scope does not hold the id, whether it exists under a different `skill_id`; if so, the request is refused with `skill_id_mismatch` and no schedule detail beyond the error code, and the named schedule is untouched. An id that exists nowhere still gets the plain not-found answer. `list` needed no change: it was already scoped correctly in isolation.

## Migration of a persisted store

A store written by the published 2.11.13a5 release (or earlier) keys a schedule's stored record by `owner`, not `skill_id`. `Schedule.from_stored()` now reads `skill_id`, falling back to the older `owner` key when it's absent, and normalises the in-memory record to `skill_id` before anything else touches it. A stored record that carries neither key is refused with `invalid_record`, which the store's existing per-entry guard in `ScheduleStore.load()` already catches and drops — the service starts with that one entry missing rather than failing to start at all. Before this part of the fix, `Schedule.key` read `record["skill_id"]` unconditionally and the load loop's KeyError on an `owner`-keyed entry was uncaught, so any deployment with one persisted schedule from the published release crashed `ScheduledEventService.__init__` on upgrade.

## Consumers checked

The only cross-repo consumer is `ovos-workshop`, which reaches the scheduler exclusively through `SchedulerClient.schedule/reschedule/cancel/get/list` and never sends or reads the raw `owner` wire field. `ovos-skill-alerts` doesn't reference the scheduler topics at all. No released downstream reads the body `owner` field directly, so no deprecation shim was needed; `SchedulerClient` itself is updated to stop sending it. Neither `not_owner` nor `skill_id_mismatch` is owned by `ovos-spec-tools`' message registry — both are free-form strings local to this repo. No scheduler-specific end-to-end cell exists in `ovoscope` (only an `enable_event_scheduler` constructor flag, no dedicated test), so there is nothing there to extend for this fix.

## Testing

`test/unittests/test_scheduler_conformance.py` and `test_scheduler_client.py` cover the ownership model, the store migration (`TestUpgradeFromOwnerKeyedStore`), and the cross-scope refusal (`test_cancelling_across_scope_is_refused_not_reported_absent`, `test_getting_across_scope_is_refused_not_reported_absent` — the second also asserts skill.a's schedule is untouched and still fires).

Fail-before, checked as three independent reverts of the rewritten suite:
- reverting the ownership-model diff drops tests including `TestOwnership::test_a_body_owner_field_is_not_the_owning_identity`;
- reverting the store-migration diff drops `TestUpgradeFromOwnerKeyedStore`'s two cells with `KeyError: 'skill_id'` from `Schedule.key` inside `ScheduledEventService.__init__` — the exact crash an upgrade from the published release hits;
- reverting the cross-scope diff drops the two cross-scope cancel/get cells with `AssertionError: True is not false` on `cancelled.data["ok"]` / `read.data["ok"]` — the exact `ok:True`-on-a-refusal defect reported.

Restoring each diff returns its own tests to green. Full suite, run on this branch merged with the current `origin/dev` tip (already up to date, no divergence to merge): **1108 passed, 6 skipped, 114 subtests passed, no failures**, run three times for stability, including `test_session_retirement` run both individually and as part of the full suite each time — no failure was reproduced in this environment (Python 3.14.6).