### PR TITLE
build: allow pyee 13.x, keep the ceiling below 14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ovos-utils>=0.8.2,<1.0.0",
     "ovos-spec-tools[langcodes]>=1.10.5a1",  # OVOS-SESSION-1 §3.5 `location` registered field
     "websocket-client>=0.54.0",
-    "pyee>=8.1.0,<13.0.0",
+    "pyee>=8.1.0,<14.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

The ceiling moves from `<13.0.0` to `<14.0.0`. pyee 13.0.1's only behaviour change checks a listener exists before removing it, which `waiter.py` already guards for. pyee 14.0.0 requires Python 3.12 (PyPI `requires_python`), and this package supports 3.10 to 3.14, so 14 stays out until the Python floor moves. Replaces renovate #279.
